### PR TITLE
TKSS-23: Backport JDK-8289572: InputStream wrapping with BufferedInputStream is redundant in HttpTimestamper

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/timestamp/HttpTimestamper.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/timestamp/HttpTimestamper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,10 @@
 
 package com.tencent.kona.sun.security.timestamp;
 
-import java.io.BufferedInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.HttpURLConnection;
 import java.util.*;
@@ -124,7 +124,7 @@ public class HttpTimestamper implements Timestamper {
 
         // Receive the reply
         byte[] replyBuffer = null;
-        try (BufferedInputStream input = new BufferedInputStream(connection.getInputStream())) {
+        try (InputStream input = connection.getInputStream()) {
             if (debug != null) {
                 String header = connection.getHeaderField(0);
                 debug.println(header);


### PR DESCRIPTION
This is backport of [JDK-8289572]: InputStream wrapping with BufferedInputStream is redundant in HttpTimestamper.

This PR will resolve #23.

[JDK-8289572]:
<https://bugs.openjdk.org/browse/JDK-8289572>