### PR TITLE
TKSS-45: Backport JDK-8288508: Enhance ECDSA usage

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECDSASignature.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECDSASignature.java
@@ -72,7 +72,7 @@ abstract class ECDSASignature extends SignatureSpi {
     private SecureRandom random;
 
     // flag indicating whether the digest has been reset
-    private boolean needsReset;
+    private boolean needsReset;// sign the data and return the signature. See JCA doc
 
     // private key, if initialized for signing
     private ECPrivateKey privateKey;
@@ -483,8 +483,7 @@ abstract class ECDSASignature extends SignatureSpi {
         Optional<ECDSAOperations> opsOpt =
             ECDSAOperations.forParameters(params);
         if (!opsOpt.isPresent()) {
-            throw new SignatureException("Curve not supported: " +
-                params.toString());
+            throw new SignatureException("Curve not supported: " + params);
         }
         byte[] sig = signDigestImpl(opsOpt.get(), seedBits, digest, privateKey,
             random);
@@ -500,22 +499,33 @@ abstract class ECDSASignature extends SignatureSpi {
     @Override
     protected boolean engineVerify(byte[] signature) throws SignatureException {
 
+        ECPoint w = publicKey.getW();
+        ECParameterSpec params = publicKey.getParams();
+
+        // Partial public key validation
+        try {
+            ECUtil.validatePublicKey(w, params);
+        } catch (InvalidKeyException e) {
+            return false;
+        }
+
+        ECDSAOperations ops = ECDSAOperations.forParameters(params)
+                .orElseThrow(() -> new SignatureException("Curve not supported: " + params));
+
+        // Full public key validation, only necessary when h != 1.
+        if (params.getCofactor() != 1) {
+            if (!ops.getEcOperations().checkOrder(w)) {
+                return false;
+            }
+        }
+
         byte[] sig;
         if (p1363Format) {
             sig = signature;
         } else {
             sig = ECUtil.decodeSignature(signature);
         }
-
-        byte[] digest = getDigestValue();
-
-        Optional<ECDSAOperations> opsOpt =
-            ECDSAOperations.forParameters(publicKey.getParams());
-        if (!opsOpt.isPresent()) {
-            throw new SignatureException("Curve not supported: " +
-                publicKey.getParams().toString());
-        }
-        return opsOpt.get().verifySignedDigest(digest, sig, publicKey.getW());
+        return ops.verifySignedDigest(getDigestValue(), sig, w);
     }
 
     // set parameter, not supported. See JCA doc

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECOperations.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECOperations.java
@@ -30,6 +30,7 @@ import com.tencent.kona.sun.security.ec.point.AffinePoint;
 import com.tencent.kona.sun.security.ec.point.MutablePoint;
 import com.tencent.kona.sun.security.ec.point.Point;
 import com.tencent.kona.sun.security.ec.point.ProjectivePoint;
+import com.tencent.kona.sun.security.util.ArrayUtil;
 import com.tencent.kona.sun.security.util.math.ImmutableIntegerModuloP;
 import com.tencent.kona.sun.security.util.math.IntegerFieldModuloP;
 import com.tencent.kona.sun.security.util.math.IntegerModuloP;
@@ -528,6 +529,20 @@ public class ECOperations {
         t3.setProduct(t0);
         p.getZ().setSum(t3);
 
+    }
+
+    // The extra step in the Full Public key validation as described in
+    // NIST SP 800-186 Appendix D.1.1.2
+    public boolean checkOrder(ECPoint point) {
+        BigInteger x = point.getAffineX();
+        BigInteger y = point.getAffineY();
+
+        // Verify that n Q = INFINITY. Output REJECT if verification fails.
+        IntegerFieldModuloP field = this.getField();
+        AffinePoint ap = new AffinePoint(field.getElement(x), field.getElement(y));
+        byte[] scalar = this.orderField.getSize().toByteArray();
+        ArrayUtil.reverse(scalar);
+        return isNeutral(this.multiply(ap, scalar));
     }
 
     public byte[] generatePrivateScalar(SecureRandom random) {

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/ECUtil.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/ECUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package com.tencent.kona.sun.security.util;
 
 import com.tencent.kona.crypto.CryptoInsts;
+import com.tencent.kona.crypto.util.Constants;
 import com.tencent.kona.jdk.internal.misc.SharedSecretsUtil;
 
 import java.io.IOException;
@@ -345,6 +346,43 @@ public final class ECUtil {
         }
 
         return prv;
+    }
+
+    // Partial Public key validation as described in NIST SP 800-186 Appendix D.1.1.1.
+    // The extra step in the full validation (described in Appendix D.1.1.2) is implemented
+    // as sun.security.ec.ECOperations#checkOrder inside the jdk.crypto.ec module.
+    public static void validatePublicKey(ECPoint point, ECParameterSpec spec)
+            throws InvalidKeyException {
+        BigInteger p;
+        ECField field = spec.getCurve().getField();
+        if (field instanceof ECFieldFp) {
+            ECFieldFp f = (ECFieldFp) field;
+            p = f.getP();
+        } else {
+            throw new InvalidKeyException("Only curves over prime fields are supported");
+        }
+
+        // 1. If Q is the point at infinity, output REJECT
+        if (point.equals(ECPoint.POINT_INFINITY)) {
+            throw new InvalidKeyException("Public point is at infinity");
+        }
+        // 2. Verify that x and y are integers in the interval [0, p-1]. Output REJECT if verification fails.
+        BigInteger x = point.getAffineX();
+        if (x.signum() < 0 || x.compareTo(p) >= 0) {
+            throw new InvalidKeyException("Public point x is not in the interval [0, p-1]");
+        }
+        BigInteger y = point.getAffineY();
+        if (y.signum() < 0 || y.compareTo(p) >= 0) {
+            throw new InvalidKeyException("Public point y is not in the interval [0, p-1]");
+        }
+        // 3. Verify that (x, y) is a point on the W_a,b by checking that (x, y) satisfies the defining
+        // equation y^2 = x^3 + a x + b where computations are carried out in GF(p). Output REJECT
+        // if verification fails.
+        BigInteger left = y.modPow(Constants.TWO, p);
+        BigInteger right = x.pow(3).add(spec.getCurve().getA().multiply(x)).add(spec.getCurve().getB()).mod(p);
+        if (!left.equals(right)) {
+            throw new InvalidKeyException("Public point is not on the curve");
+        }
     }
 
     private ECUtil() {}


### PR DESCRIPTION
This is a backport of [JDK-8288508]: Enhance ECDSA usage.
This JBS is a security issue, though it has no CVE.

This PR resolves #45.

[JDK-8288508]:
<https://bugs.openjdk.org/browse/JDK-8288508>