### PR TITLE
TKSS-37: Backport JDK-8294848: Unnecessary SSLCipher dispose implementations

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLCipher.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLCipher.java
@@ -1711,17 +1711,6 @@ enum SSLCipher {
             }
 
             @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
-            }
-
-            @Override
             int estimateFragmentSize(int packetSize, int headerSize) {
                 return packetSize - headerSize - recordIvSize - tagSize;
             }
@@ -1832,17 +1821,6 @@ enum SSLCipher {
                 }
 
                 return len + nonce.length;
-            }
-
-            @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
             }
 
             @Override
@@ -2009,17 +1987,6 @@ enum SSLCipher {
             }
 
             @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
-            }
-
-            @Override
             int estimateFragmentSize(int packetSize, int headerSize) {
                 return packetSize - headerSize - tagSize;
             }
@@ -2136,17 +2103,6 @@ enum SSLCipher {
                     keyLimitCountdown -= len;
                 }
                 return len;
-            }
-
-            @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
             }
 
             @Override
@@ -2278,17 +2234,6 @@ enum SSLCipher {
             }
 
             @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
-            }
-
-            @Override
             int estimateFragmentSize(int packetSize, int headerSize) {
                 return packetSize - headerSize - tagSize;
             }
@@ -2404,17 +2349,6 @@ enum SSLCipher {
                 }
 
                 return len;
-            }
-
-            @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
             }
 
             @Override
@@ -2568,17 +2502,6 @@ enum SSLCipher {
             }
 
             @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
-            }
-
-            @Override
             int estimateFragmentSize(int packetSize, int headerSize) {
                 return packetSize - headerSize - tagSize;
             }
@@ -2696,17 +2619,6 @@ enum SSLCipher {
                     keyLimitCountdown -= len;
                 }
                 return len;
-            }
-
-            @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
             }
 
             @Override

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPCipher.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPCipher.java
@@ -424,17 +424,6 @@ final class TLCPCipher {
             }
 
             @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
-            }
-
-            @Override
             int estimateFragmentSize(int packetSize, int headerSize) {
                 return packetSize - headerSize - recordIvSize - tagSize;
             }
@@ -546,17 +535,6 @@ final class TLCPCipher {
                 }
 
                 return len + nonce.length;
-            }
-
-            @Override
-            void dispose() {
-                if (cipher != null) {
-                    try {
-                        cipher.doFinal();
-                    } catch (Exception e) {
-                        // swallow all types of exceptions.
-                    }
-                }
             }
 
             @Override


### PR DESCRIPTION
This is a backport of [JDK-8294848]: Unnecessary SSLCipher dispose implementations.

This PR will resolves #37.

[JDK-8294848]:
<https://bugs.openjdk.org/browse/JDK-8294848>