### PR TITLE
TKSS-15: Backport JDK-8284415: Collapse identical catch branches in security libs

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/X509Key.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/X509Key.java
@@ -266,8 +266,7 @@ public class X509Key implements PublicKey {
                 result.parseKeyBits();
                 return result;
             }
-        } catch (ClassNotFoundException e) {
-        } catch (InstantiationException e) {
+        } catch (ClassNotFoundException | InstantiationException e) {
         } catch (IllegalAccessException e) {
             // this should not happen.
             throw new IOException (classname + " [internal error]");

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLExtensions.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLExtensions.java
@@ -170,9 +170,7 @@ public class CRLExtensions {
                 tmp = seq;
 
             out.write(tmp.toByteArray());
-        } catch (IOException e) {
-            throw new CRLException("Encoding error: " + e.toString());
-        } catch (CertificateException e) {
+        } catch (IOException | CertificateException e) {
             throw new CRLException("Encoding error: " + e.toString());
         }
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertImpl.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertImpl.java
@@ -704,9 +704,7 @@ public class X509CertImpl extends X509Certificate
             if (attr.getSuffix() != null) {
                 try {
                     return info.get(attr.getSuffix());
-                } catch (IOException e) {
-                    throw new CertificateParsingException(e.toString());
-                } catch (CertificateException e) {
+                } catch (IOException | CertificateException e) {
                     throw new CertificateParsingException(e.toString());
                 }
             } else {

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertInfo.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertInfo.java
@@ -230,9 +230,7 @@ public class X509CertInfo implements CertAttrSet<String> {
                 rawCertInfo = tmp.toByteArray();
             }
             return rawCertInfo.clone();
-        } catch (IOException e) {
-            throw new CertificateEncodingException(e.toString());
-        } catch (CertificateException e) {
+        } catch (IOException | CertificateException e) {
             throw new CertificateEncodingException(e.toString());
         }
     }


### PR DESCRIPTION
This is a backport of [JDK-8284415]: Collapse identical catch branches in security libs.

This PR will resolve #15.

[JDK-8284415]:
<https://bugs.openjdk.org/browse/JDK-8284415>