### PR TITLE
TKSS-66: Backport JDK-8296142: CertAttrSet::(getName|getElements|delete) are mostly useless

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityInfoAccessExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityInfoAccessExtension.java
@@ -189,30 +189,6 @@ public class AuthorityInfoAccessExtension extends Extension
         }
     }
 
-    /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(DESCRIPTIONS)) {
-            accessDescriptions = new ArrayList<>();
-        } else {
-            throw new IOException("Attribute name [" + name +
-                    "] not recognized by " +
-                    "CertAttrSet:AuthorityInfoAccessExtension.");
-        }
-        encodeThis();
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(DESCRIPTIONS);
-        return elements.elements();
-    }
-
     // Encode this extension value
     private void encodeThis() throws IOException {
         if (accessDescriptions.isEmpty()) {

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityKeyIdentifierExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityKeyIdentifierExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -268,36 +267,6 @@ implements CertAttrSet<String> {
           throw new IOException("Attribute name not recognized by " +
                         "CertAttrSet:AuthorityKeyIdentifier.");
         }
-    }
-
-    /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(KEY_ID)) {
-            id = null;
-        } else if (name.equalsIgnoreCase(AUTH_NAME)) {
-            names = null;
-        } else if (name.equalsIgnoreCase(SERIAL_NUMBER)) {
-            serialNum = null;
-        } else {
-          throw new IOException("Attribute name not recognized by " +
-                        "CertAttrSet:AuthorityKeyIdentifier.");
-        }
-        encodeThis();
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(KEY_ID);
-        elements.addElement(AUTH_NAME);
-        elements.addElement(SERIAL_NUMBER);
-
-        return (elements.elements());
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/BasicConstraintsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/BasicConstraintsExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -233,33 +232,6 @@ public class BasicConstraintsExtension extends Extension
             throw new IOException("Attribute name not recognized by " +
                     "CertAttrSet:BasicConstraints.");
         }
-    }
-
-    /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(IS_CA)) {
-            ca = false;
-        } else if (name.equalsIgnoreCase(PATH_LEN)) {
-            pathLen = -1;
-        } else {
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet:BasicConstraints.");
-        }
-        encodeThis();
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(IS_CA);
-        elements.addElement(PATH_LEN);
-
-        return (elements.elements());
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLDistributionPointsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLDistributionPointsExtension.java
@@ -28,7 +28,6 @@ package com.tencent.kona.sun.security.x509;
 import java.io.IOException;
 
 import java.util.*;
-import java.util.Collections;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -247,31 +246,6 @@ public class CRLDistributionPointsExtension extends Extension
                     "] not recognized by " +
                     "CertAttrSet:" + extensionName + '.');
         }
-    }
-
-    /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(POINTS)) {
-            distributionPoints =
-                    Collections.emptyList();
-        } else {
-            throw new IOException("Attribute name [" + name +
-                    "] not recognized by " +
-                    "CertAttrSet:" + extensionName + '.');
-        }
-        encodeThis();
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(POINTS);
-        return elements.elements();
     }
 
     // Encode this extension value

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLExtensions.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLExtensions.java
@@ -123,8 +123,8 @@ public class CRLExtensions {
             Constructor<?> cons = extClass.getConstructor(PARAMS);
             Object[] passed = new Object[] {Boolean.valueOf(ext.isCritical()),
                     ext.getExtensionValue()};
-            CertAttrSet<?> crlExt = (CertAttrSet<?>)cons.newInstance(passed);
-            if (map.put(crlExt.getName(), (Extension)crlExt) != null) {
+            Extension crlExt = (Extension)cons.newInstance(passed);
+            if (map.put(crlExt.getName(), crlExt) != null) {
                 throw new CRLException("Duplicate extensions not allowed");
             }
         } catch (InvocationTargetException invk) {
@@ -242,22 +242,16 @@ public class CRLExtensions {
             return true;
         if (!(other instanceof CRLExtensions))
             return false;
-        Collection<Extension> otherC =
-                ((CRLExtensions)other).getAllExtensions();
-        Object[] objs = otherC.toArray();
 
-        int len = objs.length;
-        if (len != map.size())
+        CRLExtensions otherCX = (CRLExtensions) other;
+        Collection<Extension> otherX = otherCX.getAllExtensions();
+        if (otherX.size() != map.size())
             return false;
 
-        Extension otherExt, thisExt;
-        String key = null;
-        for (int i = 0; i < len; i++) {
-            if (objs[i] instanceof CertAttrSet)
-                key = ((CertAttrSet)objs[i]).getName();
-            otherExt = (Extension)objs[i];
-            if (key == null)
-                key = otherExt.getExtensionId().toString();
+        Extension thisExt;
+        String key;
+        for (Extension otherExt : otherX) {
+            key = otherExt.getName();
             thisExt = map.get(key);
             if (thisExt == null)
                 return false;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLNumberExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLNumberExtension.java
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.Debug;
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -167,19 +166,6 @@ public class CRLNumberExtension extends Extension
     }
 
     /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(NUMBER)) {
-            crlNumber = null;
-        } else {
-            throw new IOException("Attribute name not recognized by" +
-                    " CertAttrSet:" + extensionName + '.');
-        }
-        encodeThis();
-    }
-
-    /**
      * Returns a printable representation of the CRLNumberExtension.
      */
     public String toString() {
@@ -221,18 +207,9 @@ public class CRLNumberExtension extends Extension
     }
 
     /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(NUMBER);
-        return (elements.elements());
-    }
-
-    /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return (extensionName);
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLReasonCodeExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLReasonCodeExtension.java
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 import java.security.cert.CRLReason;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -133,19 +132,6 @@ public class CRLReasonCodeExtension extends Extension
     }
 
     /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(REASON)) {
-            reasonCode = 0;
-        } else {
-            throw new IOException
-                    ("Name not supported by CRLReasonCodeExtension");
-        }
-        encodeThis();
-    }
-
-    /**
      * Returns a printable representation of the Reason code.
      */
     public String toString() {
@@ -169,19 +155,9 @@ public class CRLReasonCodeExtension extends Extension
     }
 
     /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(REASON);
