### PR TITLE
TKSS-85: Backport JDK-8296901: Do not create unsigned certificate and CRL

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLImpl.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLImpl.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.Certificate;
@@ -96,20 +95,262 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
     private byte[]      tbsCertList = null; // DER encoded "to-be-signed" CRL
     private AlgorithmId sigAlgId = null; // sig alg in CRL
 
-    // crl information
-    private int              version;
-    private AlgorithmId      infoSigAlgId; // sig alg in "to-be-signed" crl
-    private X500Name         issuer = null;
-    private X500Principal    issuerPrincipal = null;
-    private Date             thisUpdate = null;
-    private Date             nextUpdate = null;
-    private final Map<X509IssuerSerial,X509CRLEntry> revokedMap =
-            new TreeMap<>();
-    private final List<X509CRLEntry> revokedList = new LinkedList<>();
-    private CRLExtensions    extensions = null;
-    private static final boolean isExplicit = true;
+    private TBSCertList info;
 
-    private boolean readOnly = false;
+    // crl information
+    public static class TBSCertList {
+        private int version;
+        private AlgorithmId infoSigAlgId; // sig alg in "to-be-signed" crl
+        private X500Name issuer = null;
+        private X500Principal issuerPrincipal = null;
+        private Date thisUpdate = null;
+        private Date nextUpdate = null;
+        private final Map<X509IssuerSerial, X509CRLEntry> revokedMap =
+                new TreeMap<>();
+        private final List<X509CRLEntry> revokedList = new LinkedList<>();
+        private CRLExtensions extensions = null;
+
+        /**
+         * Initial TBSCertList constructor, no revoked certs, and no extensions.
+         *
+         * @param issuer the name of the CA issuing this CRL.
+         * @param thisDate the Date of this issue.
+         * @param nextDate the Date of the next CRL.
+         */
+        public TBSCertList(X500Name issuer, Date thisDate, Date nextDate) {
+            this.issuer = issuer;
+            this.thisUpdate = thisDate;
+            this.nextUpdate = nextDate;
+        }
+
+        /**
+         * TBSCertList constructor, revoked certs, no extensions.
+         *
+         * @param issuer the name of the CA issuing this CRL.
+         * @param thisDate the Date of this issue.
+         * @param nextDate the Date of the next CRL.
+         * @param badCerts the array of CRL entries.
+         *
+         * @exception CRLException on parsing/construction errors.
+         */
+        public TBSCertList(X500Name issuer, Date thisDate, Date nextDate,
+                           X509CRLEntry[] badCerts)
+                throws CRLException
+        {
+            this.issuer = issuer;
+            this.thisUpdate = thisDate;
+            this.nextUpdate = nextDate;
+            if (badCerts != null) {
+                X500Principal crlIssuer = getIssuerX500Principal();
+                X500Principal badCertIssuer = crlIssuer;
+                for (int i = 0; i < badCerts.length; i++) {
+                    X509CRLEntryImpl badCert = (X509CRLEntryImpl)badCerts[i];
+                    badCertIssuer = getCertIssuer(badCert, badCertIssuer);
+                    badCert.setCertificateIssuer(crlIssuer, badCertIssuer);
+                    X509IssuerSerial issuerSerial = new X509IssuerSerial
+                            (badCertIssuer, badCert.getSerialNumber());
+                    this.revokedMap.put(issuerSerial, badCert);
+                    this.revokedList.add(badCert);
+                    if (badCert.hasExtensions()) {
+                        this.version = 1;
+                    }
+                }
+            }
+        }
+
+        /**
+         * TBSCertList constructor, revoked certs and extensions.
+         *
+         * @param issuer the name of the CA issuing this CRL.
+         * @param thisDate the Date of this issue.
+         * @param nextDate the Date of the next CRL.
+         * @param badCerts the array of CRL entries.
+         * @param crlExts the CRL extensions.
+         *
+         * @exception CRLException on parsing/construction errors.
+         */
+        public TBSCertList(X500Name issuer, Date thisDate, Date nextDate,
+                           X509CRLEntry[] badCerts, CRLExtensions crlExts)
+                throws CRLException
+        {
+            this(issuer, thisDate, nextDate, badCerts);
+            if (crlExts != null) {
+                this.extensions = crlExts;
+                this.version = 1;
+            }
+        }
+
+        /**
+         * Constructs from the encoding.
+         */
+        public TBSCertList(DerValue value) throws IOException, CRLException {
+
+            if (value.tag != DerValue.tag_Sequence)
+                throw new CRLException("signed CRL fields invalid");
+
+            // parse the information
+            DerInputStream derStrm = value.data;
+            DerValue       tmp;
+            byte           nextByte;
+
+            // version (optional if v1)
+            version = 0;   // by default, version = v1 == 0
+            nextByte = (byte)derStrm.peekByte();
+            if (nextByte == DerValue.tag_Integer) {
+                version = derStrm.getInteger();
+                if (version != 1)  // i.e. v2
+                    throw new CRLException("Invalid version");
+            }
+            tmp = derStrm.getDerValue();
+
+            // signature
+            infoSigAlgId = AlgorithmId.parse(tmp);
+
+            // issuer
+            issuer = new X500Name(derStrm);
+            if (issuer.isEmpty()) {
+                throw new CRLException("Empty issuer DN not allowed in X509CRLs");
+            }
+
+            // thisUpdate
+            // check if UTCTime encoded or GeneralizedTime
+
+            nextByte = (byte)derStrm.peekByte();
+            if (nextByte == DerValue.tag_UtcTime) {
+                thisUpdate = derStrm.getUTCTime();
+            } else if (nextByte == DerValue.tag_GeneralizedTime) {
+                thisUpdate = derStrm.getGeneralizedTime();
+            } else {
+                throw new CRLException("Invalid encoding for thisUpdate"
+                        + " (tag=" + nextByte + ")");
+            }
+
+            if (derStrm.available() == 0)
+                return;     // done parsing no more optional fields present
+
+            // nextUpdate (optional)
+            nextByte = (byte)derStrm.peekByte();
+            if (nextByte == DerValue.tag_UtcTime) {
+                nextUpdate = derStrm.getUTCTime();
+            } else if (nextByte == DerValue.tag_GeneralizedTime) {
+                nextUpdate = derStrm.getGeneralizedTime();
+            } // else it is not present
+
+            if (derStrm.available() == 0)
+                return;     // done parsing no more optional fields present
+
+            // revokedCertificates (optional)
+            nextByte = (byte)derStrm.peekByte();
+            if ((nextByte == DerValue.tag_SequenceOf)
+                    && (! ((nextByte & 0x0c0) == 0x080))) {
+                DerValue[] badCerts = derStrm.getSequence(4);
+
+                X500Principal crlIssuer = getIssuerX500Principal();
+                X500Principal badCertIssuer = crlIssuer;
+                for (int i = 0; i < badCerts.length; i++) {
+                    X509CRLEntryImpl entry = new X509CRLEntryImpl(badCerts[i]);
+                    badCertIssuer = getCertIssuer(entry, badCertIssuer);
+                    entry.setCertificateIssuer(crlIssuer, badCertIssuer);
+                    X509IssuerSerial issuerSerial = new X509IssuerSerial
+                            (badCertIssuer, entry.getSerialNumber());
+                    revokedMap.put(issuerSerial, entry);
+                    revokedList.add(entry);
+                }
+            }
+
+            if (derStrm.available() == 0)
+                return;     // done parsing no extensions
+
+            // crlExtensions (optional)
+            tmp = derStrm.getDerValue();
+            if (tmp.isConstructed() && tmp.isContextSpecific((byte)0)) {
+                extensions = new CRLExtensions(tmp.data);
+            }
+        }
+
+        /**
+         * Return the issuer as X500Principal.
+         */
+        public X500Principal getIssuerX500Principal() {
+            if (issuerPrincipal == null) {
+                issuerPrincipal = issuer.asX500Principal();
+            }
+            return issuerPrincipal;
+        }
+
+        /**
+         * Returns the X500 certificate issuer DN of a CRL entry.
+         *
+         * @param entry the entry to check
+         * @param prevCertIssuer the previous entry's certificate issuer
+         * @return the X500Principal in a CertificateIssuerExtension, or
+         *   prevCertIssuer if it does not exist
+         */
+        private X500Principal getCertIssuer(X509CRLEntryImpl entry,
+                                            X500Principal prevCertIssuer) {
+
+            CertificateIssuerExtension ciExt =
+                    entry.getCertificateIssuerExtension();
+            if (ciExt != null) {
+                GeneralNames names = ciExt.getNames();
+                X500Name issuerDN = (X500Name) names.get(0).getName();
+                return issuerDN.asX500Principal();
+            } else {
+                return prevCertIssuer;
+            }
+        }
+
+        /**
+         * Encodes the "to-be-signed" TBSCertList to the OutputStream.
+         *
+         * @exception CRLException on encoding errors.
+         */
+        public byte[] encodeInfo() throws CRLException {
+            try {
+                DerOutputStream tmp = new DerOutputStream();
+                DerOutputStream rCerts = new DerOutputStream();
+                DerOutputStream seq = new DerOutputStream();
+
+                if (version != 0) // v2 crl encode version
+                    tmp.putInteger(version);
+                infoSigAlgId.encode(tmp);
+                if ((version == 0) && (issuer.toString() == null))
+                    throw new CRLException("Null Issuer DN not allowed in v1 CRL");
+                issuer.encode(tmp);
+
+                if (thisUpdate.getTime() < CertificateValidity.YR_2050)
+                    tmp.putUTCTime(thisUpdate);
+                else
+                    tmp.putGeneralizedTime(thisUpdate);
+
+                if (nextUpdate != null) {
+                    if (nextUpdate.getTime() < CertificateValidity.YR_2050)
+                        tmp.putUTCTime(nextUpdate);
+                    else
+                        tmp.putGeneralizedTime(nextUpdate);
+                }
+
+                if (!revokedList.isEmpty()) {
+                    for (X509CRLEntry entry : revokedList) {
+                        ((X509CRLEntryImpl)entry).encode(rCerts);
+                    }
+                    tmp.write(DerValue.tag_Sequence, rCerts);
+                }
+
+                if (extensions != null)
+                    extensions.encode(tmp, isExplicit);
+
+                seq.write(DerValue.tag_Sequence, tmp);
+
+                return seq.toByteArray();
+            } catch (IOException e) {
+                throw new CRLException("Encoding error: " + e.getMessage());
+            }
+        }
+
+    }
+
+    private static final boolean isExplicit = true;
 
     /**
      * PublicKey that has previously been used to successfully verify
@@ -125,10 +366,17 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
     private String verifiedProvider;
 
     /**
-     * Not to be used. As it would lead to cases of uninitialized
-     * CRL objects.
+     * Constructor simply setting all (non-cache) fields. Only used in
+     * {@link #newSigned}.
      */
