### PR TITLE
TKSS-68: Backport JDK-8295953: Use enhanced-for cycle instead of Enumeration in sun.security

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/JavaKeyStore.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/JavaKeyStore.java
@@ -48,7 +48,6 @@ import com.tencent.kona.sun.security.pkcs.EncryptedPrivateKeyInfo;
  *
  * @see KeyProtector
  * @see java.security.KeyStoreSpi
- * @see KeyTool
  *
  * @since 1.2
  */
@@ -463,9 +462,9 @@ public abstract class JavaKeyStore extends KeyStoreSpi {
     public String engineGetCertificateAlias(Certificate cert) {
         Certificate certElem;
 
-        for (Enumeration<String> e = entries.keys(); e.hasMoreElements(); ) {
-            String alias = e.nextElement();
-            Object entry = entries.get(alias);
+        for (Map.Entry<String, Object> e : entries.entrySet()) {
+            String alias = e.getKey();
+            Object entry = e.getValue();
             if (entry instanceof TrustedCertEntry) {
                 certElem = ((TrustedCertEntry)entry).cert;
             } else if (((KeyEntry)entry).chain != null) {
@@ -546,10 +545,9 @@ public abstract class JavaKeyStore extends KeyStoreSpi {
 
             dos.writeInt(entries.size());
 
-            for (Enumeration<String> e = entries.keys(); e.hasMoreElements();) {
-
-                String alias = e.nextElement();
-                Object entry = entries.get(alias);
+            for (Map.Entry<String, Object> e : entries.entrySet()) {
+                String alias = e.getKey();
+                Object entry = e.getValue();
 
                 if (entry instanceof KeyEntry) {
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLEntryImpl.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLEntryImpl.java
@@ -413,12 +413,8 @@ public class X509CRLEntryImpl extends X509CRLEntry
 
             if (extAlias == null) { // may be unknown
                 ObjectIdentifier findOID = Oid.of(oid);
-                Extension ex;
-                ObjectIdentifier inCertOID;
-                for (Enumeration<Extension> e = extensions.getElements();
-                     e.hasMoreElements();) {
-                    ex = e.nextElement();
-                    inCertOID = ex.getExtensionId();
+                for (Extension ex : extensions.getAllExtensions()) {
+                    ObjectIdentifier inCertOID = ex.getExtensionId();
                     if (inCertOID.equals((Object) findOID)) {
                         crlExt = ex;
                         break;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLImpl.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLImpl.java
@@ -1022,12 +1022,8 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
 
             if (extAlias == null) { // may be unknown
                 ObjectIdentifier findOID = Oid.of(oid);
-                Extension ex;
-                ObjectIdentifier inCertOID;
-                for (Enumeration<Extension> e = extensions.getElements();
-                     e.hasMoreElements();) {
-                    ex = e.nextElement();
-                    inCertOID = ex.getExtensionId();
+                for (Extension ex : extensions.getAllExtensions()) {
+                    ObjectIdentifier inCertOID = ex.getExtensionId();
                     if (inCertOID.equals((Object) findOID)) {
                         crlExt = ex;
                         break;

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLSessionImpl.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLSessionImpl.java
@@ -1363,9 +1363,7 @@ final class SSLSessionImpl extends ExtendedSSLSession {
     public String[] getValueNames() {
         ArrayList<Object> v = new ArrayList<>();
         Object securityCtx = SecureKey.getCurrentSecurityContext();
-        for (Enumeration<SecureKey> e = boundValues.keys();
-                e.hasMoreElements(); ) {
-            SecureKey key = e.nextElement();
+        for (SecureKey key : boundValues.keySet()) {
             if (securityCtx.equals(key.getSecurityContext())) {
                 v.add(key.getAppKey());
             }


### PR DESCRIPTION
This is a backport of [JDK-8295953]: Use enhanced-for cycle instead of Enumeration in sun.security.

This PR will resolve #68.

[JDK-8295953]:
<https://bugs.openjdk.org/browse/JDK-8295953>