-
-        return elements.elements();
-    }
-
-    /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return NAME;
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertAttrSet.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertAttrSet.java
@@ -28,7 +28,6 @@ package com.tencent.kona.sun.security.x509;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import java.io.IOException;
 import java.security.cert.CertificateException;
-import java.util.Enumeration;
 
 /**
  * This interface defines the methods required of a certificate attribute.
@@ -46,13 +45,6 @@ import java.util.Enumeration;
  * @see CertificateException
  */
 public interface CertAttrSet<T> {
-    /**
-     * Returns a short string describing this certificate attribute.
-     *
-     * @return value of this certificate attribute in
-     *         printable form.
-     */
-    String toString();
 
     /**
      * Encodes the attribute to the output stream in a format
@@ -88,30 +80,4 @@ public interface CertAttrSet<T> {
      */
     Object get(String name)
             throws CertificateException, IOException;
-
-    /**
-     * Deletes an attribute value from this CertAttrSet.
-     *
-     * @param name the name of the attribute to delete.
-     *
-     * @exception CertificateException on attribute handling errors.
-     * @exception IOException on other errors.
-     */
-    void delete(String name)
-            throws CertificateException, IOException;
-
-    /**
-     * Returns an enumeration of the names of the attributes existing within
-     * this attribute.
-     *
-     * @return an enumeration of the attribute names.
-     */
-    Enumeration<T> getElements();
-
-    /**
-     * Returns the name (identifier) of this CertAttrSet.
-     *
-     * @return the name of this CertAttrSet.
-     */
-    String getName();
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateAlgorithmId.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateAlgorithmId.java
@@ -27,8 +27,6 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.cert.CertificateException;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerInputStream;
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -137,34 +135,5 @@ public class CertificateAlgorithmId implements CertAttrSet<String> {
             throw new IOException("Attribute name not recognized by " +
                     "CertAttrSet:CertificateAlgorithmId.");
         }
-    }
-
-    /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(ALGORITHM)) {
-            algId = null;
-        } else {
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet:CertificateAlgorithmId.");
-        }
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(ALGORITHM);
-        return (elements.elements());
-    }
-
-    /**
-     * Return the name of this attribute.
-     */
-    public String getName() {
-        return (NAME);
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateExtensions.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateExtensions.java
@@ -110,8 +110,8 @@ public class CertificateExtensions implements CertAttrSet<Extension> {
 
             Object[] passed = new Object[] {Boolean.valueOf(ext.isCritical()),
                     ext.getExtensionValue()};
-            CertAttrSet<?> certExt = (CertAttrSet<?>) cons.newInstance(passed);
-            if (map.put(certExt.getName(), (Extension)certExt) != null) {
+            Extension certExt = (Extension) cons.newInstance(passed);
+            if (map.put(certExt.getName(), certExt) != null) {
                 throw new IOException("Duplicate extensions not allowed");
             }
         } catch (InvocationTargetException invk) {
@@ -239,14 +239,6 @@ public class CertificateExtensions implements CertAttrSet<Extension> {
     }
 
     /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<Extension> getElements() {
-        return Collections.enumeration(map.values());
-    }
-
-    /**
      * Return a collection view of the extensions.
      * @return a collection view of the extensions in this Certificate.
      */
@@ -257,13 +249,6 @@ public class CertificateExtensions implements CertAttrSet<Extension> {
     public Map<String,Extension> getUnparseableExtensions() {
         return (unparseableExtensions == null) ?
                 Collections.emptyMap() : unparseableExtensions;
-    }
-
-    /**
-     * Return the name of this attribute.
-     */
-    public String getName() {
-        return NAME;
     }
 
     /**
@@ -290,22 +275,16 @@ public class CertificateExtensions implements CertAttrSet<Extension> {
             return true;
         if (!(other instanceof CertificateExtensions))
             return false;
-        Collection<Extension> otherC =
-                ((CertificateExtensions)other).getAllExtensions();
-        Object[] objs = otherC.toArray();
 
-        int len = objs.length;
-        if (len != map.size())
+        CertificateExtensions otherCX = (CertificateExtensions) other;
+        Collection<Extension> otherX = otherCX.getAllExtensions();
+        if (otherX.size() != map.size())
             return false;
 
-        Extension otherExt, thisExt;
-        String key = null;
-        for (int i = 0; i < len; i++) {
-            if (objs[i] instanceof CertAttrSet)
-                key = ((CertAttrSet)objs[i]).getName();
-            otherExt = (Extension)objs[i];
-            if (key == null)
-                key = otherExt.getExtensionId().toString();
+        Extension thisExt;
+        String key;
+        for (Extension otherExt : otherX) {
+            key = otherExt.getName();
             thisExt = map.get(key);
             if (thisExt == null)
                 return false;
@@ -313,7 +292,7 @@ public class CertificateExtensions implements CertAttrSet<Extension> {
                 return false;
         }
         return this.getUnparseableExtensions().equals(
-                ((CertificateExtensions)other).getUnparseableExtensions());
+                otherCX.getUnparseableExtensions());
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateIssuerExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateIssuerExtension.java
@@ -25,7 +25,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -150,21 +149,6 @@ public class CertificateIssuerExtension extends Extension
     }
 
     /**
-     * Deletes the attribute value.
-     *
-     * @throws IOException on error
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(ISSUER)) {
-            names = null;
-        } else {
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet:CertificateIssuer");
-        }
-        encodeThis();
-    }
-
-    /**
      * Returns a printable representation of the certificate issuer.
      */
     public String toString() {
@@ -189,18 +173,9 @@ public class CertificateIssuerExtension extends Extension
     }
 
     /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(ISSUER);
-        return elements.elements();
-    }
-
-    /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return NAME;
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateIssuerName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateIssuerName.java
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Enumeration;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -55,7 +54,7 @@ public class CertificateIssuerName implements CertAttrSet<String> {
     public static final String DN_NAME = "dname";
 
     // accessor name for cached X500Principal only
-    // do not allow a set() of this value, do not advertise with getElements()
+    // do not allow a set() of this value
     public static final String DN_PRINCIPAL = "x500principal";
 
     // Private data member
@@ -144,36 +143,5 @@ public class CertificateIssuerName implements CertAttrSet<String> {
             throw new IOException("Attribute name not recognized by " +
                     "CertAttrSet:CertificateIssuerName.");
         }
-    }
-
-    /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(DN_NAME)) {
-            dnName = null;
-            dnPrincipal = null;
-        } else {
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet:CertificateIssuerName.");
-        }
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(DN_NAME);
-
-        return (elements.elements());
-    }
-
-    /**
-     * Return the name of this attribute.
-     */
-    public String getName() {
-        return(NAME);
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePoliciesExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePoliciesExtension.java
@@ -219,33 +219,9 @@ public class CertificatePoliciesExtension extends Extension
     }
 
     /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(POLICIES)) {
-            certPolicies = null;
-        } else {
-            throw new IOException("Attribute name [" + name +
-                    "] not recognized by " +
-                    "CertAttrSet:CertificatePoliciesExtension.");
-        }
-        encodeThis();
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(POLICIES);
-
-        return (elements.elements());
-    }
-
-    /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return (NAME);
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateSerialNumber.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateSerialNumber.java
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.x509;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
-import java.util.Enumeration;
 import java.util.Random;
 
 import com.tencent.kona.sun.security.util.DerInputStream;
