### PR TITLE
TKSS-27: Upgrade BC to 1.72

### DIFF
--- a/kona-crypto/build.gradle.kts
+++ b/kona-crypto/build.gradle.kts
@@ -1,10 +1,7 @@
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.gradle.api.tasks.testing.logging.TestLogEvent
-
 plugins {
     id("kona-common")
 }
 
 dependencies {
-    implementation("org.bouncycastle:bcprov-jdk18on:1.71")
+    implementation("org.bouncycastle:bcprov-jdk18on:1.72")
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2Cipher.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2Cipher.java
@@ -71,10 +71,6 @@ public class SM2Cipher extends GMCipherSpi {
     @Override
     public byte[] engineDoFinal(byte[] in, int inOfs, int inLen)
             throws IllegalBlockSizeException, BadPaddingException {
-        // BC cannot process empty input
-        if (inLen == 0) {
-            return new byte[0];
-        }
         return super.engineDoFinal(in, inOfs, inLen);
     }
 

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2Test.java
@@ -246,12 +246,12 @@ public class SM2Test {
         Cipher cipher = Cipher.getInstance("SM2", PROVIDER);
 
         cipher.init(Cipher.ENCRYPT_MODE, pubKey);
-        byte[] ciphertext = cipher.doFinal(EMPTY);
+        TestUtils.checkThrowable(BadPaddingException.class,
+                () -> cipher.doFinal(EMPTY));
 
         cipher.init(Cipher.DECRYPT_MODE, priKey);
-        byte[] cleartext = cipher.doFinal(ciphertext);
-
-        Assertions.assertArrayEquals(EMPTY, cleartext);
+        TestUtils.checkThrowable(BadPaddingException.class,
+                () -> cipher.doFinal(EMPTY));
     }
 
     @Test

--- a/kona-pkix/build.gradle.kts
+++ b/kona-pkix/build.gradle.kts
@@ -1,6 +1,3 @@
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.gradle.api.tasks.testing.logging.TestLogEvent
-
 plugins {
     id("kona-common")
 }


### PR DESCRIPTION
BouncyCastle just released 1.72.
This version resolves a SM2 encryption issue, which may lead to infinite loop.
The fix is https://github.com/bcgit/bc-java/commit/58940b9c3e99b70f3cc43c00b9f1f6f1e87f1cc6

This PR will resolve #27.