-    private X509CRLImpl() { }
+    public X509CRLImpl(TBSCertList info, AlgorithmId sigAlgId, byte[] signature,
+                       byte[] tbsCertList, byte[] signedCRL) {
+        this.info = info;
+        this.sigAlgId = sigAlgId;
+        this.signature = signature;
+        this.tbsCertList = tbsCertList;
+        this.signedCRL = Objects.requireNonNull(signedCRL);
+    }
 
     /**
      * Unmarshals an X.509 CRL from its encoded form, parsing the encoded
@@ -144,7 +392,6 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
         try {
             parse(new DerValue(crlData));
         } catch (IOException e) {
-            signedCRL = null;
             throw new CRLException("Parsing error: " + e.getMessage());
         }
     }
@@ -159,7 +406,6 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
         try {
             parse(val);
         } catch (IOException e) {
-            signedCRL = null;
             throw new CRLException("Parsing error: " + e.getMessage());
         }
     }
@@ -175,78 +421,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
         try {
             parse(new DerValue(inStrm));
         } catch (IOException e) {
-            signedCRL = null;
             throw new CRLException("Parsing error: " + e.getMessage());
-        }
-    }
-
-    /**
-     * Initial CRL constructor, no revoked certs, and no extensions.
-     *
-     * @param issuer the name of the CA issuing this CRL.
-     * @param thisDate the Date of this issue.
-     * @param nextDate the Date of the next CRL.
-     */
-    public X509CRLImpl(X500Name issuer, Date thisDate, Date nextDate) {
-        this.issuer = issuer;
-        this.thisUpdate = thisDate;
-        this.nextUpdate = nextDate;
-    }
-
-    /**
-     * CRL constructor, revoked certs, no extensions.
-     *
-     * @param issuer the name of the CA issuing this CRL.
-     * @param thisDate the Date of this issue.
-     * @param nextDate the Date of the next CRL.
-     * @param badCerts the array of CRL entries.
-     *
-     * @exception CRLException on parsing/construction errors.
-     */
-    public X509CRLImpl(X500Name issuer, Date thisDate, Date nextDate,
-                       X509CRLEntry[] badCerts)
-            throws CRLException
-    {
-        this.issuer = issuer;
-        this.thisUpdate = thisDate;
-        this.nextUpdate = nextDate;
-        if (badCerts != null) {
-            X500Principal crlIssuer = getIssuerX500Principal();
-            X500Principal badCertIssuer = crlIssuer;
-            for (int i = 0; i < badCerts.length; i++) {
-                X509CRLEntryImpl badCert = (X509CRLEntryImpl)badCerts[i];
-                badCertIssuer = getCertIssuer(badCert, badCertIssuer);
-                badCert.setCertificateIssuer(crlIssuer, badCertIssuer);
-                X509IssuerSerial issuerSerial = new X509IssuerSerial
-                        (badCertIssuer, badCert.getSerialNumber());
-                this.revokedMap.put(issuerSerial, badCert);
-                this.revokedList.add(badCert);
-                if (badCert.hasExtensions()) {
-                    this.version = 1;
-                }
-            }
-        }
-    }
-
-    /**
-     * CRL constructor, revoked certs and extensions.
-     *
-     * @param issuer the name of the CA issuing this CRL.
-     * @param thisDate the Date of this issue.
-     * @param nextDate the Date of the next CRL.
-     * @param badCerts the array of CRL entries.
-     * @param crlExts the CRL extensions.
-     *
-     * @exception CRLException on parsing/construction errors.
-     */
-    public X509CRLImpl(X500Name issuer, Date thisDate, Date nextDate,
-                       X509CRLEntry[] badCerts, CRLExtensions crlExts)
-            throws CRLException
-    {
-        this(issuer, thisDate, nextDate, badCerts);
-        if (crlExts != null) {
-            this.extensions = crlExts;
-            this.version = 1;
         }
     }
 