@@ -148,29 +147,6 @@ public class CertificateSerialNumber implements CertAttrSet<String> {
             throw new IOException("Attribute name not recognized by " +
                     "CertAttrSet:CertificateSerialNumber.");
         }
-    }
-
-    /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(NUMBER)) {
-            serial = null;
-        } else {
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet:CertificateSerialNumber.");
-        }
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(NUMBER);
-
-        return (elements.elements());
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateSubjectName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateSubjectName.java
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Enumeration;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -55,7 +54,7 @@ public class CertificateSubjectName implements CertAttrSet<String> {
     public static final String DN_NAME = "dname";
 
     // accessor name for cached X500Principal only
-    // do not allow a set() of this value, do not advertise with getElements()
+    // do not allow a set() of this value
     public static final String DN_PRINCIPAL = "x500principal";
 
     // Private data member
@@ -144,36 +143,5 @@ public class CertificateSubjectName implements CertAttrSet<String> {
             throw new IOException("Attribute name not recognized by " +
                     "CertAttrSet:CertificateSubjectName.");
         }
-    }
-
-    /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(DN_NAME)) {
-            dnName = null;
-            dnPrincipal = null;
-        } else {
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet:CertificateSubjectName.");
-        }
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(DN_NAME);
-
-        return(elements.elements());
-    }
-
-    /**
-     * Return the name of this attribute.
-     */
-    public String getName() {
-        return(NAME);
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateValidity.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateValidity.java
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.x509;
 import java.io.IOException;
 import java.security.cert.*;
 import java.util.Date;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerInputStream;
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -201,39 +200,6 @@ public class CertificateValidity implements CertAttrSet<String> {
             throw new IOException("Attribute name not recognized by " +
                     "CertAttrSet: CertificateValidity.");
         }
-    }
-
-    /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(NOT_BEFORE)) {
-            notBefore = null;
-        } else if (name.equalsIgnoreCase(NOT_AFTER)) {
-            notAfter = null;
-        } else {
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet: CertificateValidity.");
-        }
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(NOT_BEFORE);
-        elements.addElement(NOT_AFTER);
-
-        return (elements.elements());
-    }
-
-    /**
-     * Return the name of this attribute.
-     */
-    public String getName() {
-        return (NAME);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateVersion.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateVersion.java
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerInputStream;
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -197,36 +196,6 @@ public class CertificateVersion implements CertAttrSet<String> {
             throw new IOException("Attribute name not recognized by " +
                     "CertAttrSet: CertificateVersion.");
         }
-    }
-
-    /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(VERSION)) {
-            version = V1;
-        } else {
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet: CertificateVersion.");
-        }
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(VERSION);
-
-        return (elements.elements());
-    }
-
-    /**
-     * Return the name of this attribute.
-     */
-    public String getName() {
-        return(NAME);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateX509Key.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateX509Key.java
@@ -28,7 +28,6 @@ package com.tencent.kona.sun.security.x509;
 import java.security.PublicKey;
 import java.io.InputStream;
 import java.io.IOException;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerInputStream;
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -128,35 +127,5 @@ public class CertificateX509Key implements CertAttrSet<String> {
             throw new IOException("Attribute name not recognized by " +
                     "CertAttrSet: CertificateX509Key.");
         }
-    }
-
-    /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(KEY)) {
-            key = null;
-        } else {
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet: CertificateX509Key.");
-        }
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(KEY);
-
-        return(elements.elements());
-    }
-
-    /**
-     * Return the name of this attribute.
-     */
-    public String getName() {
-        return(NAME);
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/ExtendedKeyUsageExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/ExtendedKeyUsageExtension.java
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.Vector;
 
@@ -240,33 +239,9 @@ public class ExtendedKeyUsageExtension extends Extension
     }
 
     /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(USAGES)) {
-            keyUsages = null;
-        } else {
-            throw new IOException("Attribute name [" + name +
-                    "] not recognized by " +
-                    "CertAttrSet:ExtendedKeyUsageExtension.");
-        }
-        encodeThis();
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(USAGES);
-
-        return (elements.elements());
-    }
-
-    /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return (NAME);
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/Extension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/Extension.java
@@ -219,6 +219,15 @@ public class Extension implements java.security.cert.Extension {
         return extensionValue;
     }
 
