### PR TITLE
TKSS-76: Cannot access sun.nio.ch.DirectBuffer on JDK 17

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/java/nio/DirectBufferUtil.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/java/nio/DirectBufferUtil.java
@@ -1,0 +1,31 @@
+package com.tencent.kona.java.nio;
+
+import java.lang.reflect.Field;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+
+public class DirectBufferUtil {
+
+    private static Field addressField;
+
+    public static long address(ByteBuffer bb) {
+        try {
+            return getAddressField().getLong(bb);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("Cannot get address", e);
+        }
+    }
+
+    private static Field getAddressField() {
+        if (addressField == null) {
+            try {
+                addressField = Buffer.class.getDeclaredField("address");
+                addressField.setAccessible(true);
+            } catch (NoSuchFieldException e) {
+                throw new RuntimeException("Cannot get address field", e);
+            }
+        }
+
+        return addressField;
+    }
+}


### PR DESCRIPTION
```
java.lang.IllegalAccessError:
class com.tencent.kona.crypto.provider.GaloisCounterMode$GCMEngine (in unnamed module @0x2d58d9ed) 
cannot access class sun.nio.ch.DirectBuffer (in module java.base)
because module java.base does not export sun.nio.ch to unnamed module @0x2d58d9ed
            at com.tencent.kona.crypto.provider.GaloisCounterMode$GCMEngine.overlapDetection(GaloisCounterMode.java:929)
            at com.tencent.kona.crypto.provider.GaloisCounterMode$GCMEncrypt.doFinal(GaloisCounterMode.java:1318)
            at com.tencent.kona.crypto.provider.GaloisCounterMode.engineDoFinal(GaloisCounterMode.java:452)
            at java.base/javax.crypto.Cipher.doFinal(Cipher.java:2500)
            at com.tencent.kona.sun.security.ssl.TLCPCipher$TLCPGcmWriteCipherGenerator$GcmWriteCipher.encrypt(TLCPCipher.java:522)
            at com.tencent.kona.sun.security.ssl.OutputRecord.t10Encrypt(OutputRecord.java:440)
            at com.tencent.kona.sun.security.ssl.OutputRecord.encrypt(OutputRecord.java:344)
            at com.tencent.kona.sun.security.ssl.SSLEngineOutputRecord$HandshakeFragment.acquireCiphertext(SSLEngineOutputRecord.java:535)
            at com.tencent.kona.sun.security.ssl.SSLEngineOutputRecord.acquireCiphertext(SSLEngineOutputRecord.java:353)
            at com.tencent.kona.sun.security.ssl.SSLEngineOutputRecord.encode(SSLEngineOutputRecord.java:205)
            at com.tencent.kona.sun.security.ssl.SSLEngineOutputRecord.encode(SSLEngineOutputRecord.java:187)
            at com.tencent.kona.sun.security.ssl.SSLEngineImpl.encode(SSLEngineImpl.java:304)
            at com.tencent.kona.sun.security.ssl.SSLEngineImpl.writeRecord(SSLEngineImpl.java:246)
            at com.tencent.kona.sun.security.ssl.SSLEngineImpl.wrap(SSLEngineImpl.java:146)
            at com.tencent.kona.sun.security.ssl.SSLEngineImpl.wrap(SSLEngineImpl.java:123)
            at java.base/javax.net.ssl.SSLEngine.wrap(SSLEngine.java:564)
```