### PR TITLE
TKSS-81: Backport JDK-8296736: Some PKCS9Attribute can be created but cannot be encoded

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS9Attribute.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS9Attribute.java
@@ -386,6 +386,12 @@ public class PKCS9Attribute implements DerEncoder {
         this.oid = oid;
         index = indexOf(oid, PKCS9_OIDS, 1);
         Class<?> clazz = index == -1 ? BYTE_ARRAY_CLASS: VALUE_CLASSES[index];
+        if (clazz == null) {
+            throw new IllegalArgumentException(
+                    "No value class supported " +
+                            " for attribute " + oid +
+                            " constructing PKCS9Attribute");
+        }
         if (!clazz.isInstance(value)) {
             throw new IllegalArgumentException(
                     "Wrong value class " +
@@ -605,20 +611,20 @@ public class PKCS9Attribute implements DerEncoder {
             break;
 
             case 9:     // extended-certificate attribute -- not supported
-                throw new IOException("PKCS9 extended-certificate " +
+                throw new IllegalArgumentException("PKCS9 extended-certificate " +
                         "attribute not supported.");
                 // break unnecessary
             case 10:    // issuerAndserialNumber attribute -- not supported
-                throw new IOException("PKCS9 IssuerAndSerialNumber " +
+                throw new IllegalArgumentException("PKCS9 IssuerAndSerialNumber " +
                         "attribute not supported.");
                 // break unnecessary
             case 11:    // RSA DSI proprietary
             case 12:    // RSA DSI proprietary
-                throw new IOException("PKCS9 RSA DSI attributes " +
+                throw new IllegalArgumentException("PKCS9 RSA DSI attributes " +
                         "11 and 12, not supported.");
                 // break unnecessary
             case 13:    // S/MIME unused attribute
-                throw new IOException("PKCS9 attribute #13 not supported.");
+                throw new IllegalArgumentException("PKCS9 attribute #13 not supported.");
                 // break unnecessary
 
             case 14:     // ExtensionRequest
@@ -630,14 +636,18 @@ public class PKCS9Attribute implements DerEncoder {
             }
             break;
             case 15:    // SMIMECapability
-                throw new IOException("PKCS9 attribute #15 not supported.");
+                throw new IllegalArgumentException("PKCS9 attribute #15 not supported.");
                 // break unnecessary
 
             case 16:    // SigningCertificate
-                throw new IOException(
-                        "PKCS9 SigningCertificate attribute not supported.");
-                // break unnecessary
-
+                {
+                    DerOutputStream temp2 = new DerOutputStream();
+                    SigningCertificateInfo info = (SigningCertificateInfo)value;
+                    byte[] infoBytes = info.toByteArray();
+                    temp2.write(infoBytes, 0, infoBytes.length);
+                    temp.write(DerValue.tag_Set, temp2.toByteArray());
+                }
+                break;
             case 17:    // SignatureTimestampToken
             case 18:    // CMSAlgorithmProtection
                 temp.write(DerValue.tag_Set, (byte[])value);

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/SigningCertificateInfo.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/SigningCertificateInfo.java
@@ -79,14 +79,21 @@ import com.tencent.kona.sun.security.x509.SerialNumber;
  * @since 1.5
  * @author Vincent Ryan
  */
-public class SigningCertificateInfo {
+class SigningCertificateInfo {
 
+    private byte[] ber;
     private ESSCertId[] certId = null;
 
-    public SigningCertificateInfo(byte[] ber) throws IOException {
+    SigningCertificateInfo(byte[] ber) throws IOException {
         parse(ber);
+        this.ber = ber;
     }
 
+    byte[] toByteArray() {
+        return ber;
+    }
+
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("[\n");
@@ -99,7 +106,7 @@ public class SigningCertificateInfo {
         return sb.toString();
     }
 
-    public void parse(byte[] bytes) throws IOException {
+    private void parse(byte[] bytes) throws IOException {
 
         // Parse signingCertificate
         DerValue derValue = new DerValue(bytes);
@@ -122,45 +129,46 @@ public class SigningCertificateInfo {
             }
         }
     }
-}
 
-class ESSCertId {
+    static class ESSCertId {
 
-    private static volatile HexDumpEncoder hexDumper;
+        private static volatile HexDumpEncoder hexDumper;
 
-    private final byte[] certHash;
-    private final GeneralNames issuer;
-    private final SerialNumber serialNumber;
+        private final byte[] certHash;
+        private final GeneralNames issuer;
+        private final SerialNumber serialNumber;
 
-    ESSCertId(DerValue certId) throws IOException {
-        // Parse certHash
-        certHash = certId.data.getDerValue().toByteArray();
+        ESSCertId(DerValue certId) throws IOException {
+            // Parse certHash
+            certHash = certId.data.getDerValue().toByteArray();
 
-        // Parse issuerSerial, if present
-        if (certId.data.available() > 0) {
-            DerValue issuerSerial = certId.data.getDerValue();
-            // Parse issuer
-            issuer = new GeneralNames(issuerSerial.data.getDerValue());
-            // Parse serialNumber
-            serialNumber = new SerialNumber(issuerSerial.data.getDerValue());
-        } else {
-            issuer = null;
-            serialNumber = null;
+            // Parse issuerSerial, if present
+            if (certId.data.available() > 0) {
+                DerValue issuerSerial = certId.data.getDerValue();
+                // Parse issuer
+                issuer = new GeneralNames(issuerSerial.data.getDerValue());
+                // Parse serialNumber
+                serialNumber = new SerialNumber(issuerSerial.data.getDerValue());
+            } else {
+                issuer = null;
+                serialNumber = null;
+            }
         }
-    }
 
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("[\n\tCertificate hash (SHA-1):\n");
-        if (hexDumper == null) {
-            hexDumper = new HexDumpEncoder();
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("[\n\tCertificate hash (SHA-1):\n");
+            if (hexDumper == null) {
+                hexDumper = new HexDumpEncoder();
+            }
+            sb.append(hexDumper.encode(certHash));
+            if (issuer != null && serialNumber != null) {
+                sb.append("\n\tIssuer: " + issuer + "\n");
+                sb.append("\t" + serialNumber);
+            }
+            sb.append("\n]");
+            return sb.toString();
         }
-        sb.append(hexDumper.encode(certHash));
-        if (issuer != null && serialNumber != null) {
-            sb.append("\n\tIssuer: " + issuer + "\n");
-            sb.append("\t" + serialNumber);
-        }
-        sb.append("\n]");
-        return sb.toString();
     }
 }


### PR DESCRIPTION
This is a backport of [JDK-8296736]: Some PKCS9Attribute can be created but cannot be encoded.

This PR will resolve #81.

[JDK-8296736]:
<https://bugs.openjdk.org/browse/JDK-8296736>