### PR TITLE
TKSS-64: TKSS-64: Backport JDK-8296072: CertAttrSet::encode and DerEncoder::derEncode should write into DerOutputStream

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/FeedbackCipher.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/FeedbackCipher.java
@@ -39,7 +39,6 @@ import javax.crypto.*;
  * @see CipherBlockChaining
  * @see CipherFeedback
  * @see OutputFeedback
- * @see PCBC
  */
 abstract class FeedbackCipher {
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerEncoder.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerEncoder.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.util;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 /**
  * Interface to an object that knows how to write its own DER
@@ -41,7 +40,7 @@ public interface DerEncoder {
      *
      * @param out  the stream on which the DER encoding is written.
      */
-    void derEncode(OutputStream out)
+    void derEncode(DerOutputStream out)
         throws IOException;
 
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerOutputStream.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerOutputStream.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.util;
 
 import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
@@ -586,7 +585,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      *  @exception IOException on output error.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         out.write(toByteArray());
     }
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/AlgorithmId.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/AlgorithmId.java
@@ -169,9 +169,8 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * @exception IOException on encoding error.
      */
     @Override
-    public void derEncode (OutputStream out) throws IOException {
+    public void derEncode (DerOutputStream out) throws IOException {
         DerOutputStream bytes = new DerOutputStream();
-        DerOutputStream tmp = new DerOutputStream();
 
         bytes.putOID(algid);
 
@@ -239,8 +238,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
         } else {
             bytes.write(encodedParams);
         }
-        tmp.write(DerValue.tag_Sequence, bytes);
-        out.write(tmp.toByteArray());
+        out.write(DerValue.tag_Sequence, bytes);
     }
 
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS9Attribute.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS9Attribute.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.pkcs;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CertificateException;
 import java.util.Date;
 
