### PR TITLE
TKSS-19: Backport JDK-8286908: ECDSA signature should not return parameters

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/AlgorithmId.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/AlgorithmId.java
@@ -218,10 +218,14 @@ public class AlgorithmId implements Serializable, DerEncoder {
                     || algid.equals((Object) ed25519_oid)
                     || algid.equals((Object) x448_oid)
                     || algid.equals((Object) x25519_oid)
+                    || algid.equals(SHA1withECDSA_oid)
                     || algid.equals((Object) SHA224withECDSA_oid)
                     || algid.equals((Object) SHA256withECDSA_oid)
                     || algid.equals((Object) SHA384withECDSA_oid)
                     || algid.equals((Object) SHA512withECDSA_oid)) {
+                // RFC 3279 2.2.3: When the ecdsa-with-SHA1 algorithm identifier
+                // appears as the algorithm field in an AlgorithmIdentifier,
+                // the encoding MUST omit the parameters field.
                 // RFC 4055 3.3: when an RSASSA-PSS key does not require
                 // parameter validation, field is absent.
                 // RFC 8410 3: for id-X25519, id-X448, id-Ed25519, and
@@ -706,6 +710,8 @@ public class AlgorithmId implements Serializable, DerEncoder {
     public static final ObjectIdentifier x448_oid =
             Oid.of(KnownOIDs.X448);
 
+    public static final ObjectIdentifier SHA1withECDSA_oid =
+            Oid.of(KnownOIDs.SHA1withECDSA);
     public static final ObjectIdentifier SHA224withECDSA_oid =
             Oid.of(KnownOIDs.SHA224withECDSA);
     public static final ObjectIdentifier SHA256withECDSA_oid =

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/SignatureUtil.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/SignatureUtil.java
@@ -152,17 +152,10 @@ public class SignatureUtil {
                     createAlgorithmParameters(sigName, paramBytes);
                 paramSpec = RSAUtil.getParamSpec(params);
             } else if (sigName.contains("ECDSA")) {
-                try {
-                    Provider p = CryptoInsts.getSignature(sigName).getProvider();
-                    paramSpec = ECUtil.getECParameterSpec(p, paramBytes);
-                } catch (Exception e) {
-                    throw new ProviderException("Error handling EC parameters", e);
-                }
-                // ECUtil discards exception and returns null, so we need to check
-                // the returned value
-                if (paramSpec == null) {
-                    throw new ProviderException("Error handling EC parameters");
-                }
+                // Some certificates have params in an ECDSA algorithmID.
+                // According to RFC 3279 2.2.3 and RFC 5758 3.2,
+                // they are useless and should be ignored.
+                return null;
             } else {
                 throw new ProviderException
                      ("Unrecognized algorithm for signature parameters " +


### PR DESCRIPTION
This a backport of [JDK-8286908]: ECDSA signature should not return parameters.

This PR will resolve #19.

[JDK-8286908]:
<https://bugs.openjdk.org/browse/JDK-8286908>