+    /**
+     * Returns the extension name. The default implementation returns the
+     * string form of the extensionId. Known extensions should override this
+     * method to return a human readable name.
+     */
+    public String getName() {
+        return getId();
+    }
+
     public String getId() {
         return extensionId.toString();
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InhibitAnyPolicyExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InhibitAnyPolicyExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.Debug;
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -216,39 +215,11 @@ public class InhibitAnyPolicyExtension extends Extension
     }
 
     /**
-     * Delete the attribute value.
-     *
-     * @param name name of attribute to delete. Must be SKIP_CERTS.
-     * @throws IOException on error.  In this case, IOException will always be
-     *                     thrown, because the only attribute, SKIP_CERTS, is
-     *                     required.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(SKIP_CERTS))
-            throw new IOException("Attribute " + SKIP_CERTS +
-                    " may not be deleted.");
-        else
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet:InhibitAnyPolicy.");
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     *
-     * @return enumeration of elements
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(SKIP_CERTS);
-        return (elements.elements());
-    }
-
-    /**
      * Return the name of this attribute.
      *
      * @return name of attribute.
      */
+    @Override
     public String getName() {
         return (NAME);
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InvalidityDateExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InvalidityDateExtension.java
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 import java.util.Date;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -152,19 +151,6 @@ public class InvalidityDateExtension extends Extension
     }
 
     /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(DATE)) {
-            date = null;
-        } else {
-            throw new IOException
-                    ("Name not supported by InvalidityDateExtension");
-        }
-        encodeThis();
-    }
-
-    /**
      * Returns a printable representation of the Invalidity Date.
      */
     public String toString() {
@@ -188,19 +174,9 @@ public class InvalidityDateExtension extends Extension
     }
 
     /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(DATE);