@@ -256,9 +431,6 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      * code.
      */
     public byte[] getEncodedInternal() throws CRLException {
-        if (signedCRL == null) {
-            throw new CRLException("Null CRL to encode");
-        }
         return signedCRL;
     }
 
@@ -269,56 +441,6 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      */
     public byte[] getEncoded() throws CRLException {
         return getEncodedInternal().clone();
-    }
-
-    /**
-     * Encodes the "to-be-signed" CRL to the OutputStream.
-     *
-     * @param out the OutputStream to write to.
-     * @exception CRLException on encoding errors.
-     */
-    public void encodeInfo(OutputStream out) throws CRLException {
-        try {
-            DerOutputStream tmp = new DerOutputStream();
-            DerOutputStream rCerts = new DerOutputStream();
-            DerOutputStream seq = new DerOutputStream();
-
-            if (version != 0) // v2 crl encode version
-                tmp.putInteger(version);
-            infoSigAlgId.encode(tmp);
-            if ((version == 0) && (issuer.toString() == null))
-                throw new CRLException("Null Issuer DN not allowed in v1 CRL");
-            issuer.encode(tmp);
-
-            if (thisUpdate.getTime() < CertificateValidity.YR_2050)
-                tmp.putUTCTime(thisUpdate);
-            else
-                tmp.putGeneralizedTime(thisUpdate);
-
-            if (nextUpdate != null) {
-                if (nextUpdate.getTime() < CertificateValidity.YR_2050)
-                    tmp.putUTCTime(nextUpdate);
-                else
-                    tmp.putGeneralizedTime(nextUpdate);
-            }
-
-            if (!revokedList.isEmpty()) {
-                for (X509CRLEntry entry : revokedList) {
-                    ((X509CRLEntryImpl)entry).encode(rCerts);
-                }
-                tmp.write(DerValue.tag_Sequence, rCerts);
-            }
-
-            if (extensions != null)
-                extensions.encode(tmp, isExplicit);
-
-            seq.write(DerValue.tag_Sequence, tmp);
-
-            tbsCertList = seq.toByteArray();
-            out.write(tbsCertList);
-        } catch (IOException e) {
-            throw new CRLException("Encoding error: " + e.getMessage());
-        }
     }
 
     /**
@@ -370,9 +492,6 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
                 return;
             }
         }
-        if (signedCRL == null) {
-            throw new CRLException("Uninitialized CRL");
-        }
         Signature   sigVerf = null;
         String sigName = sigAlgId.getName();
         if (sigProvider.isEmpty()) {
@@ -423,9 +542,6 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
             throws CRLException, NoSuchAlgorithmException, InvalidKeyException,
             SignatureException {
 
-        if (signedCRL == null) {
-            throw new CRLException("Uninitialized CRL");
-        }
         Signature sigVerf;
         String sigName = sigAlgId.getName();
         if (sigProvider == null) {
@@ -456,10 +572,12 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
     }
 
     /**
-     * Encodes an X.509 CRL, and signs it using the given key.
+     * Creates a new X.509 CRL, which is signed using the given key.
      *
+     * @param info the TBSCertList to sign
      * @param key the private key used for signing.
      * @param algorithm the name of the signature algorithm used.
+     * @return a newly signed CRL
      *
      * @exception NoSuchAlgorithmException on unsupported signature algorithms.
      * @exception InvalidKeyException on incorrect key.
@@ -467,18 +585,20 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      * @exception SignatureException on signature errors.
      * @exception CRLException if any mandatory data was omitted.
      */
