### PR TITLE
TKSS-13: Backport JDK-8283525: http://tools.ietf.org/html/* URLs return 404

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS7.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS7.java
@@ -950,7 +950,7 @@ public class PKCS7 {
 
     /**
      * Examine the certificate for a Subject Information Access extension
-     * (<a href="http://tools.ietf.org/html/rfc5280">RFC 5280</a>).
+     * (<a href="https://tools.ietf.org/html/rfc5280">RFC 5280</a>).
      * The extension's {@code accessMethod} field should contain the object
      * identifier defined for timestamping: 1.3.6.1.5.5.7.48.3 and its
      * {@code accessLocation} field should contain an HTTP or HTTPS URL.

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityInfoAccessExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityInfoAccessExtension.java
@@ -43,7 +43,7 @@ import com.tencent.kona.sun.security.util.DerValue;
  * certificate that identifies the specific OCSP Responder to use when
  * performing on-line validation of that certificate.
  * <p>
- * This extension is defined in <a href="http://tools.ietf.org/html/rfc5280">
+ * This extension is defined in <a href="https://tools.ietf.org/html/rfc5280">
  * Internet X.509 PKI Certificate and Certificate Revocation List
  * (CRL) Profile</a>. The profile permits
  * the extension to be included in end-entity or CA certificates,

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DeltaCRLIndicatorExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DeltaCRLIndicatorExtension.java
@@ -42,7 +42,7 @@ import java.math.BigInteger;
  *
  * <p>
  * The extension is defined in Section 5.2.4 of
- * <a href="http://tools.ietf.org/html/rfc5280">Internet X.509 PKI
+ * <a href="https://tools.ietf.org/html/rfc5280">Internet X.509 PKI
  * Certificate and Certificate Revocation List (CRL) Profile</a>.
  *
  * <p>

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/FreshestCRLExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/FreshestCRLExtension.java
@@ -38,7 +38,7 @@ import java.util.List;
  *
  * <p>
  * The extension is defined in Section 5.2.6 of
- * <a href="http://tools.ietf.org/html/rfc5280">Internet X.509 PKI
+ * <a href="https://tools.ietf.org/html/rfc5280">Internet X.509 PKI
  * Certificate and Certificate Revocation List (CRL) Profile</a>.
  *
  * <p>

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuingDistributionPointExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuingDistributionPointExtension.java
@@ -46,7 +46,7 @@ import com.tencent.kona.sun.security.util.DerValue;
  *
  * <p>
  * The extension is defined in Section 5.2.5 of
- * <a href="http://tools.ietf.org/html/rfc5280">Internet X.509 PKI
+ * <a href="https://tools.ietf.org/html/rfc5280">Internet X.509 PKI
  * Certificate and Certificate Revocation List (CRL) Profile</a>.
  *
  * <p>

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectInfoAccessExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectInfoAccessExtension.java
@@ -48,7 +48,7 @@ import com.tencent.kona.sun.security.util.DerValue;
  * included in end entity or CA certificates.  Conforming CAs MUST mark
  * this extension as non-critical.
  * <p>
- * This extension is defined in <a href="http://tools.ietf.org/html/rfc5280">
+ * This extension is defined in <a href="https://tools.ietf.org/html/rfc5280">
  * Internet X.509 PKI Certificate and Certificate Revocation List
  * (CRL) Profile</a>. The profile permits
  * the extension to be included in end-entity or CA certificates,

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLImpl.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLImpl.java
@@ -62,7 +62,7 @@ import com.tencent.kona.sun.security.util.SignatureUtil;
  *     signature            BIT STRING  }
  * </pre>
  * More information can be found in
- * <a href="http://tools.ietf.org/html/rfc5280">RFC 5280: Internet X.509
+ * <a href="https://tools.ietf.org/html/rfc5280">RFC 5280: Internet X.509
  * Public Key Infrastructure Certificate and CRL Profile</a>.
  * <p>
  * The ASN.1 definition of <code>tbsCertList</code> is:


### PR DESCRIPTION
This is a backport of [JDK-8283525]: http://tools.ietf.org/html/* URLs return 404

This PR will resolve #13.

[JDK-8283525]:
<https://bugs.openjdk.org/browse/JDK-8283525>