-
-        return elements.elements();
-    }
-
-    /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return NAME;
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuerAlternativeNameExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuerAlternativeNameExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -202,32 +201,9 @@ public class IssuerAlternativeNameExtension
     }
 
     /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(ISSUER_NAME)) {
-            names = null;
-        } else {
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet:IssuerAlternativeName.");
-        }
-        encodeThis();
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(ISSUER_NAME);
-
-        return (elements.elements());
-    }
-
-    /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return (NAME);
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuingDistributionPointExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuingDistributionPointExtension.java
@@ -27,8 +27,6 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 
-import java.util.*;
-
 import com.tencent.kona.sun.security.util.DerInputStream;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -222,6 +220,7 @@ public class IssuingDistributionPointExtension extends Extension
     /**
      * Returns the name of this attribute.
      */
+    @Override
     public String getName() {
         return NAME;
     }
@@ -324,51 +323,6 @@ public class IssuingDistributionPointExtension extends Extension
                     "] not recognized by " +
                     "CertAttrSet:IssuingDistributionPointExtension.");
         }
-    }
-
-    /**
-     * Deletes the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(POINT)) {
-            distributionPoint = null;
-
-        } else if (name.equalsIgnoreCase(INDIRECT_CRL)) {
-            isIndirectCRL = false;
-
-        } else if (name.equalsIgnoreCase(REASONS)) {
-            revocationReasons = null;
-
-        } else if (name.equalsIgnoreCase(ONLY_USER_CERTS)) {
-            hasOnlyUserCerts = false;
-
-        } else if (name.equalsIgnoreCase(ONLY_CA_CERTS)) {
-            hasOnlyCACerts = false;
-
-        } else if (name.equalsIgnoreCase(ONLY_ATTRIBUTE_CERTS)) {
-            hasOnlyAttributeCerts = false;
-
-        } else {
-            throw new IOException("Attribute name [" + name +
-                    "] not recognized by " +
-                    "CertAttrSet:IssuingDistributionPointExtension.");
-        }
-        encodeThis();
-    }
-
-    /**
-     * Returns an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(POINT);
-        elements.addElement(REASONS);
-        elements.addElement(ONLY_USER_CERTS);
-        elements.addElement(ONLY_CA_CERTS);
-        elements.addElement(ONLY_ATTRIBUTE_CERTS);
-        elements.addElement(INDIRECT_CRL);
-        return elements.elements();
     }
 
     // Encodes this extension value

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/KeyUsageExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/KeyUsageExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.BitArray;
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -245,35 +244,6 @@ public class KeyUsageExtension extends Extension
     }
 
     /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(DIGITAL_SIGNATURE)) {
-            set(0,false);
-        } else if (name.equalsIgnoreCase(NON_REPUDIATION)) {
-            set(1,false);
-        } else if (name.equalsIgnoreCase(KEY_ENCIPHERMENT)) {
-            set(2,false);
-        } else if (name.equalsIgnoreCase(DATA_ENCIPHERMENT)) {
-            set(3,false);
-        } else if (name.equalsIgnoreCase(KEY_AGREEMENT)) {
-            set(4,false);
-        } else if (name.equalsIgnoreCase(KEY_CERTSIGN)) {
-            set(5,false);
-        } else if (name.equalsIgnoreCase(CRL_SIGN)) {
-            set(6,false);
-        } else if (name.equalsIgnoreCase(ENCIPHER_ONLY)) {
-            set(7,false);
-        } else if (name.equalsIgnoreCase(DECIPHER_ONLY)) {
-            set(8,false);
-        } else {
-            throw new IOException("Attribute name not recognized by"
-                    + " CertAttrSet:KeyUsage.");
-        }
-        encodeThis();
-    }
-
-    /**
      * Returns a printable representation of the KeyUsage.
      */
     public String toString() {
@@ -329,26 +299,6 @@ public class KeyUsageExtension extends Extension
        super.encode(out);
     }
 
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(DIGITAL_SIGNATURE);
-        elements.addElement(NON_REPUDIATION);
-        elements.addElement(KEY_ENCIPHERMENT);
-        elements.addElement(DATA_ENCIPHERMENT);
-        elements.addElement(KEY_AGREEMENT);
-        elements.addElement(KEY_CERTSIGN);
-        elements.addElement(CRL_SIGN);
-        elements.addElement(ENCIPHER_ONLY);
-        elements.addElement(DECIPHER_ONLY);
-
-        return (elements.elements());
-    }
-
-
     public boolean[] getBits() {
         return bitString.clone();
     }