-    public void sign(PrivateKey key, String algorithm)
+    public static X509CRLImpl newSigned(TBSCertList info, PrivateKey key, String algorithm)
             throws CRLException, NoSuchAlgorithmException, InvalidKeyException,
-            NoSuchProviderException, SignatureException {
-        sign(key, algorithm, null);
+                   NoSuchProviderException, SignatureException {
+        return newSigned(info, key, algorithm, null);
     }
 
     /**
-     * Encodes an X.509 CRL, and signs it using the given key.
+     * Creates a new X.509 CRL, which is signed using the given key.
      *
+     * @param info the TBSCertList to sign
      * @param key the private key used for signing.
      * @param algorithm the name of the signature algorithm used.
      * @param provider (optional) the name of the provider.
+     * @return a newly signed CRL
      *
      * @exception NoSuchAlgorithmException on unsupported signature algorithms.
      * @exception InvalidKeyException on incorrect key.
@@ -486,39 +606,38 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      * @exception SignatureException on signature errors.
      * @exception CRLException if any mandatory data was omitted.
      */
-    public void sign(PrivateKey key, String algorithm, String provider)
+    public static X509CRLImpl newSigned(TBSCertList info, PrivateKey key, String algorithm, String provider)
             throws CRLException, NoSuchAlgorithmException, InvalidKeyException,
-            NoSuchProviderException, SignatureException {
+                   NoSuchProviderException, SignatureException {
         try {
-            if (readOnly)
-                throw new CRLException("cannot over-write existing CRL");
-
             Signature sigEngine = SignatureUtil.fromKey(algorithm, key, provider);
-            sigAlgId = SignatureUtil.fromSignature(sigEngine, key);
-            infoSigAlgId = sigAlgId;
+            AlgorithmId sigAlgId = SignatureUtil.fromSignature(sigEngine, key);
+            info.infoSigAlgId = sigAlgId;
 
             DerOutputStream out = new DerOutputStream();
             DerOutputStream tmp = new DerOutputStream();
 
             // encode crl info
-            encodeInfo(tmp);
+            byte[] tbsCertList = info.encodeInfo();
+            tmp.write(tbsCertList, 0, tbsCertList.length);
 
             // encode algorithm identifier
             sigAlgId.encode(tmp);
 
             // Create and encode the signature itself.
             sigEngine.update(tbsCertList, 0, tbsCertList.length);
-            signature = sigEngine.sign();
+            byte[] signature = sigEngine.sign();
             tmp.putBitString(signature);
 
             // Wrap the signed data in a SEQUENCE { data, algorithm, sig }
             out.write(DerValue.tag_Sequence, tmp);
-            signedCRL = out.toByteArray();
-            readOnly = true;
+            byte[] signedCRL = out.toByteArray();
 
+            return new X509CRLImpl(info, sigAlgId, signature,
+                    tbsCertList, signedCRL);
         } catch (IOException e) {
             throw new CRLException("Error while encoding data: " +
-                    e.getMessage());
+                                   e.getMessage());
         }
     }
 
@@ -535,44 +654,44 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
     public String toStringWithAlgName(String name) {
         StringBuilder sb = new StringBuilder();
         sb.append("X.509 CRL v")
-                .append(version+1)
-                .append('\n');
+            .append(info.version+1)
+            .append('\n');
         if (sigAlgId != null)
             sb.append("Signature Algorithm: ")
-                    .append(name)
-                    .append(", OID=")
-                    .append(sigAlgId.getOID())
-                    .append('\n');
-        if (issuer != null)
+                .append(name)
+                .append(", OID=")
+                .append(sigAlgId.getOID())
+                .append('\n');
+        if (info.issuer != null)
             sb.append("Issuer: ")
-                    .append(issuer)
-                    .append('\n');
-        if (thisUpdate != null)
+                .append(info.issuer)
+                .append('\n');
+        if (info.thisUpdate != null)
             sb.append("\nThis Update: ")
-                    .append(thisUpdate)
-                    .append('\n');
-        if (nextUpdate != null)
+                .append(info.thisUpdate)
+                .append('\n');
+        if (info.nextUpdate != null)
             sb.append("Next Update: ")
-                    .append(nextUpdate)
-                    .append('\n');
-        if (revokedList.isEmpty())
+                .append(info.nextUpdate)
+                .append('\n');
+        if (info.revokedList.isEmpty())
             sb.append("\nNO certificates have been revoked\n");
         else {
             sb.append("\nRevoked Certificates: ")
-                    .append(revokedList.size());
+                .append(info.revokedList.size());
             int i = 1;
-            for (X509CRLEntry entry: revokedList) {
+            for (X509CRLEntry entry: info.revokedList) {
                 sb.append("\n[")
-                        .append(i++)
-                        .append("] ")
-                        .append(entry);
+                    .append(i++)
+                    .append("] ")
+                    .append(entry);
             }
         }
-        if (extensions != null) {
-            Collection<Extension> allExts = extensions.getAllExtensions();
+        if (info.extensions != null) {
+            Collection<Extension> allExts = info.extensions.getAllExtensions();
             Object[] objs = allExts.toArray();
             sb.append("\nCRL Extensions: ")
-                    .append(objs.length);
+                .append(objs.length);
             for (int i = 0; i < objs.length; i++) {
                 sb.append("\n[").append(i+1).append("]: ");
                 Extension ext = (Extension)objs[i];
@@ -586,9 +705,9 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
                             extValue = out.toByteArray();
                             HexDumpEncoder enc = new HexDumpEncoder();
                             sb.append("Extension unknown: ")
-                                    .append("DER encoded OCTET string =\n")
-                                    .append(enc.encodeBuffer(extValue))
-                                    .append('\n');
+                                .append("DER encoded OCTET string =\n")
+                                .append(enc.encodeBuffer(extValue))
+                                .append('\n');
                         }
                     } else {
                         sb.append(ext); // sub-class exists
@@ -601,8 +720,8 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
         if (signature != null) {
             HexDumpEncoder encoder = new HexDumpEncoder();
             sb.append("\nSignature:\n")
-                    .append(encoder.encodeBuffer(signature))
-                    .append('\n');
+                .append(encoder.encodeBuffer(signature))
+                .append('\n');
         } else {
             sb.append("NOT signed yet\n");
         }
@@ -617,12 +736,13 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      * false otherwise.
      */
     public boolean isRevoked(Certificate cert) {
-        if (revokedMap.isEmpty() || (!(cert instanceof X509Certificate))) {
+        if (info.revokedMap.isEmpty() ||
+                (!(cert instanceof X509Certificate))) {
             return false;
         }
         X509Certificate xcert = (X509Certificate) cert;
         X509IssuerSerial issuerSerial = new X509IssuerSerial(xcert);
-        return revokedMap.containsKey(issuerSerial);
+        return info.revokedMap.containsKey(issuerSerial);
     }
 
     /**
@@ -636,7 +756,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      * @return the version number, i.e. 1 or 2.
      */
     public int getVersion() {
-        return version+1;
+        return info.version + 1;
     }
 
     /**
@@ -669,7 +789,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      */
     @SuppressWarnings("deprecation")
     public Principal getIssuerDN() {
-        return issuer;
+        return info.issuer;
     }
 
     /**
@@ -677,10 +797,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      * to provide a slightly more efficient version.
      */
     public X500Principal getIssuerX500Principal() {
-        if (issuerPrincipal == null) {
-            issuerPrincipal = issuer.asX500Principal();
-        }
-        return issuerPrincipal;
+        return info.getIssuerX500Principal();
     }
 
     /**
@@ -690,7 +807,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      * @return the thisUpdate date from the CRL.
      */
     public Date getThisUpdate() {
-        return new Date(thisUpdate.getTime());
+        return new Date(info.thisUpdate.getTime());
     }
 
     /**
@@ -700,9 +817,9 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      * not present.
      */
     public Date getNextUpdate() {
-        if (nextUpdate == null)
+        if (info.nextUpdate == null)
             return null;
-        return new Date(nextUpdate.getTime());
+        return new Date(info.nextUpdate.getTime());
     }
 
     /**
@@ -713,24 +830,24 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      * @see X509CRLEntry
      */
     public X509CRLEntry getRevokedCertificate(BigInteger serialNumber) {
-        if (revokedMap.isEmpty()) {
+        if (info.revokedMap.isEmpty()) {
             return null;
         }
         // assume this is a direct CRL entry (cert and CRL issuer are the same)
         X509IssuerSerial issuerSerial = new X509IssuerSerial
-                (getIssuerX500Principal(), serialNumber);
-        return revokedMap.get(issuerSerial);
+            (getIssuerX500Principal(), serialNumber);
+        return info.revokedMap.get(issuerSerial);
     }
 
     /**
      * Gets the CRL entry for the given certificate.
      */
     public X509CRLEntry getRevokedCertificate(X509Certificate cert) {
-        if (revokedMap.isEmpty()) {
+        if (info.revokedMap.isEmpty()) {
             return null;
         }
         X509IssuerSerial issuerSerial = new X509IssuerSerial(cert);
-        return revokedMap.get(issuerSerial);
+        return info.revokedMap.get(issuerSerial);
     }
 
     /**
@@ -742,10 +859,10 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      * @see X509CRLEntry
      */
     public Set<X509CRLEntry> getRevokedCertificates() {
-        if (revokedList.isEmpty()) {
+        if (info.revokedList.isEmpty()) {
             return null;
         } else {
-            return new TreeSet<>(revokedList);
+            return new TreeSet<>(info.revokedList);
         }
     }
 
@@ -937,9 +1054,9 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      * not supported, otherwise return false.
      */
     public boolean hasUnsupportedCriticalExtension() {
-        if (extensions == null)
+        if (info.extensions == null)
             return false;
-        return extensions.hasUnsupportedCriticalExtension();
+        return info.extensions.hasUnsupportedCriticalExtension();
     }
 
     /**
@@ -951,11 +1068,11 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      * CRL that are marked critical.
      */
     public Set<String> getCriticalExtensionOIDs() {
-        if (extensions == null) {
+        if (info.extensions == null) {
             return null;
         }
         Set<String> extSet = new TreeSet<>();
-        for (Extension ex : extensions.getAllExtensions()) {
+        for (Extension ex : info.extensions.getAllExtensions()) {
             if (ex.isCritical()) {
                 extSet.add(ex.getExtensionId().toString());
             }
@@ -972,11 +1089,11 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      * CRL that are NOT marked critical.
      */
     public Set<String> getNonCriticalExtensionOIDs() {
-        if (extensions == null) {
+        if (info.extensions == null) {
             return null;
         }
         Set<String> extSet = new TreeSet<>();
-        for (Extension ex : extensions.getAllExtensions()) {
+        for (Extension ex : info.extensions.getAllExtensions()) {
             if (!ex.isCritical()) {
                 extSet.add(ex.getExtensionId().toString());
             }
@@ -996,23 +1113,23 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      * @return the der encoded octet string of the extension value.
      */
     public byte[] getExtensionValue(String oid) {
-        if (extensions == null)
+        if (info.extensions == null)
             return null;
         try {
-            String extAlias = OIDMap.getName(Oid.of(oid));
+            String extAlias = OIDMap.getName(ObjectIdentifier.of(oid));
             Extension crlExt = null;
 
             if (extAlias == null) { // may be unknown
-                ObjectIdentifier findOID = Oid.of(oid);
-                for (Extension ex : extensions.getAllExtensions()) {
+                ObjectIdentifier findOID = ObjectIdentifier.of(oid);
+                for (Extension ex : info.extensions.getAllExtensions()) {
                     ObjectIdentifier inCertOID = ex.getExtensionId();
-                    if (inCertOID.equals((Object) findOID)) {
+                    if (inCertOID.equals(findOID)) {
                         crlExt = ex;
                         break;
                     }
                 }
             } else
-                crlExt = extensions.getExtension(extAlias);
+                crlExt = info.extensions.getExtension(extAlias);
             if (crlExt == null)
                 return null;
             byte[] extData = crlExt.getExtensionValue();
@@ -1033,134 +1150,47 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      * @return Object of type {@code <extension>} or null, if not found
      */
     public Object getExtension(ObjectIdentifier oid) {
-        if (extensions == null)
+        if (info.extensions == null)
             return null;
 
         // XXX Consider cloning this
-        return extensions.getExtension(OIDMap.getName(oid));
+        return info.extensions.getExtension(OIDMap.getName(oid));
     }
 
     /*
      * Parses an X.509 CRL, should be used only by constructors.
      */
     private void parse(DerValue val) throws CRLException, IOException {
-        // check if we can overwrite the certificate
-        if (readOnly)
-            throw new CRLException("cannot over-write existing CRL");
 
         if ( val.getData() == null || val.tag != DerValue.tag_Sequence)
             throw new CRLException("Invalid DER-encoded CRL data");
-
         signedCRL = val.toByteArray();
         DerValue[] seq = new DerValue[3];
-
         seq[0] = val.data.getDerValue();
         seq[1] = val.data.getDerValue();
         seq[2] = val.data.getDerValue();
-
         if (val.data.available() != 0)
             throw new CRLException("signed overrun, bytes = "
-                    + val.data.available());
+                                     + val.data.available());
 
-        if (seq[0].tag != DerValue.tag_Sequence)
-            throw new CRLException("signed CRL fields invalid");
+        info = new TBSCertList(seq[0]);
 
         sigAlgId = AlgorithmId.parse(seq[1]);
+        // the "inner" and "outer" signature algorithms must match
+        if (!sigAlgId.equals(info.infoSigAlgId)) {
+            throw new CRLException("Signature algorithm mismatch");
+        }
+
         signature = seq[2].getBitString();
 
         if (seq[1].data.available() != 0)
             throw new CRLException("AlgorithmId field overrun");
-
         if (seq[2].data.available() != 0)
             throw new CRLException("Signature field overrun");
-
         // the tbsCertsList
         tbsCertList = seq[0].toByteArray();
 
-        // parse the information
-        DerInputStream derStrm = seq[0].data;
-        DerValue       tmp;
-        byte           nextByte;
 
-        // version (optional if v1)
-        version = 0;   // by default, version = v1 == 0
-        nextByte = (byte)derStrm.peekByte();
-        if (nextByte == DerValue.tag_Integer) {
-            version = derStrm.getInteger();
-            if (version != 1)  // i.e. v2
-                throw new CRLException("Invalid version");
-        }
-        tmp = derStrm.getDerValue();
-
-        // signature
-        AlgorithmId tmpId = AlgorithmId.parse(tmp);
-
-        // the "inner" and "outer" signature algorithms must match
-        if (! tmpId.equals(sigAlgId))
-            throw new CRLException("Signature algorithm mismatch");
-        infoSigAlgId = tmpId;
-
-        // issuer
-        issuer = new X500Name(derStrm);
-        if (issuer.isEmpty()) {
-            throw new CRLException("Empty issuer DN not allowed in X509CRLs");
-        }
-
-        // thisUpdate
-        // check if UTCTime encoded or GeneralizedTime
-
-        nextByte = (byte)derStrm.peekByte();
-        if (nextByte == DerValue.tag_UtcTime) {
-            thisUpdate = derStrm.getUTCTime();
-        } else if (nextByte == DerValue.tag_GeneralizedTime) {
-            thisUpdate = derStrm.getGeneralizedTime();
-        } else {
-            throw new CRLException("Invalid encoding for thisUpdate"
-                    + " (tag=" + nextByte + ")");
-        }
-
-        if (derStrm.available() == 0)
-            return;     // done parsing no more optional fields present
-
-        // nextUpdate (optional)
-        nextByte = (byte)derStrm.peekByte();
-        if (nextByte == DerValue.tag_UtcTime) {
-            nextUpdate = derStrm.getUTCTime();
-        } else if (nextByte == DerValue.tag_GeneralizedTime) {
-            nextUpdate = derStrm.getGeneralizedTime();
-        } // else it is not present
-
-        if (derStrm.available() == 0)
-            return;     // done parsing no more optional fields present
-
-        // revokedCertificates (optional)
-        nextByte = (byte)derStrm.peekByte();
-        if ((nextByte == DerValue.tag_SequenceOf)
-                && (! ((nextByte & 0x0c0) == 0x080))) {
-            DerValue[] badCerts = derStrm.getSequence(4);
-
-            X500Principal crlIssuer = getIssuerX500Principal();
-            X500Principal badCertIssuer = crlIssuer;
-            for (int i = 0; i < badCerts.length; i++) {
-                X509CRLEntryImpl entry = new X509CRLEntryImpl(badCerts[i]);
-                badCertIssuer = getCertIssuer(entry, badCertIssuer);
-                entry.setCertificateIssuer(crlIssuer, badCertIssuer);
-                X509IssuerSerial issuerSerial = new X509IssuerSerial
-                        (badCertIssuer, entry.getSerialNumber());
-                revokedMap.put(issuerSerial, entry);
-                revokedList.add(entry);
-            }
-        }
-
-        if (derStrm.available() == 0)
-            return;     // done parsing no extensions
-
-        // crlExtensions (optional)
-        tmp = derStrm.getDerValue();
-        if (tmp.isConstructed() && tmp.isContextSpecific((byte)0)) {
-            extensions = new CRLExtensions(tmp.data);
-        }
-        readOnly = true;
     }
 
     /**
@@ -1220,32 +1250,8 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
         }
     }
 
-    /**
-     * Returns the X500 certificate issuer DN of a CRL entry.
-     *
-     * @param entry the entry to check
-     * @param prevCertIssuer the previous entry's certificate issuer
-     * @return the X500Principal in a CertificateIssuerExtension, or
-     *   prevCertIssuer if it does not exist
-     */
-    private X500Principal getCertIssuer(X509CRLEntryImpl entry,
-        X500Principal prevCertIssuer) {
-
-        CertificateIssuerExtension ciExt =
-                entry.getCertificateIssuerExtension();
-        if (ciExt != null) {
-            GeneralNames names = ciExt.getNames();
-            X500Name issuerDN = (X500Name) names.get(0).getName();
-            return issuerDN.asX500Principal();
-        } else {
-            return prevCertIssuer;
-        }
-    }
-
     @Override
     public void encode(DerOutputStream out) throws IOException {
-        if (signedCRL == null)
-            throw new IOException("Null CRL to encode");
         out.write(signedCRL.clone());
     }
 


### PR DESCRIPTION
This is a backport of [JDK-8296901]: Do not create unsigned certificate and CRL.

This is PR will resolve #85.

[JDK-8296901]:
<https://bugs.openjdk.org/browse/JDK-8296901>