### PR TITLE
TKSS-77: Backport JDK-8296741: Illegal X400Address and EDIPartyName should not be created

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/EDIPartyName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/EDIPartyName.java
@@ -26,6 +26,7 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import com.tencent.kona.sun.security.util.DerInputStream;
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -64,7 +65,7 @@ public class EDIPartyName implements GeneralNameInterface {
      */
     public EDIPartyName(String assignerName, String partyName) {
         this.assigner = assignerName;
-        this.party = partyName;
+        this.party = Objects.requireNonNull(partyName);
     }
 
     /**
@@ -73,7 +74,7 @@ public class EDIPartyName implements GeneralNameInterface {
      * @param partyName the name of the EDI party.
      */
     public EDIPartyName(String partyName) {
-        this.party = partyName;
+        this(null, partyName);
     }
 
     /**
@@ -109,6 +110,9 @@ public class EDIPartyName implements GeneralNameInterface {
                 party = opt.getAsString();
             }
         }
+        if (party == null) {
+            throw new IOException("party cannot be missing");
+        }
     }
 
     /**
@@ -135,8 +139,6 @@ public class EDIPartyName implements GeneralNameInterface {
             tagged.write(DerValue.createTag(DerValue.TAG_CONTEXT,
                     false, TAG_ASSIGNER), tmp2);
         }
-        if (party == null)
-            throw  new IOException("Cannot have null partyName");
 
         // XXX - shd check is chars fit into PrintableString
         tmp.putPrintableString(party);

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralSubtrees.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralSubtrees.java
@@ -256,7 +256,7 @@ public class GeneralSubtrees implements Cloneable {
                     newName = new GeneralName(new DNSName(""));
                     break;
                 case GeneralNameInterface.NAME_X400:
-                    newName = new GeneralName(new X400Address((byte[])null));
+                    newName = new GeneralName(new X400Address(null));
                     break;
                 case GeneralNameInterface.NAME_DIRECTORY:
                     newName = new GeneralName(new X500Name(""));

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X400Address.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X400Address.java
@@ -336,16 +336,13 @@ import com.tencent.kona.sun.security.util.DerValue;
 public class X400Address implements GeneralNameInterface {
 
     // Private data members
-    byte[] nameValue;
+    DerValue derValue;
 
     /**
      * Create the X400Address object from the specified byte array
      *
      * @param value value of the name as a byte array
      */
-    public X400Address(byte[] value) {
-        nameValue = value;
-    }
 
     /**
      * Create the X400Address object from the passed encoded Der value.
@@ -354,7 +351,7 @@ public class X400Address implements GeneralNameInterface {
      * @exception IOException on error.
      */
     public X400Address(DerValue derValue) throws IOException {
-        nameValue = derValue.toByteArray();
+        this.derValue = derValue;
     }
 
     /**
@@ -370,8 +367,8 @@ public class X400Address implements GeneralNameInterface {
      * @param out the DER stream to encode the X400Address to.
      * @exception IOException on encoding errors.
      */
+    @Override
     public void encode(DerOutputStream out) throws IOException {
-        DerValue derValue = new DerValue(nameValue);
         out.putDerValue(derValue);
     }
 


### PR DESCRIPTION
This is a backport of [JDK-8296741]: Illegal X400Address and EDIPartyName should not be created.

This PR will resolve #77.

[JDK-8296741]:
<https://bugs.openjdk.org/browse/JDK-8296741>