@@ -356,6 +306,7 @@ public class KeyUsageExtension extends Extension
     /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return (NAME);
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/NameConstraintsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/NameConstraintsExtension.java
@@ -28,7 +28,6 @@ package com.tencent.kona.sun.security.x509;
 import java.io.IOException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.*;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -285,35 +284,9 @@ public class NameConstraintsExtension extends Extension
     }
 
     /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(PERMITTED_SUBTREES)) {
-            permitted = null;
-        } else if (name.equalsIgnoreCase(EXCLUDED_SUBTREES)) {
-            excluded = null;
-        } else {
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet:NameConstraintsExtension.");
-        }
-        encodeThis();
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(PERMITTED_SUBTREES);
-        elements.addElement(EXCLUDED_SUBTREES);
-
-        return (elements.elements());
-    }
-
-    /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return (NAME);
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/NetscapeCertTypeExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/NetscapeCertTypeExtension.java
@@ -221,14 +221,6 @@ public class NetscapeCertTypeExtension extends Extension
     }
 
     /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        set(getPosition(name), false);
-        encodeThis();
-    }
-
-    /**
      * Returns a printable representation of the NetscapeCertType.
      */
     public String toString() {
@@ -279,16 +271,9 @@ public class NetscapeCertTypeExtension extends Extension
     }
 
     /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        return mAttributeNames.elements();
-    }
-
-    /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return (NAME);
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/OCSPNoCheckExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/OCSPNoCheckExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.util.Enumeration;
 
 /**
  * Represent the OCSP NoCheck Extension from RFC2560.
@@ -105,24 +104,9 @@ public class OCSPNoCheckExtension extends Extension
     }
 
     /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        throw new IOException("No attribute is allowed by " +
-                "CertAttrSet:OCSPNoCheckExtension.");
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        return (new AttributeNameEnumeration()).elements();
-    }
-
-    /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return NAME;
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyConstraintsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyConstraintsExtension.java
@@ -26,8 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerInputStream;
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -247,35 +245,9 @@ public class PolicyConstraintsExtension extends Extension
     }
 
     /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(REQUIRE)) {
-            require = -1;
-        } else if (name.equalsIgnoreCase(INHIBIT)) {
-            inhibit = -1;
-        } else {
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet:PolicyConstraints.");
-        }
-        encodeThis();
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(REQUIRE);
-        elements.addElement(INHIBIT);
-
-        return (elements.elements());
-    }
-
-    /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return (NAME);
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyInformation.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyInformation.java
@@ -28,7 +28,6 @@ package com.tencent.kona.sun.security.x509;
 import java.io.IOException;
 import java.security.cert.PolicyQualifierInfo;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -215,41 +214,6 @@ public class PolicyInformation {
             throw new IOException("Attribute name [" + name +
                     "] not recognized by PolicyInformation");
         }
-    }
-
-    /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(QUALIFIERS)) {
-            policyQualifiers = Collections.emptySet();
-        } else if (name.equalsIgnoreCase(ID)) {
-            throw new IOException("Attribute ID may not be deleted from " +
-                    "PolicyInformation.");
-        } else {
-            //ID may not be deleted
-            throw new IOException("Attribute name [" + name +
-                    "] not recognized by PolicyInformation.");
-        }
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(ID);
-        elements.addElement(QUALIFIERS);
-
-        return elements.elements();
-    }
-
-    /**
-     * Return the name of this attribute.
-     */
-    public String getName() {
-        return NAME;
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyMappingsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyMappingsExtension.java
@@ -188,32 +188,9 @@ public class PolicyMappingsExtension extends Extension
     }
 
     /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(MAP)) {
-            maps = null;
-        } else {
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet:PolicyMappingsExtension.");
-        }
-        encodeThis();
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements () {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(MAP);
-
-        return elements.elements();
-    }
-
-    /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName () {
         return (NAME);
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PrivateKeyUsageExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PrivateKeyUsageExtension.java
@@ -31,7 +31,6 @@ import java.security.cert.CertificateParsingException;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
 import java.util.Date;
-import java.util.Enumeration;
 import java.util.Objects;
 
 import com.tencent.kona.sun.security.util.DerInputStream;
@@ -287,36 +286,9 @@ public class PrivateKeyUsageExtension extends Extension
     }
 
     /**
-     * Delete the attribute value.
-     * @exception CertificateException on attribute handling errors.
-     */
-    public void delete(String name) throws CertificateException, IOException {
-        if (name.equalsIgnoreCase(NOT_BEFORE)) {
-            notBefore = null;
-        } else if (name.equalsIgnoreCase(NOT_AFTER)) {
-            notAfter = null;
-        } else {
-            throw new CertificateException("Attribute name not recognized by"
-                    + " CertAttrSet:PrivateKeyUsage.");
-        }
-        encodeThis();
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(NOT_BEFORE);
-        elements.addElement(NOT_AFTER);
-
-        return(elements.elements());
-    }
-
-    /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return(NAME);
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/ReasonFlags.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/ReasonFlags.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.BitArray;
 import com.tencent.kona.sun.security.util.DerInputStream;
