### PR TITLE
TKSS-21: Backport JDK-8277307: Pre shared key sent under both session_ticket and pre_shared_key extensions

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SessionTicketExtension.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SessionTicketExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -397,7 +397,9 @@ final class SessionTicketExtension {
             chc.statelessResumption = true;
 
             // If resumption is not in progress, return an empty value
-            if (!chc.isResumption || chc.resumingSession == null) {
+            if (!chc.isResumption || chc.resumingSession == null
+                    || chc.resumingSession.getPskIdentity() == null
+                    || chc.resumingSession.getProtocolVersion().useTLS13PlusSpec()) {
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
                     SSLLogger.fine("Stateless resumption supported");
                 }


### PR DESCRIPTION
This is backport of [JDK-8277307]: Pre shared key sent under both session_ticket and pre_shared_key extensions.

This PR will resolve #21.

[JDK-8277307]:
<https://bugs.openjdk.org/browse/JDK-8277307>