### PR TITLE
TKSS-39: Backport JDK-8294997: Improve ECC math operations

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECOperations.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECOperations.java
@@ -350,25 +350,19 @@ public class ECOperations {
         p.getY().setValue(t2).setProduct(b);
         p.getY().setDifference(p.getZ());
 
-        p.getX().setValue(p.getY()).setProduct(two);
-        p.getY().setSum(p.getX());
-        p.getY().setReduced();
+        p.getY().setProduct(three);
         p.getX().setValue(t1).setDifference(p.getY());
 
         p.getY().setSum(t1);
         p.getY().setProduct(p.getX());
         p.getX().setProduct(t3);
 
-        t3.setValue(t2).setProduct(two);
-        t2.setSum(t3);
+        t2.setProduct(three);
         p.getZ().setProduct(b);
 
-        t2.setReduced();
         p.getZ().setDifference(t2);
         p.getZ().setDifference(t0);
-        t3.setValue(p.getZ()).setProduct(two);
-        p.getZ().setReduced();
-        p.getZ().setSum(t3);
+        p.getZ().setProduct(three);
         t0.setProduct(three);
 
         t0.setDifference(t2);
@@ -459,8 +453,8 @@ public class ECOperations {
         p.getX().setDifference(t1);
 
         p.getZ().setProduct(t4);
-        t1.setValue(t3).setProduct(t0);
-        p.getZ().setSum(t1);
+        t3.setProduct(t0);
+        p.getZ().setSum(t3);
 
     }
 
@@ -530,9 +524,9 @@ public class ECOperations {
 
         p.getX().setDifference(t1);
         p.getZ().setProduct(t4);
-        t1.setValue(t3).setProduct(t0);
 
-        p.getZ().setSum(t1);
+        t3.setProduct(t0);
+        p.getZ().setSum(t3);
 
     }
 
@@ -547,7 +541,7 @@ public class ECOperations {
             random.nextBytes(seedArr);
             try {
                 return seedToScalar(seedArr);
-            } catch (ECOperations.IntermediateValueException ex) {
+            } catch (IntermediateValueException ex) {
                 // try again in the next iteration
             }
         }

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/Curve25519OrderField.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/Curve25519OrderField.java
@@ -49,10 +49,10 @@ public final class Curve25519OrderField extends IntegerPolynomial {
     private static BigInteger evaluateModulus() {
         BigInteger result = BigInteger.valueOf(2).pow(252);
         result = result.add(BigInteger.valueOf(16110573));
-        result = result.add(BigInteger.valueOf(2).pow(26).multiply(BigInteger.valueOf(10012311)));
-        result = result.add(BigInteger.valueOf(2).pow(52).multiply(BigInteger.valueOf(30238081)));
-        result = result.subtract(BigInteger.valueOf(2).pow(78).multiply(BigInteger.valueOf(8746018)));
-        result = result.add(BigInteger.valueOf(2).pow(104).multiply(BigInteger.valueOf(1367802)));
+        result = result.add(BigInteger.valueOf(10012311).shiftLeft(26));
+        result = result.add(BigInteger.valueOf(30238081).shiftLeft(52));
+        result = result.subtract(BigInteger.valueOf(8746018).shiftLeft(78));
+        result = result.add(BigInteger.valueOf(1367802).shiftLeft(104));
         return result;
     }
     @Override

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/Curve448OrderField.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/Curve448OrderField.java
@@ -49,14 +49,14 @@ public final class Curve448OrderField extends IntegerPolynomial {
     private static BigInteger evaluateModulus() {
         BigInteger result = BigInteger.valueOf(2).pow(446);
         result = result.subtract(BigInteger.valueOf(78101261));
-        result = result.add(BigInteger.valueOf(2).pow(28).multiply(BigInteger.valueOf(126626091)));
-        result = result.add(BigInteger.valueOf(2).pow(56).multiply(BigInteger.valueOf(93279523)));
-        result = result.subtract(BigInteger.valueOf(2).pow(84).multiply(BigInteger.valueOf(64542500)));
-        result = result.add(BigInteger.valueOf(2).pow(112).multiply(BigInteger.valueOf(110109037)));
-        result = result.add(BigInteger.valueOf(2).pow(140).multiply(BigInteger.valueOf(77262179)));
-        result = result.subtract(BigInteger.valueOf(2).pow(168).multiply(BigInteger.valueOf(104575269)));
-        result = result.add(BigInteger.valueOf(2).pow(196).multiply(BigInteger.valueOf(130851391)));
-        result = result.subtract(BigInteger.valueOf(2).pow(224));
+        result = result.add(BigInteger.valueOf(126626091).shiftLeft(28));
+        result = result.add(BigInteger.valueOf(93279523).shiftLeft(56));
+        result = result.subtract(BigInteger.valueOf(64542500).shiftLeft(84));
+        result = result.add(BigInteger.valueOf(110109037).shiftLeft(112));
+        result = result.add(BigInteger.valueOf(77262179).shiftLeft(140));
+        result = result.subtract(BigInteger.valueOf(104575269).shiftLeft(168));
+        result = result.add(BigInteger.valueOf(130851391).shiftLeft(196));
+        result = result.subtract(BigInteger.valueOf(1).shiftLeft(224));
         return result;
     }
     @Override

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomial.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomial.java
@@ -326,9 +326,10 @@ public abstract class IntegerPolynomial implements IntegerFieldModuloP {
     }
 
     protected void setLimbsValuePositive(BigInteger v, long[] limbs) {
-        BigInteger mod = BigInteger.valueOf(1 << bitsPerLimb);
+        assert bitsPerLimb < 32;
+        long limbMask = (1L << bitsPerLimb) - 1;
         for (int i = 0; i < limbs.length; i++) {
-            limbs[i] = v.mod(mod).longValue();
+            limbs[i] = v.intValue() & limbMask;
             v = v.shiftRight(bitsPerLimb);
         }
     }

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomial448.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomial448.java
@@ -47,7 +47,7 @@ public final class IntegerPolynomial448 extends IntegerPolynomial {
     //(224%nat,-1)::(0%nat,-1)::nil.
     private static BigInteger evaluateModulus() {
         BigInteger result = BigInteger.valueOf(2).pow(448);
-        result = result.subtract(BigInteger.valueOf(2).pow(224));
+        result = result.subtract(BigInteger.valueOf(1).shiftLeft(224));
         result = result.subtract(BigInteger.valueOf(1));
         return result;
     }

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomialP256.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomialP256.java
@@ -48,9 +48,9 @@ public final class IntegerPolynomialP256 extends IntegerPolynomial {
     //(224%nat,-1)::(192%nat,1)::(96%nat,1)::(0%nat,-1)::nil.
     private static BigInteger evaluateModulus() {
         BigInteger result = BigInteger.valueOf(2).pow(256);
-        result = result.subtract(BigInteger.valueOf(2).pow(224));
-        result = result.add(BigInteger.valueOf(2).pow(192));
-        result = result.add(BigInteger.valueOf(2).pow(96));
+        result = result.subtract(BigInteger.valueOf(1).shiftLeft(224));
+        result = result.add(BigInteger.valueOf(1).shiftLeft(192));
+        result = result.add(BigInteger.valueOf(1).shiftLeft(96));
         result = result.subtract(BigInteger.valueOf(1));
         return result;
     }

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomialP384.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomialP384.java
@@ -48,9 +48,9 @@ public final class IntegerPolynomialP384 extends IntegerPolynomial {
     //(128%nat,-1)::(96%nat,-1)::(32%nat,1)::(0%nat,-1)::nil.
     private static BigInteger evaluateModulus() {
         BigInteger result = BigInteger.valueOf(2).pow(384);
-        result = result.subtract(BigInteger.valueOf(2).pow(128));
-        result = result.subtract(BigInteger.valueOf(2).pow(96));
-        result = result.add(BigInteger.valueOf(2).pow(32));
+        result = result.subtract(BigInteger.valueOf(1).shiftLeft(128));
+        result = result.subtract(BigInteger.valueOf(1).shiftLeft(96));
+        result = result.add(BigInteger.valueOf(1).shiftLeft(32));
         result = result.subtract(BigInteger.valueOf(1));
         return result;
     }

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomialSM2.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomialSM2.java
@@ -48,9 +48,9 @@ public final class IntegerPolynomialSM2 extends IntegerPolynomial {
     //(224%nat,-1)::(96%nat,-1)::(64%nat,1)::(0%nat,-1)::nil.
     private static BigInteger evaluateModulus() {
         BigInteger result = BigInteger.valueOf(2).pow(256);
-        result = result.subtract(BigInteger.valueOf(2).pow(224));
-        result = result.subtract(BigInteger.valueOf(2).pow(96));
-        result = result.add(BigInteger.valueOf(2).pow(64));
+        result = result.subtract(BigInteger.valueOf(1).shiftLeft(224));
+        result = result.subtract(BigInteger.valueOf(1).shiftLeft(96));
+        result = result.add(BigInteger.valueOf(1).shiftLeft(64));
         result = result.subtract(BigInteger.valueOf(1));
         return result;
     }

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/P256OrderField.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/P256OrderField.java
@@ -49,12 +49,12 @@ public final class P256OrderField extends IntegerPolynomial {
     private static BigInteger evaluateModulus() {
         BigInteger result = BigInteger.valueOf(2).pow(256);
         result = result.add(BigInteger.valueOf(6497617));
-        result = result.subtract(BigInteger.valueOf(2).pow(26).multiply(BigInteger.valueOf(26038081)));
-        result = result.add(BigInteger.valueOf(2).pow(52).multiply(BigInteger.valueOf(32001852)));
-        result = result.subtract(BigInteger.valueOf(2).pow(78).multiply(BigInteger.valueOf(21586850)));
-        result = result.subtract(BigInteger.valueOf(2).pow(104).multiply(BigInteger.valueOf(4397317)));
-        result = result.add(BigInteger.valueOf(2).pow(182).multiply(BigInteger.valueOf(1024)));
-        result = result.subtract(BigInteger.valueOf(2).pow(208).multiply(BigInteger.valueOf(65536)));
+        result = result.subtract(BigInteger.valueOf(26038081).shiftLeft(26));
+        result = result.add(BigInteger.valueOf(32001852).shiftLeft(52));
+        result = result.subtract(BigInteger.valueOf(21586850).shiftLeft(78));
+        result = result.subtract(BigInteger.valueOf(4397317).shiftLeft(104));
+        result = result.add(BigInteger.valueOf(1024).shiftLeft(182));
+        result = result.subtract(BigInteger.valueOf(65536).shiftLeft(208));
         return result;
     }
     @Override

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/P384OrderField.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/P384OrderField.java
@@ -49,12 +49,12 @@ public final class P384OrderField extends IntegerPolynomial {
     private static BigInteger evaluateModulus() {
         BigInteger result = BigInteger.valueOf(2).pow(384);
         result = result.subtract(BigInteger.valueOf(54187661));
-        result = result.subtract(BigInteger.valueOf(2).pow(28).multiply(BigInteger.valueOf(20867411)));
-        result = result.add(BigInteger.valueOf(2).pow(56).multiply(BigInteger.valueOf(10975981)));
-        result = result.add(BigInteger.valueOf(2).pow(84).multiply(BigInteger.valueOf(14361739)));
-        result = result.subtract(BigInteger.valueOf(2).pow(112).multiply(BigInteger.valueOf(35694566)));
-        result = result.subtract(BigInteger.valueOf(2).pow(140).multiply(BigInteger.valueOf(132168845)));
-        result = result.subtract(BigInteger.valueOf(2).pow(168).multiply(BigInteger.valueOf(3710130)));
+        result = result.subtract(BigInteger.valueOf(20867411).shiftLeft(28));
+        result = result.add(BigInteger.valueOf(10975981).shiftLeft(56));
+        result = result.add(BigInteger.valueOf(14361739).shiftLeft(84));
+        result = result.subtract(BigInteger.valueOf(35694566).shiftLeft(112));
+        result = result.subtract(BigInteger.valueOf(132168845).shiftLeft(140));
+        result = result.subtract(BigInteger.valueOf(3710130).shiftLeft(168));
         return result;
     }
     @Override

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/P521OrderField.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/P521OrderField.java
@@ -49,15 +49,15 @@ public final class P521OrderField extends IntegerPolynomial {
     private static BigInteger evaluateModulus() {
         BigInteger result = BigInteger.valueOf(2).pow(521);
         result = result.add(BigInteger.valueOf(20472841));
-        result = result.add(BigInteger.valueOf(2).pow(28).multiply(BigInteger.valueOf(117141993)));
-        result = result.subtract(BigInteger.valueOf(2).pow(56).multiply(BigInteger.valueOf(62411077)));
-        result = result.subtract(BigInteger.valueOf(2).pow(84).multiply(BigInteger.valueOf(56915814)));
-        result = result.add(BigInteger.valueOf(2).pow(112).multiply(BigInteger.valueOf(97532854)));
-        result = result.add(BigInteger.valueOf(2).pow(140).multiply(BigInteger.valueOf(76509338)));
-        result = result.subtract(BigInteger.valueOf(2).pow(168).multiply(BigInteger.valueOf(75510783)));
-        result = result.subtract(BigInteger.valueOf(2).pow(196).multiply(BigInteger.valueOf(67962521)));
-        result = result.add(BigInteger.valueOf(2).pow(224).multiply(BigInteger.valueOf(25593732)));
-        result = result.subtract(BigInteger.valueOf(2).pow(252).multiply(BigInteger.valueOf(91)));
+        result = result.add(BigInteger.valueOf(117141993).shiftLeft(28));
+        result = result.subtract(BigInteger.valueOf(62411077).shiftLeft(56));
+        result = result.subtract(BigInteger.valueOf(56915814).shiftLeft(84));
+        result = result.add(BigInteger.valueOf(97532854).shiftLeft(112));
+        result = result.add(BigInteger.valueOf(76509338).shiftLeft(140));
+        result = result.subtract(BigInteger.valueOf(75510783).shiftLeft(168));
+        result = result.subtract(BigInteger.valueOf(67962521).shiftLeft(196));
+        result = result.add(BigInteger.valueOf(25593732).shiftLeft(224));
+        result = result.subtract(BigInteger.valueOf(91).shiftLeft(252));
         return result;
     }
     @Override

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/SM2OrderField.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/SM2OrderField.java
@@ -49,11 +49,11 @@ public final class SM2OrderField extends IntegerPolynomial {
     private static BigInteger evaluateModulus() {
         BigInteger result = BigInteger.valueOf(2).pow(256);
         result = result.add(BigInteger.valueOf(30753059));
-        result = result.subtract(BigInteger.valueOf(2).pow(26).multiply(BigInteger.valueOf(16973234)));
-        result = result.add(BigInteger.valueOf(2).pow(52).multiply(BigInteger.valueOf(5420348)));
-        result = result.add(BigInteger.valueOf(2).pow(78).multiply(BigInteger.valueOf(28083992)));
-        result = result.subtract(BigInteger.valueOf(2).pow(104).multiply(BigInteger.valueOf(9305121)));
-        result = result.subtract(BigInteger.valueOf(2).pow(208).multiply(BigInteger.valueOf(65536)));
+        result = result.subtract(BigInteger.valueOf(16973234).shiftLeft(26));
+        result = result.add(BigInteger.valueOf(5420348).shiftLeft(52));
+        result = result.add(BigInteger.valueOf(28083992).shiftLeft(78));
+        result = result.subtract(BigInteger.valueOf(9305121).shiftLeft(104));
+        result = result.subtract(BigInteger.valueOf(65536).shiftLeft(208));
         return result;
     }
     @Override

--- a/kona-crypto/src/test/java/com/tencent/kona/sun/security/util/math/intpoly/FieldGen.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/sun/security/util/math/intpoly/FieldGen.java
@@ -265,8 +265,7 @@ public class FieldGen {
         }
 
         public BigInteger getValue() {
-            return BigInteger.valueOf(2).pow(power)
-                    .multiply(BigInteger.valueOf(coefficient));
+            return BigInteger.valueOf(coefficient).shiftLeft(power);
         }
 
         public String toString() {
@@ -493,7 +492,7 @@ public class FieldGen {
         String fileName = params.getClassName() + ".java";
         PrintWriter out = new PrintWriter(Files.newBufferedWriter(
                 destPath.resolve(fileName)));
-        out.println(text);
+        out.print(text);
         out.close();
     }
 
@@ -682,14 +681,12 @@ public class FieldGen {
                 subtract = true;
             }
             String coefExpr = "BigInteger.valueOf(" + coefValue + ")";
-            String powExpr = "BigInteger.valueOf(2).pow(" + t.getPower() + ")";
+            String powExpr = ".shiftLeft(" + t.getPower() + ")";
             String termExpr = "ERROR";
             if (t.getPower() == 0) {
                 termExpr = coefExpr;
-            } else if (coefValue == 1) {
-                termExpr = powExpr;
             } else {
-                termExpr = powExpr + ".multiply(" + coefExpr + ")";
+                termExpr = coefExpr + powExpr;
             }
             if (subtract) {
                 result.appendLine("result = result.subtract(" + termExpr + ");");


### PR DESCRIPTION
This is a backport of [JDK-8294997]: Improve ECC math operations.

This PR will resolve #39.

[JDK-8294997]:
<https://bugs.openjdk.org/browse/JDK-8294997>