### PR TITLE
TKSS-17: Backport JDK-8289274: Cleanup unnecessary null comparison before instanceof check in security modules

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/BitArray.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/BitArray.java
@@ -179,7 +179,7 @@ public class BitArray {
 
     public boolean equals(Object obj) {
         if (obj == this) return true;
-        if (obj == null || !(obj instanceof BitArray)) return false;
+        if (!(obj instanceof BitArray)) return false;
 
         BitArray ba = (BitArray) obj;
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs12/PKCS12KeyStore.java
@@ -315,7 +315,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
         Entry entry = entries.get(alias.toLowerCase(Locale.ENGLISH));
         Key key = null;
 
-        if (entry == null || (!(entry instanceof KeyEntry))) {
+        if (!(entry instanceof KeyEntry)) {
             return null;
         }
 
@@ -478,7 +478,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
      */
     public Certificate[] engineGetCertificateChain(String alias) {
         Entry entry = entries.get(alias.toLowerCase(Locale.ENGLISH));
-        if (entry != null && entry instanceof PrivateKeyEntry) {
+        if (entry instanceof PrivateKeyEntry) {
             if (((PrivateKeyEntry) entry).chain == null) {
                 return null;
             } else {
@@ -1020,7 +1020,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
         }
 
         Entry entry = entries.get(alias.toLowerCase(Locale.ENGLISH));
-        if (entry != null && entry instanceof KeyEntry) {
+        if (entry instanceof KeyEntry) {
             throw new KeyStoreException("Cannot overwrite own certificate");
         }
 
@@ -1103,11 +1103,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
      */
     public boolean engineIsKeyEntry(String alias) {
         Entry entry = entries.get(alias.toLowerCase(Locale.ENGLISH));
-        if (entry != null && entry instanceof KeyEntry) {
-            return true;
-        } else {
-            return false;
-        }
+        return entry instanceof KeyEntry;
     }
 
     /**
@@ -1119,12 +1115,8 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
      */
     public boolean engineIsCertificateEntry(String alias) {
         Entry entry = entries.get(alias.toLowerCase(Locale.ENGLISH));
-        if (entry != null && entry instanceof CertEntry &&
-                ((CertEntry) entry).trustedKeyUsage != null) {
-            return true;
-        } else {
-            return false;
-        }
+        return entry instanceof CertEntry &&
+                ((CertEntry) entry).trustedKeyUsage != null;
     }
 
     /**
@@ -1152,10 +1144,10 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
 
         Entry entry = entries.get(alias.toLowerCase(Locale.ENGLISH));
         if (entryClass == KeyStore.PrivateKeyEntry.class) {
-            return (entry != null && entry instanceof PrivateKeyEntry);
+            return (entry instanceof PrivateKeyEntry);
         }
         if (entryClass == KeyStore.SecretKeyEntry.class) {
-            return (entry != null && entry instanceof SecretKeyEntry);
+            return (entry instanceof SecretKeyEntry);
         }
         return false;
     }
@@ -1838,7 +1830,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
 
             String alias = e.nextElement();
             Entry entry = entries.get(alias);
-            if (entry == null || (!(entry instanceof KeyEntry))) {
+            if ((!(entry instanceof KeyEntry))) {
                 continue;
             }
             DerOutputStream safeBag = new DerOutputStream();

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/JavaKeyStore.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/JavaKeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,7 +129,7 @@ public abstract class JavaKeyStore extends KeyStoreSpi {
     {
         Object entry = entries.get(convertAlias(alias));
 
-        if (entry == null || !(entry instanceof KeyEntry)) {
+        if (!(entry instanceof KeyEntry)) {
             return null;
         }
         if (password == null) {
@@ -166,7 +166,7 @@ public abstract class JavaKeyStore extends KeyStoreSpi {
     public Certificate[] engineGetCertificateChain(String alias) {
         Object entry = entries.get(convertAlias(alias));
 
-        if (entry != null && entry instanceof KeyEntry) {
+        if (entry instanceof KeyEntry) {
             if (((KeyEntry)entry).chain == null) {
                 return null;
             } else {
@@ -364,7 +364,7 @@ public abstract class JavaKeyStore extends KeyStoreSpi {
         synchronized(entries) {
 
             Object entry = entries.get(convertAlias(alias));
-            if ((entry != null) && (entry instanceof KeyEntry)) {
+            if ((entry instanceof KeyEntry)) {
                 throw new KeyStoreException
                     ("Cannot overwrite own certificate");
             }
@@ -429,11 +429,7 @@ public abstract class JavaKeyStore extends KeyStoreSpi {
      */
     public boolean engineIsKeyEntry(String alias) {
         Object entry = entries.get(convertAlias(alias));
-        if ((entry != null) && (entry instanceof KeyEntry)) {
-            return true;
-        } else {
-            return false;
-        }
+        return entry instanceof KeyEntry;
     }
 
     /**
@@ -445,11 +441,7 @@ public abstract class JavaKeyStore extends KeyStoreSpi {
      */
     public boolean engineIsCertificateEntry(String alias) {
         Object entry = entries.get(convertAlias(alias));
-        if ((entry != null) && (entry instanceof TrustedCertEntry)) {
-            return true;
-        } else {
-            return false;
-        }
+        return entry instanceof TrustedCertEntry;
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/CertId.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/CertId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,19 +207,15 @@ public class CertId {
         if (this == other) {
             return true;
         }
-        if (other == null || (!(other instanceof CertId))) {
+        if ((!(other instanceof CertId))) {
             return false;
         }
 
         CertId that = (CertId) other;
-        if (hashAlgId.equals(that.getHashAlgorithm()) &&
+        return hashAlgId.equals(that.getHashAlgorithm()) &&
                 Arrays.equals(issuerNameHash, that.getIssuerNameHash()) &&
                 Arrays.equals(issuerKeyHash, that.getIssuerKeyHash()) &&
-                certSerialNumber.getNumber().equals(that.getSerialNumber())) {
-            return true;
-        } else {
-            return false;
-        }
+                certSerialNumber.getNumber().equals(that.getSerialNumber());
     }
 
     /**
@@ -228,13 +224,13 @@ public class CertId {
     @Override public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("CertId \n");
-        sb.append("Algorithm: " + hashAlgId.toString() +"\n");
+        sb.append("Algorithm: " + hashAlgId.toString() + "\n");
         sb.append("issuerNameHash \n");
         HexDumpEncoder encoder = new HexDumpEncoder();
         sb.append(encoder.encode(issuerNameHash));
         sb.append("\nissuerKeyHash: \n");
         sb.append(encoder.encode(issuerKeyHash));
-        sb.append("\n" +  certSerialNumber.toString());
+        sb.append("\n" + certSerialNumber.toString());
         return sb.toString();
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/RevocationChecker.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/RevocationChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -498,10 +498,8 @@ class RevocationChecker extends PKIXRevocationChecker {
                 }
                 break;
             case "SSLServer":
-                result = (t != null && t instanceof IOException);
-                break;
             case "URI":
-                result = (t != null && t instanceof IOException);
+                result = (t instanceof IOException);
                 break;
             default:
                 // we don't know about any other remote CertStore types

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AccessDescription.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AccessDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,7 +92,7 @@ public final class AccessDescription {
     }
 
     public boolean equals(Object obj) {
-        if (obj == null || (!(obj instanceof AccessDescription))) {
+        if ((!(obj instanceof AccessDescription))) {
             return false;
         }
         AccessDescription that = (AccessDescription)obj;


### PR DESCRIPTION
This is a backport of [JDK-8289274]: Cleanup unnecessary null comparison before instanceof check in security modules.

This PR will resolve #17.

[JDK-8289274]:
<https://bugs.openjdk.org/browse/JDK-8289274>