@@ -191,13 +190,6 @@ public class ReasonFlags {
     }
 
     /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        set(name, Boolean.FALSE);
-    }
-
-    /**
      * Returns a printable representation of the ReasonFlags.
      */
     public String toString() {
@@ -243,17 +235,5 @@ public class ReasonFlags {
      */
     public void encode(DerOutputStream out) throws IOException {
         out.putTruncatedUnalignedBitString(new BitArray(this.bitString));
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements () {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        for( int i=0; i<NAMES.length; i++ ) {
-            elements.addElement(NAMES[i]);
-        }
-        return (elements.elements());
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectAlternativeNameExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectAlternativeNameExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -204,32 +203,9 @@ public class SubjectAlternativeNameExtension extends Extension
     }
 
     /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(SUBJECT_NAME)) {
-            names = null;
-        } else {
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet:SubjectAlternativeName.");
-        }
-        encodeThis();
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(SUBJECT_NAME);
-
-        return (elements.elements());
-    }
-
-    /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return (NAME);
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectInfoAccessExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectInfoAccessExtension.java
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 
-import java.util.Collections;
 import java.util.*;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -143,6 +142,7 @@ public class SubjectInfoAccessExtension extends Extension
     /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return NAME;
     }
@@ -192,31 +192,6 @@ public class SubjectInfoAccessExtension extends Extension
                     "] not recognized by " +
                     "CertAttrSet:SubjectInfoAccessExtension.");
         }
-    }
-
-    /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(DESCRIPTIONS)) {
-            accessDescriptions =
-                    Collections.emptyList();
-        } else {
-            throw new IOException("Attribute name [" + name +
-                    "] not recognized by " +
-                    "CertAttrSet:SubjectInfoAccessExtension.");
-        }
-        encodeThis();
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(DESCRIPTIONS);
-        return elements.elements();
     }
 
     // Encode this extension value

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectKeyIdentifierExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectKeyIdentifierExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.util.Enumeration;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -165,32 +164,9 @@ public class SubjectKeyIdentifierExtension extends Extension
     }
 
     /**
-     * Delete the attribute value.
-     */
-    public void delete(String name) throws IOException {
-        if (name.equalsIgnoreCase(KEY_ID)) {
-            id = null;
-        } else {
-            throw new IOException("Attribute name not recognized by " +
-                    "CertAttrSet:SubjectKeyIdentifierExtension.");
-        }
-        encodeThis();
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(KEY_ID);
-
-        return (elements.elements());
-    }
-
-    /**
      * Return the name of this attribute.
      */
