### PR TITLE
TKSS-78: Backport JDK-8296900: CertificateValidity fields are not optional

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateValidity.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateValidity.java
@@ -27,6 +27,7 @@ package com.tencent.kona.sun.security.x509;
 import java.io.IOException;
 import java.security.cert.*;
 import java.util.Date;
+import java.util.Objects;
 
 import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerInputStream;
@@ -48,8 +49,8 @@ public class CertificateValidity implements DerEncoder {
     static final long YR_2050 = 2524608000000L;
 
     // Private data members
-    private Date        notBefore;
-    private Date        notAfter;
+    private final Date        notBefore;
+    private final Date        notAfter;
 
     // Returns the first time the certificate is valid.
     public Date getNotBefore() {
@@ -61,8 +62,27 @@ public class CertificateValidity implements DerEncoder {
        return new Date(notAfter.getTime());
     }
 
-    // Construct the class from the DerValue
-    private void construct(DerValue derVal) throws IOException {
+    /**
+     * The constructor for this class for the specified interval.
+     *
+     * @param notBefore the date and time before which the certificate
+     *                   is not valid
+     * @param notAfter the date and time after which the certificate is
+     *                  not valid
+     */
+    public CertificateValidity(Date notBefore, Date notAfter) {
+        this.notBefore = Objects.requireNonNull(notBefore);
+        this.notAfter = Objects.requireNonNull(notAfter);
+    }
+
+    /**
+     * Create the object, decoding the values from the passed DER stream.
+     *
+     * @param in the DerInputStream to read the CertificateValidity from
+     * @exception IOException on decoding errors.
+     */
+    public CertificateValidity(DerInputStream in) throws IOException {
+        DerValue derVal = in.getDerValue();
         if (derVal.tag != DerValue.tag_Sequence) {
             throw new IOException("Invalid encoded CertificateValidity, " +
                     "starting sequence tag missing.");
@@ -94,40 +114,9 @@ public class CertificateValidity implements DerEncoder {
     }
 
     /**
-     * Default constructor for the class.
-     */
-    public CertificateValidity() { }
-
-    /**
-     * The default constructor for this class for the specified interval.
-     *
-     * @param notBefore the date and time before which the certificate
-     *                   is not valid.
-     * @param notAfter the date and time after which the certificate is
-     *                  not valid.
-     */
-    public CertificateValidity(Date notBefore, Date notAfter) {
-        this.notBefore = notBefore;
-        this.notAfter = notAfter;
-    }
-
-    /**
-     * Create the object, decoding the values from the passed DER stream.
-     *
-     * @param in the DerInputStream to read the CertificateValidity from.
-     * @exception IOException on decoding errors.
-     */
-    public CertificateValidity(DerInputStream in) throws IOException {
-        DerValue derVal = in.getDerValue();
-        construct(derVal);
-    }
-
-    /**
      * Return the validity period as user readable string.
      */
     public String toString() {
-        if (notBefore == null || notAfter == null)
-            return "";
         return "Validity: [From: " + notBefore +
                 ",\n               To: " + notAfter + ']';
     }
@@ -141,12 +130,6 @@ public class CertificateValidity implements DerEncoder {
     @Override
     public void encode(DerOutputStream out) throws IOException {
 
-        // in cases where default constructor is used check for
-        // null values
-        if (notBefore == null || notAfter == null) {
-            throw new IOException("CertificateValidity:" +
-                    " null values to encode.\n");
-        }
         DerOutputStream pair = new DerOutputStream();
 
         if (notBefore.getTime() < YR_2050) {


### PR DESCRIPTION
This is a backport of [JDK-8296900]: CertificateValidity fields are not optional.

This PR will resolve #78.

[JDK-8296900]: 
<https://bugs.openjdk.org/browse/JDK-8296900>