### PR TITLE
TKSS-61: Backport of JDK-8256660: Disable DTLS 1.0

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLContextImpl.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLContextImpl.java
@@ -1294,7 +1294,7 @@ public abstract class SSLContextImpl extends SSLContextSpi {
     }
 
     /*
-     * The SSLContext implementation for customized TLS protocols
+     * The SSLContext implementation for customized DTLS protocols
      *
      * @see SSLContext
      */
@@ -1352,13 +1352,11 @@ public abstract class SSLContextImpl extends SSLContextSpi {
                         ProtocolVersion.DTLS12,
                         ProtocolVersion.DTLS10
                 };
-                if (!client)
-                    return Arrays.asList(candidates);
             } else {
                 // Use the customized TLS protocols.
                 candidates =
                         new ProtocolVersion[customized.size()];
-                candidates = customized.toArray(candidates);
+                candidates = refactored.toArray(candidates);
             }
 
             return getAvailableProtocols(candidates);


### PR DESCRIPTION
This is a backport of [JDK-8256660]: Disable DTLS 1.0.
Although DTLS has nothing to do with TLCP, it would be better to align the codes with the OpenJDK's.

This PR will resolve #61.

[JDK-8256660]:
<https://bugs.openjdk.org/browse/JDK-8256660>