@@ -533,7 +532,7 @@ public class PKCS9Attribute implements DerEncoder {
      * should be encoded as <code>T61String</code>s.
      */
     @Override
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         DerOutputStream temp = new DerOutputStream();
         temp.putOID(oid);
         switch (index) {
@@ -651,11 +650,7 @@ public class PKCS9Attribute implements DerEncoder {
             default: // can't happen
         }
 
-        DerOutputStream derOut = new DerOutputStream();
-        derOut.write(DerValue.tag_Sequence, temp.toByteArray());
-
-        out.write(derOut.toByteArray());
-
+        out.write(DerValue.tag_Sequence, temp.toByteArray());
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/SignerInfo.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/SignerInfo.java
@@ -248,7 +248,7 @@ public class SignerInfo implements DerEncoder {
      *
      * @exception IOException on encoding error.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         DerOutputStream seq = new DerOutputStream();
         seq.putInteger(version);
         DerOutputStream issuerAndSerialNumber = new DerOutputStream();
@@ -270,10 +270,7 @@ public class SignerInfo implements DerEncoder {
         if (unauthenticatedAttributes != null)
             unauthenticatedAttributes.encode((byte)0xA1, seq);
 
-        DerOutputStream tmp = new DerOutputStream();
-        tmp.write(DerValue.tag_Sequence, seq);
-
-        out.write(tmp.toByteArray());
+        out.write(DerValue.tag_Sequence, seq);
     }
 
     /*

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AVA.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AVA.java
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.Reader;
 import java.security.AccessController;
 import java.text.Normalizer;
@@ -647,14 +646,13 @@ public class AVA implements DerEncoder {
      *
      * @exception IOException on encoding error.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         DerOutputStream         tmp = new DerOutputStream();
         DerOutputStream         tmp2 = new DerOutputStream();
 
         tmp.putOID(oid);
         value.encode(tmp);
-        tmp2.write(DerValue.tag_Sequence, tmp);
-        out.write(tmp2.toByteArray());
+        out.write(DerValue.tag_Sequence, tmp);
     }
 
     private String toKeyword(int format, Map<String, String> oidMap) {

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityInfoAccessExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityInfoAccessExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import java.util.*;
 
@@ -149,15 +148,14 @@ public class AuthorityInfoAccessExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.AuthInfoAccess_Id;
             this.critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityKeyIdentifierExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityKeyIdentifierExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -213,18 +212,17 @@ implements CertAttrSet<String> {
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on error.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             extensionId = PKIXExtensions.AuthorityKey_Id;
             critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/BasicConstraintsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/BasicConstraintsExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -191,16 +190,14 @@ public class BasicConstraintsExtension extends Extension
      *
      * @param out the DerOutputStream to encode the extension to.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
-            this.extensionId = PKIXExtensions.BasicConstraints_Id;
-            critical = ca;
-            encodeThis();
-        }
-        super.encode(tmp);
-
-        out.write(tmp.toByteArray());
+             this.extensionId = PKIXExtensions.BasicConstraints_Id;
+             critical = ca;
+             encodeThis();
+         }
+         super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLDistributionPointsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLDistributionPointsExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import java.util.*;
 import java.util.Collections;
@@ -199,7 +198,8 @@ public class CRLDistributionPointsExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         encode(out, PKIXExtensions.CRLDistributionPoints_Id, false);
     }
 
@@ -207,17 +207,15 @@ public class CRLDistributionPointsExtension extends Extension
      * Write the extension to the DerOutputStream.
      * (Also called by the subclass)
      */
-    protected void encode(OutputStream out, ObjectIdentifier extensionId,
-                          boolean isCritical) throws IOException {
+    protected void encode(DerOutputStream out, ObjectIdentifier extensionId,
+            boolean isCritical) throws IOException {
 
-        DerOutputStream tmp = new DerOutputStream();
         if (this.extensionValue == null) {
             this.extensionId = extensionId;
             this.critical = isCritical;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLExtensions.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLExtensions.java
@@ -30,7 +30,6 @@ import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.security.cert.CRLException;
-import java.security.cert.CertificateException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -147,16 +146,8 @@ public class CRLExtensions {
             throws CRLException {
         try {
             DerOutputStream extOut = new DerOutputStream();
-            Collection<Extension> allExts = map.values();
-            Object[] objs = allExts.toArray();
-
-            for (int i = 0; i < objs.length; i++) {
-                if (objs[i] instanceof CertAttrSet)
-                    ((CertAttrSet)objs[i]).encode(extOut);
-                else if (objs[i] instanceof Extension)
-                    ((Extension)objs[i]).encode(extOut);
-                else
-                    throw new CRLException("Illegal extension object");
+            for (Extension ext : map.values()) {
+                ext.encode(extOut);
             }
 
             DerOutputStream seq = new DerOutputStream();
@@ -170,7 +161,7 @@ public class CRLExtensions {
                 tmp = seq;
 
             out.write(tmp.toByteArray());
-        } catch (IOException | CertificateException e) {
+        } catch (IOException e) {
             throw new CRLException("Encoding error: " + e.toString());
         }
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLNumberExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLNumberExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.math.BigInteger;
 import java.util.Enumeration;
 
@@ -201,7 +200,8 @@ public class CRLNumberExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         encode(out, PKIXExtensions.CRLNumber_Id, true);
     }
 
@@ -209,18 +209,15 @@ public class CRLNumberExtension extends Extension
      * Write the extension to the DerOutputStream.
      * (Also called by the subclass)
      */
-    protected void encode(OutputStream out, ObjectIdentifier extensionId,
-                          boolean isCritical) throws IOException {
+    protected void encode(DerOutputStream out, ObjectIdentifier extensionId,
+            boolean isCritical) throws IOException {
 
-        DerOutputStream  tmp = new DerOutputStream();
-
-        if (this.extensionValue == null) {
-            this.extensionId = extensionId;
-            this.critical = isCritical;
-            encodeThis();
-        }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+       if (this.extensionValue == null) {
+           this.extensionId = extensionId;
+           this.critical = isCritical;
+           encodeThis();
+       }
+       super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLReasonCodeExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLReasonCodeExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CRLReason;
 import java.util.Enumeration;
 
@@ -159,16 +158,14 @@ public class CRLReasonCodeExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream  tmp = new DerOutputStream();
-
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.ReasonCode_Id;
             this.critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertAttrSet.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertAttrSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
 
 package com.tencent.kona.sun.security.x509;
 
+import com.tencent.kona.sun.security.util.DerOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CertificateException;
 import java.util.Enumeration;
 
@@ -58,12 +58,12 @@ public interface CertAttrSet<T> {
      * Encodes the attribute to the output stream in a format
      * that can be parsed by the <code>decode</code> method.
      *
-     * @param out the OutputStream to encode the attribute to.
+     * @param out the DerOutputStream to encode the attribute to.
      *
      * @exception CertificateException on encoding or validity errors.
      * @exception IOException on other errors.
      */
-    void encode(OutputStream out)
+    void encode(DerOutputStream out)
             throws CertificateException, IOException;
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateAlgorithmId.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateAlgorithmId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
+import java.security.cert.CertificateException;
 import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerInputStream;
@@ -107,11 +107,9 @@ public class CertificateAlgorithmId implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
-        algId.encode(tmp);
-
-        out.write(tmp.toByteArray());
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
+        algId.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateExtensions.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateExtensions.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.security.cert.CertificateException;
@@ -153,7 +152,8 @@ public class CertificateExtensions implements CertAttrSet<Extension> {
      * @exception CertificateException on encoding errors.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out)
+    @Override
+    public void encode(DerOutputStream out)
             throws CertificateException, IOException {
         encode(out, false);
     }
@@ -166,33 +166,21 @@ public class CertificateExtensions implements CertAttrSet<Extension> {
      * @exception CertificateException on encoding errors.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out, boolean isCertReq)
+    public void encode(DerOutputStream out, boolean isCertReq)
             throws CertificateException, IOException {
-        DerOutputStream extOut = new DerOutputStream();
-        Collection<Extension> allExts = map.values();
-        Object[] objs = allExts.toArray();
-
-        for (int i = 0; i < objs.length; i++) {
-            if (objs[i] instanceof CertAttrSet)
-                ((CertAttrSet)objs[i]).encode(extOut);
-            else if (objs[i] instanceof Extension)
-                ((Extension)objs[i]).encode(extOut);
-            else
-                throw new CertificateException("Illegal extension object");
+                DerOutputStream extOut = new DerOutputStream();
+        for (Extension ext : map.values()) {
+            ext.encode(extOut);
         }
 
-        DerOutputStream seq = new DerOutputStream();
-        seq.write(DerValue.tag_Sequence, extOut);
-
-        DerOutputStream tmp;
         if (!isCertReq) { // certificate
-            tmp = new DerOutputStream();
-            tmp.write(DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)3),
+            DerOutputStream seq = new DerOutputStream();
+            seq.write(DerValue.tag_Sequence, extOut);
+            out.write(DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)3),
                     seq);
-        } else
-            tmp = seq; // pkcs#10 certificateRequest
-
-        out.write(tmp.toByteArray());
+        } else {
+            out.write(DerValue.tag_Sequence, extOut);
+        }
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateIssuerExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateIssuerExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -176,18 +175,17 @@ public class CertificateIssuerExtension extends Extension
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to
+     * @param out the DerOutputStream to write the extension to
      * @exception IOException on encoding errors
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream  tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.CertificateIssuer_Id;
             critical = true;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateIssuerName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateIssuerName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import javax.security.auth.x500.X500Principal;
@@ -109,11 +108,9 @@ public class CertificateIssuerName implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
-        dnName.encode(tmp);
-
-        out.write(tmp.toByteArray());
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
+        dnName.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePoliciesExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePoliciesExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.*;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -177,15 +176,14 @@ public class CertificatePoliciesExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
-            extensionId = PKIXExtensions.CertificatePolicies_Id;
-            critical = false;
-            encodeThis();
+          extensionId = PKIXExtensions.CertificatePolicies_Id;
+          critical = false;
+          encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateSerialNumber.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateSerialNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.math.BigInteger;
 import java.util.Enumeration;
 import java.util.Random;
@@ -119,11 +118,9 @@ public class CertificateSerialNumber implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
-        serial.encode(tmp);
-
-        out.write(tmp.toByteArray());
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
+        serial.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateSubjectName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateSubjectName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import javax.security.auth.x500.X500Principal;
@@ -109,11 +108,9 @@ public class CertificateSubjectName implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
-        dnName.encode(tmp);
-
-        out.write(tmp.toByteArray());
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
+        dnName.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateValidity.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateValidity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.*;
 import java.util.Date;
 import java.util.Enumeration;
@@ -146,10 +145,11 @@ public class CertificateValidity implements CertAttrSet<String> {
     /**
      * Encode the CertificateValidity period in DER form to the stream.
      *
-     * @param out the OutputStream to marshal the contents to.
+     * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
 
         // in cases where default constructor is used check for
         // null values
@@ -169,10 +169,7 @@ public class CertificateValidity implements CertAttrSet<String> {
         } else {
             pair.putGeneralizedTime(notAfter);
         }
-        DerOutputStream seq = new DerOutputStream();
-        seq.write(DerValue.tag_Sequence, pair);
-
-        out.write(seq.toByteArray());
+        out.write(DerValue.tag_Sequence, pair);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateVersion.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerInputStream;
@@ -157,10 +156,11 @@ public class CertificateVersion implements CertAttrSet<String> {
     /**
      * Encode the CertificateVersion period in DER form to the stream.
      *
-     * @param out the OutputStream to marshal the contents to.
+     * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         // Nothing for default
         if (version == V1) {
             return;
@@ -168,11 +168,8 @@ public class CertificateVersion implements CertAttrSet<String> {
         DerOutputStream tmp = new DerOutputStream();
         tmp.putInteger(version);
 
-        DerOutputStream seq = new DerOutputStream();
-        seq.write(DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)0),
-                tmp);
-
-        out.write(seq.toByteArray());
+        out.write(DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)0),
+                  tmp);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateX509Key.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateX509Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package com.tencent.kona.sun.security.x509;
 import java.security.PublicKey;
 import java.io.InputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerInputStream;
@@ -99,14 +98,12 @@ public class CertificateX509Key implements CertAttrSet<String> {
     /**
      * Encode the key in DER form to the stream.
      *
-     * @param out the OutputStream to marshal the contents to.
+     * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
-        tmp.write(key.getEncoded());
-
-        out.write(tmp.toByteArray());
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
+        out.write(key.getEncoded());
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DeltaCRLIndicatorExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DeltaCRLIndicatorExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,9 @@
 
 package com.tencent.kona.sun.security.x509;
 
+import com.tencent.kona.sun.security.util.DerOutputStream;
+
 import java.io.IOException;
-import java.io.OutputStream;
 import java.math.BigInteger;
 
 /**
@@ -106,7 +107,7 @@ public class DeltaCRLIndicatorExtension extends CRLNumberExtension {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    public void encode(DerOutputStream out) throws IOException {
         super.encode(out, PKIXExtensions.DeltaCRLIndicator_Id, true);
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/ExtendedKeyUsageExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/ExtendedKeyUsageExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -198,15 +197,14 @@ public class ExtendedKeyUsageExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
-            extensionId = PKIXExtensions.ExtendedKeyUsage_Id;
-            critical = false;
-            encodeThis();
+          extensionId = PKIXExtensions.ExtendedKeyUsage_Id;
+          critical = false;
+          encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/Extension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/Extension.java
@@ -144,22 +144,27 @@ public class Extension implements java.security.cert.Extension {
         return ext;
     }
 
-    public void encode(OutputStream out) throws IOException {
+    /**
+     * Implementing {@link java.security.cert.Extension#encode(OutputStream)}.
+     * This implementation is made final to make sure all {@code encode()}
+     * methods in child classes are actually implementations of
+     * {@link #encode(DerOutputStream)} below.
+     *
+     * @param out the output stream
+     * @throws IOException
+     */
+    @Override
+    public final void encode(OutputStream out) throws IOException {
         if (out == null) {
             throw new NullPointerException();
         }
-
-        DerOutputStream dos1 = new DerOutputStream();
-        DerOutputStream dos2 = new DerOutputStream();
-
-        dos1.putOID(extensionId);
-        if (critical) {
-            dos1.putBoolean(true);
+        if (out instanceof DerOutputStream) {
+            encode((DerOutputStream) out);
+        } else {
+            DerOutputStream dos = new DerOutputStream();
+            encode(dos);
+            out.write(dos.toByteArray());
         }
-        dos1.putOctetString(extensionValue);
-
-        dos2.write(DerValue.tag_Sequence, dos1);
-        out.write(dos2.toByteArray());
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/FreshestCRLExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/FreshestCRLExtension.java
@@ -25,8 +25,9 @@
 
 package com.tencent.kona.sun.security.x509;
 
+import com.tencent.kona.sun.security.util.DerOutputStream;
+
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.List;
 
 /**
@@ -89,7 +90,8 @@ public class FreshestCRLExtension extends CRLDistributionPointsExtension {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         super.encode(out, PKIXExtensions.FreshestCRL_Id, false);
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InhibitAnyPolicyExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InhibitAnyPolicyExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.Debug;
@@ -164,16 +163,14 @@ public class InhibitAnyPolicyExtension extends Extension
      *
      * @param out the DerOutputStream to encode the extension to.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
-            this.extensionId = PKIXExtensions.InhibitAnyPolicy_Id;
-            critical = true;
-            encodeThis();
-        }
-        super.encode(tmp);
-
-        out.write(tmp.toByteArray());
+             this.extensionId = PKIXExtensions.InhibitAnyPolicy_Id;
+             critical = true;
+             encodeThis();
+         }
+         super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InvalidityDateExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InvalidityDateExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Date;
 import java.util.Enumeration;
 
@@ -178,16 +177,14 @@ public class InvalidityDateExtension extends Extension
      * @param out the DerOutputStream to write the extension to
      * @exception IOException on encoding errors
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream  tmp = new DerOutputStream();
-
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.InvalidityDate_Id;
             this.critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuerAlternativeNameExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuerAlternativeNameExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -160,18 +159,17 @@ public class IssuerAlternativeNameExtension
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding error.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.IssuerAlternativeName_Id;
             critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuingDistributionPointExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuingDistributionPointExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import java.util.*;
 
@@ -234,15 +233,14 @@ public class IssuingDistributionPointExtension extends Extension
      * @param out the output stream.
      * @exception IOException on encoding error.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.IssuingDistributionPoint_Id;
             this.critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/KeyUsageExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/KeyUsageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.BitArray;
@@ -320,16 +319,14 @@ public class KeyUsageExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream  tmp = new DerOutputStream();
-
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
-            this.extensionId = PKIXExtensions.KeyUsage_Id;
-            this.critical = true;
-            encodeThis();
-        }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+           this.extensionId = PKIXExtensions.KeyUsage_Id;
+           this.critical = true;
+           encodeThis();
+       }
+       super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/NameConstraintsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/NameConstraintsExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.*;
@@ -235,18 +234,17 @@ public class NameConstraintsExtension extends Extension
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.NameConstraints_Id;
             this.critical = true;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/NetscapeCertTypeExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/NetscapeCertTypeExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.*;
 
 import com.tencent.kona.sun.security.util.BitArray;
@@ -269,16 +268,14 @@ public class NetscapeCertTypeExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream  tmp = new DerOutputStream();
-
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = NetscapeCertType_Id;
             this.critical = true;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyConstraintsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyConstraintsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,15 +203,14 @@ public class PolicyConstraintsExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
-            extensionId = PKIXExtensions.PolicyConstraints_Id;
-            critical = true;
-            encodeThis();
+          extensionId = PKIXExtensions.PolicyConstraints_Id;
+          critical = true;
+          encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyMappingsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyMappingsExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.*;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -145,18 +144,17 @@ public class PolicyMappingsExtension extends Extension
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.PolicyMappings_Id;
             critical = true;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PrivateKeyUsageExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PrivateKeyUsageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.CertificateExpiredException;
@@ -239,18 +238,17 @@ public class PrivateKeyUsageExtension extends Extension
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.PrivateKeyUsage_Id;
             critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectAlternativeNameExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectAlternativeNameExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -162,18 +161,17 @@ public class SubjectAlternativeNameExtension extends Extension
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.SubjectAlternativeName_Id;
             critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectInfoAccessExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectInfoAccessExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import java.util.Collections;
 import java.util.*;
@@ -154,15 +153,14 @@ public class SubjectInfoAccessExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.SubjectInfoAccess_Id;
             this.critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectKeyIdentifierExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectKeyIdentifierExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -123,18 +122,17 @@ public class SubjectKeyIdentifierExtension extends Extension
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.SubjectKey_Id;
             critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLImpl.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLImpl.java
@@ -1265,7 +1265,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
     }
 
     @Override
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         if (signedCRL == null)
             throw new IOException("Null CRL to encode");
         out.write(signedCRL.clone());

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertImpl.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertImpl.java
@@ -378,7 +378,8 @@ public class X509CertImpl extends X509Certificate
      *
      * @exception IOException on encoding error.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    @Override
+    public void derEncode(DerOutputStream out) throws IOException {
         if (signedCert == null)
             throw new IOException("Null certificate to encode");
         out.write(signedCert.clone());

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertInfo.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertInfo.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import java.security.cert.*;
 import java.util.*;
@@ -180,14 +179,15 @@ public class X509CertInfo implements CertAttrSet<String> {
      * @exception CertificateException on encoding errors.
      * @exception IOException on other errors.
      */
-    public void encode(OutputStream out)
+    @Override
+    public void encode(DerOutputStream out)
             throws CertificateException, IOException {
         if (rawCertInfo == null) {
-            DerOutputStream tmp = new DerOutputStream();
-            emit(tmp);
-            rawCertInfo = tmp.toByteArray();
+            emit(out);
+            rawCertInfo = out.toByteArray();
+        } else {
+            out.write(rawCertInfo.clone());
         }
-        out.write(rawCertInfo.clone());
     }
 
     /**


### PR DESCRIPTION
This is backport of [JDK-8296072]: CertAttrSet::encode and DerEncoder::derEncode should write into DerOutputStream.

This PR will resolve #64.

[JDK-8296072]:
<https://bugs.openjdk.org/browse/JDK-8296072>