### PR TITLE
TKSS-83: Backport JDK-8296442: EncryptedPrivateKeyInfo can be created with an uninitialized AlgorithmParameters

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/AlgorithmId.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/AlgorithmId.java
@@ -113,9 +113,9 @@ public class AlgorithmId implements Serializable, DerEncoder {
             try {
                 encodedParams = algParams.getEncoded();
             } catch (IOException ioe) {
-                // Ignore this at the moment. This exception can occur
-                // if AlgorithmParameters was not initialized yet. Will
-                // try to re-getEncoded() again later.
+                throw new IllegalStateException(
+                        "AlgorithmParameters not initialized or cannot be decoded",
+                        ioe);
             }
         }
     }
@@ -166,12 +166,6 @@ public class AlgorithmId implements Serializable, DerEncoder {
         DerOutputStream bytes = new DerOutputStream();
 
         bytes.putOID(algid);
-
-        // Re-getEncoded() from algParams if it was not initialized
-        if (algParams != null && encodedParams == null) {
-            encodedParams = algParams.getEncoded();
-            // If still not initialized. Let the IOE be thrown.
-        }
 
         if (encodedParams == null) {
             // Changes backed out for compatibility with Solaris
@@ -493,6 +487,8 @@ public class AlgorithmId implements Serializable, DerEncoder {
      *
      * @param algparams the associated algorithm parameters.
      * @exception NoSuchAlgorithmException on error.
+     * @exception IllegalStateException if algparams is not initialized
+     *                                  or cannot be encoded
      */
     public static AlgorithmId get(AlgorithmParameters algparams)
             throws NoSuchAlgorithmException {

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs12/MacData.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs12/MacData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,36 +94,6 @@ class MacData {
                     "must be non-null");
 
         AlgorithmId algid = AlgorithmId.get(algName);
-        this.digestAlgorithmName = algid.getName();
-        this.digestAlgorithmParams = algid.getParameters();
-
-        if (digest == null) {
-            throw new NullPointerException("the digest " +
-                    "parameter must be non-null");
-        } else if (digest.length == 0) {
-            throw new IllegalArgumentException("the digest " +
-                    "parameter must not be empty");
-        } else {
-            this.digest = digest.clone();
-        }
-
-        this.macSalt = salt;
-        this.iterations = iterations;
-
-        // delay the generation of ASN.1 encoding until
-        // getEncoded() is called
-        this.encoded = null;
-
-    }
-
-    MacData(AlgorithmParameters algParams, byte[] digest,
-            byte[] salt, int iterations) throws NoSuchAlgorithmException
-    {
-        if (algParams == null)
-            throw new NullPointerException("the algParams parameter " +
-                    "must be non-null");
-
-        AlgorithmId algid = AlgorithmId.get(algParams);
         this.digestAlgorithmName = algid.getName();
         this.digestAlgorithmParams = algid.getParameters();
 


### PR DESCRIPTION
This is a backport of [JDK-8296442]: EncryptedPrivateKeyInfo can be created with an uninitialized AlgorithmParameters.

This PR will resolve #83.

[JDK-8296442]:
<https://bugs.openjdk.org/browse/JDK-8296442>