+    @Override
     public String getName() {
         return (NAME);
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertImpl.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertImpl.java
@@ -771,69 +771,6 @@ public class X509CertImpl extends X509Certificate
     }
 
     /**
-     * Delete the requested attribute from the certificate.
-     *
-     * @param name the name of the attribute.
-     * @exception CertificateException on invalid attribute identifier.
-     * @exception IOException on other errors.
-     */
-    public void delete(String name)
-            throws CertificateException, IOException {
-        // check if immutable
-        if (readOnly)
-            throw new CertificateException("cannot over-write existing"
-                    + " certificate");
-
-        X509AttributeName attr = new X509AttributeName(name);
-        String id = attr.getPrefix();
-        if (!(id.equalsIgnoreCase(NAME))) {
-            throw new CertificateException("Invalid root of attribute name,"
-                    + " expected ["
-                    + NAME + "], received " + id);
-        }
-        attr = new X509AttributeName(attr.getSuffix());
-        id = attr.getPrefix();
-
-        if (id.equalsIgnoreCase(INFO)) {
-            if (attr.getSuffix() == null) {
-                info = null;
-            } else {
-                info.delete(attr.getSuffix());
-            }
-        } else if (id.equalsIgnoreCase(ALG_ID)) {
-            algId = null;
-        } else if (id.equalsIgnoreCase(SIGNATURE)) {
-            signature = null;
-        } else if (id.equalsIgnoreCase(SIGNED_CERT)) {
-            signedCert = null;
-        } else {
-            throw new CertificateException("Attribute name not recognized or " +
-                    "delete() not allowed for the same: " + id);
-        }
-    }
-
-    /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(NAME + DOT + INFO);
-        elements.addElement(NAME + DOT + ALG_ID);
-        elements.addElement(NAME + DOT + SIGNATURE);
-        elements.addElement(NAME + DOT + SIGNED_CERT);
-
-        return elements.elements();
-    }
-
-    /**
-     * Return the name of this attribute.
-     */
-    public String getName() {
-        return(NAME);
-    }
-
-    /**
      * Returns a printable representation of the certificate.  This does not
      * contain all the information available to distinguish this from any
      * other certificate.  The certificate must be fully constructed

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertInfo.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertInfo.java
@@ -191,26 +191,6 @@ public class X509CertInfo implements CertAttrSet<String> {
     }
 
     /**
-     * Return an enumeration of names of attributes existing within this
-     * attribute.
-     */
-    public Enumeration<String> getElements() {
-        AttributeNameEnumeration elements = new AttributeNameEnumeration();
-        elements.addElement(VERSION);
-        elements.addElement(SERIAL_NUMBER);
-        elements.addElement(ALGORITHM_ID);
-        elements.addElement(ISSUER);
-        elements.addElement(VALIDITY);
-        elements.addElement(SUBJECT);
-        elements.addElement(KEY);
-        elements.addElement(ISSUER_ID);
-        elements.addElement(SUBJECT_ID);
-        elements.addElement(EXTENSIONS);
-
-        return elements.elements();
-    }
-
-    /**
      * Return the name of this attribute.
      */
     public String getName() {
@@ -444,85 +424,6 @@ public class X509CertInfo implements CertAttrSet<String> {
                     if (extensions == null)
                         extensions = new CertificateExtensions();
                     extensions.set(suffix, val);
-                }
-                break;
-        }
-    }
-
-    /**
-     * Delete the certificate attribute.
-     *
-     * @param name the name of the Certificate attribute.
-     * @exception CertificateException on invalid attributes.
-     * @exception IOException on other errors.
-     */
-    public void delete(String name)
-            throws CertificateException, IOException {
-        X509AttributeName attrName = new X509AttributeName(name);
-
-        int attr = attributeMap(attrName.getPrefix());
-        if (attr == 0) {
-            throw new CertificateException("Attribute name not recognized: "
-                    + name);
-        }
-        // set rawCertInfo to null, so that we are forced to re-encode
-        rawCertInfo = null;
-        String suffix = attrName.getSuffix();
-
-        switch (attr) {
-            case ATTR_VERSION:
-                if (suffix == null) {
-                    version = null;
-                } else {
-                    version.delete(suffix);
-                }
-                break;
-            case (ATTR_SERIAL):
-                if (suffix == null) {
-                    serialNum = null;
-                } else {
-                    serialNum.delete(suffix);
-                }
-                break;
-            case (ATTR_ALGORITHM):
-                if (suffix == null) {
-                    algId = null;
-                } else {
-                    algId.delete(suffix);
-                }
-                break;
-            case (ATTR_ISSUER):
-                issuer = null;
-                break;
-            case (ATTR_VALIDITY):
-                if (suffix == null) {
-                    interval = null;
-                } else {
-                    interval.delete(suffix);
-                }
-                break;
-            case (ATTR_SUBJECT):
-                subject = null;
-                break;
-            case (ATTR_KEY):
-                if (suffix == null) {
-                    pubKey = null;
-                } else {
-                    pubKey.delete(suffix);
-                }
-                break;
-            case (ATTR_ISSUER_ID):
-                issuerUniqueId = null;
-                break;
-            case (ATTR_SUBJECT_ID):
-                subjectUniqueId = null;
-                break;
-            case (ATTR_EXTENSIONS):
-                if (suffix == null) {
-                    extensions = null;
-                } else {
-                    if (extensions != null)
-                        extensions.delete(suffix);
                 }
                 break;
         }


### PR DESCRIPTION
This is a backport of [JDK-8296142]: CertAttrSet::(getName|getElements|delete) are mostly useless.

This PR will resolve #66.

[JDK-8296142]:
<https://bugs.openjdk.org/browse/JDK-8296142>