### PR TITLE
TKSS-92: Backport JDK-8296742: Illegal X509 Extension should not be created

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityInfoAccessExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityInfoAccessExtension.java
@@ -74,11 +74,15 @@ public class AuthorityInfoAccessExtension extends Extension {
      * Create an AuthorityInfoAccessExtension from a List of
      * AccessDescription; the criticality is set to false.
      *
-     * @param accessDescriptions the List of AccessDescription
+     * @param accessDescriptions the List of AccessDescription,
+     *                           cannot be null or empty.
      * @throws IOException on error
      */
     public AuthorityInfoAccessExtension(
             List<AccessDescription> accessDescriptions) throws IOException {
+        if (accessDescriptions == null || accessDescriptions.isEmpty()) {
+            throw new IllegalArgumentException("accessDescriptions is null or empty");
+        }
         this.extensionId = PKIXExtensions.AuthInfoAccess_Id;
         this.critical = false;
         this.accessDescriptions = accessDescriptions;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityKeyIdentifierExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityKeyIdentifierExtension.java
@@ -100,8 +100,8 @@ public class AuthorityKeyIdentifierExtension extends Extension {
     }
 
     /**
-     * The default constructor for this extension.  Null parameters make
-     * the element optional (not present).
+     * The default constructor for this extension. At least one parameter
+     * must be non null. Null parameters make the element optional (not present).
      *
      * @param kid the KeyIdentifier associated with this extension.
      * @param names the GeneralNames associated with this extension
@@ -111,7 +111,11 @@ public class AuthorityKeyIdentifierExtension extends Extension {
      */
     public AuthorityKeyIdentifierExtension(KeyIdentifier kid, GeneralNames names,
                                            SerialNumber sn)
-    throws IOException {
+            throws IOException {
+        if (kid == null && names == null && sn == null) {
+            throw new IllegalArgumentException(
+                    "AuthorityKeyIdentifierExtension cannot be empty");
+        }
         this.id = kid;
         this.names = names;
         this.serialNum = sn;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLDistributionPointsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLDistributionPointsExtension.java
@@ -106,7 +106,8 @@ public class CRLDistributionPointsExtension extends Extension {
      * DistributionPoint.
      *
      * @param isCritical the criticality setting.
-     * @param distributionPoints the list of distribution points
+     * @param distributionPoints the list of distribution points,
+     *                           cannot be null or empty.
      * @throws IOException on error
      */
     public CRLDistributionPointsExtension(boolean isCritical,
@@ -122,6 +123,11 @@ public class CRLDistributionPointsExtension extends Extension {
     protected CRLDistributionPointsExtension(ObjectIdentifier extensionId,
             boolean isCritical, List<DistributionPoint> distributionPoints,
             String extensionName) throws IOException {
+
+        if (distributionPoints == null || distributionPoints.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "distribution points cannot be null or empty");
+        }
 
         this.extensionId = extensionId;
         this.critical = isCritical;
@@ -146,7 +152,7 @@ public class CRLDistributionPointsExtension extends Extension {
      * Creates the extension (also called by the subclass).
      */
     protected CRLDistributionPointsExtension(ObjectIdentifier extensionId,
-                                             Boolean critical, Object value, String extensionName)
+            Boolean critical, Object value, String extensionName)
             throws IOException {
 
         this.extensionId = extensionId;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLNumberExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLNumberExtension.java
@@ -81,7 +81,7 @@ public class CRLNumberExtension extends Extension {
      * Create a CRLNumberExtension with the BigInteger value .
      * The criticality is set to false.
      *
-     * @param crlNum the value to be set for the extension.
+     * @param crlNum the value to be set for the extension, cannot be null
      */
     public CRLNumberExtension(BigInteger crlNum) throws IOException {
         this(PKIXExtensions.CRLNumber_Id, false, crlNum, NAME, LABEL);
@@ -91,8 +91,12 @@ public class CRLNumberExtension extends Extension {
      * Creates the extension (also called by the subclass).
      */
     protected CRLNumberExtension(ObjectIdentifier extensionId,
-                                 boolean isCritical, BigInteger crlNum, String extensionName,
-                                 String extensionLabel) throws IOException {
+            boolean isCritical, BigInteger crlNum, String extensionName,
+            String extensionLabel) throws IOException {
+
+        if (crlNum == null) {
+            throw new IllegalArgumentException("CRL number cannot be null");
+        }
 
         this.extensionId = extensionId;
         this.critical = isCritical;
@@ -119,8 +123,8 @@ public class CRLNumberExtension extends Extension {
      * Creates the extension (also called by the subclass).
      */
     protected CRLNumberExtension(ObjectIdentifier extensionId,
-                                 Boolean critical, Object value, String extensionName,
-                                 String extensionLabel) throws IOException {
+            Boolean critical, Object value, String extensionName,
+            String extensionLabel) throws IOException {
 
         this.extensionId = extensionId;
         this.critical = critical.booleanValue();

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLReasonCodeExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLReasonCodeExtension.java
@@ -70,10 +70,13 @@ public class CRLReasonCodeExtension extends Extension {
      * Create a CRLReasonCodeExtension with the passed in reason.
      *
      * @param critical true if the extension is to be treated as critical.
-     * @param reason the enumerated value for the reason code.
+     * @param reason the enumerated value for the reason code, must be positive.
      */
     public CRLReasonCodeExtension(boolean critical, int reason)
             throws IOException {
+        if (reason <= 0) {
+            throw new IllegalArgumentException("reason code must be positive");
+        }
         this.extensionId = PKIXExtensions.ReasonCode_Id;
         this.critical = critical;
         this.reasonCode = reason;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateIssuerExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateIssuerExtension.java
@@ -80,10 +80,13 @@ public class CertificateIssuerExtension extends Extension {
      * Create a CertificateIssuerExtension containing the specified issuer name.
      * Criticality is automatically set to true.
      *
-     * @param issuer the certificate issuer
+     * @param issuer the certificate issuer, cannot be null or empty.
      * @throws IOException on error
      */
     public CertificateIssuerExtension(GeneralNames issuer) throws IOException {
+        if (issuer == null || issuer.isEmpty()) {
+            throw new IllegalArgumentException("issuer cannot be null or empty");
+        }
         this.extensionId = PKIXExtensions.CertificateIssuer_Id;
         this.critical = true;
         this.names = issuer;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePoliciesExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePoliciesExtension.java
@@ -106,10 +106,14 @@ public class CertificatePoliciesExtension extends Extension {
      * a List of PolicyInformation with specified criticality.
      *
      * @param critical true if the extension is to be treated as critical.
-     * @param certPolicies the List of PolicyInformation.
+     * @param certPolicies the List of PolicyInformation, cannot be null or empty.
      */
     public CertificatePoliciesExtension(Boolean critical,
-                                        List<PolicyInformation> certPolicies) throws IOException {
+            List<PolicyInformation> certPolicies) throws IOException {
+        if (certPolicies == null || certPolicies.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "certificate policies cannot be null or empty");
+        }
         this.certPolicies = certPolicies;
         this.extensionId = PKIXExtensions.CertificatePolicies_Id;
         this.critical = critical.booleanValue();

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePolicyId.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePolicyId.java
@@ -26,6 +26,7 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -46,7 +47,7 @@ public class CertificatePolicyId {
      * @param id the ObjectIdentifier for the policy id.
      */
     public CertificatePolicyId(ObjectIdentifier id) {
-        this.id = id;
+        this.id = Objects.requireNonNull(id);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePolicyMap.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePolicyMap.java
@@ -26,6 +26,7 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -48,8 +49,8 @@ public class CertificatePolicyMap {
      */
     public CertificatePolicyMap(CertificatePolicyId issuer,
                                 CertificatePolicyId subject) {
-        this.issuerDomain = issuer;
-        this.subjectDomain = subject;
+        this.issuerDomain = Objects.requireNonNull(issuer);
+        this.subjectDomain = Objects.requireNonNull(subject);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/ExtendedKeyUsageExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/ExtendedKeyUsageExtension.java
@@ -118,10 +118,15 @@ public class ExtendedKeyUsageExtension extends Extension {
      * a Vector of KeyUsages with specified criticality.
      *
      * @param critical true if the extension is to be treated as critical.
-     * @param keyUsages the Vector of KeyUsages (ObjectIdentifiers)
+     * @param keyUsages the Vector of KeyUsages (ObjectIdentifiers),
+     *                  cannot be null or empty.
      */
     public ExtendedKeyUsageExtension(Boolean critical, Vector<ObjectIdentifier> keyUsages)
             throws IOException {
+        if (keyUsages == null || keyUsages.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "key usages cannot be null or empty");
+        }
         this.keyUsages = keyUsages;
         this.extensionId = PKIXExtensions.ExtendedKeyUsage_Id;
         this.critical = critical.booleanValue();

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/Extension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/Extension.java
@@ -28,6 +28,7 @@ package com.tencent.kona.sun.security.x509;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.Objects;
 
 import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerInputStream;
@@ -177,10 +178,10 @@ public class Extension implements java.security.cert.Extension, DerEncoder {
     @Override
     public void encode(DerOutputStream out) throws IOException {
 
-        if (extensionId == null)
-            throw new IOException("Null OID to encode for the extension!");
-        if (extensionValue == null)
-            throw new IOException("No value to encode for the extension!");
+        Objects.requireNonNull(extensionId,
+                "No OID to encode for the extension");
+        Objects.requireNonNull(extensionValue,
+                "No value to encode for the extension");
 
         DerOutputStream dos = new DerOutputStream();
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralSubtree.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralSubtree.java
@@ -26,6 +26,7 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.*;
+import java.util.Objects;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -62,7 +63,7 @@ public class GeneralSubtree {
      * @param max the maximum BaseDistance
      */
     public GeneralSubtree(GeneralName name, int min, int max) {
-        this.name = name;
+        this.name = Objects.requireNonNull(name);
         this.minimum = min;
         this.maximum = max;
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InhibitAnyPolicyExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InhibitAnyPolicyExtension.java
@@ -88,7 +88,7 @@ public class InhibitAnyPolicyExtension extends Extension {
      */
     public InhibitAnyPolicyExtension(int skipCerts) throws IOException {
         if (skipCerts < -1)
-            throw new IOException("Invalid value for skipCerts");
+            throw new IllegalArgumentException("Invalid value for skipCerts");
         if (skipCerts == -1)
             this.skipCerts = Integer.MAX_VALUE;
         else

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InvalidityDateExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InvalidityDateExtension.java
@@ -89,10 +89,13 @@ public class InvalidityDateExtension extends Extension {
      * Create a InvalidityDateExtension with the passed in date.
      *
      * @param critical true if the extension is to be treated as critical.
-     * @param date the invalidity date
+     * @param date the invalidity date, cannot be null.
      */
     public InvalidityDateExtension(boolean critical, Date date)
             throws IOException {
+        if (date == null) {
+            throw new IllegalArgumentException("date cannot be null");
+        }
         this.extensionId = PKIXExtensions.InvalidityDate_Id;
         this.critical = critical;
         this.date = date;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuerAlternativeNameExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuerAlternativeNameExtension.java
@@ -71,10 +71,7 @@ public class IssuerAlternativeNameExtension extends Extension {
      */
     public IssuerAlternativeNameExtension(GeneralNames names)
             throws IOException {
-        this.names = names;
-        this.extensionId = PKIXExtensions.IssuerAlternativeName_Id;
-        this.critical = false;
-        encodeThis();
+        this(false, names);
     }
 
     /**
@@ -82,24 +79,18 @@ public class IssuerAlternativeNameExtension extends Extension {
      * and GeneralNames.
      *
      * @param critical true if the extension is to be treated as critical.
-     * @param names the GeneralNames for the issuer.
+     * @param names the GeneralNames for the issuer, cannot be null or empty.
      * @exception IOException on error.
      */
     public IssuerAlternativeNameExtension(Boolean critical, GeneralNames names)
             throws IOException {
+        if (names == null || names.isEmpty()) {
+            throw new IllegalArgumentException("names cannot be null or empty");
+        }
         this.names = names;
         this.extensionId = PKIXExtensions.IssuerAlternativeName_Id;
         this.critical = critical.booleanValue();
         encodeThis();
-    }
-
-    /**
-     * Create a default IssuerAlternativeNameExtension.
-     */
-    public IssuerAlternativeNameExtension() {
-        extensionId = PKIXExtensions.IssuerAlternativeName_Id;
-        critical = false;
-        names = new GeneralNames();
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuingDistributionPointExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuingDistributionPointExtension.java
@@ -110,7 +110,8 @@ public class IssuingDistributionPointExtension extends Extension {
      *        issuer CRL entry extension.
      * @throws IllegalArgumentException if more than one of
      *        <code>hasOnlyUserCerts</code>, <code>hasOnlyCACerts</code>,
-     *        <code>hasOnlyAttributeCerts</code> is set to <code>true</code>.
+     *        <code>hasOnlyAttributeCerts</code> is set to <code>true</code>,
+     *        or all arguments are either <code>null</code> or <code>false</code>.
      * @throws IOException on encoding error.
      */
     public IssuingDistributionPointExtension(
@@ -119,6 +120,14 @@ public class IssuingDistributionPointExtension extends Extension {
             boolean hasOnlyAttributeCerts, boolean isIndirectCRL)
             throws IOException {
 
+        if (distributionPoint == null &&
+                revocationReasons == null &&
+                !hasOnlyUserCerts &&
+                !hasOnlyCACerts &&
+                !hasOnlyAttributeCerts &&
+                !isIndirectCRL) {
+            throw new IllegalArgumentException("elements cannot be empty");
+        }
         if ((hasOnlyUserCerts && (hasOnlyCACerts || hasOnlyAttributeCerts)) ||
                 (hasOnlyCACerts && (hasOnlyUserCerts || hasOnlyAttributeCerts)) ||
                 (hasOnlyAttributeCerts && (hasOnlyUserCerts || hasOnlyCACerts))) {

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/NameConstraintsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/NameConstraintsExtension.java
@@ -129,8 +129,8 @@ public class NameConstraintsExtension extends Extension
     }
 
     /**
-     * The default constructor for this class. Both parameters
-     * are optional and can be set to null.  The extension criticality
+     * The default constructor for this class. Both parameters are optional
+     * but at least one should be non null.  The extension criticality
      * is set to true.
      *
      * @param permitted the permitted GeneralSubtrees (null for optional).
@@ -139,6 +139,10 @@ public class NameConstraintsExtension extends Extension
     public NameConstraintsExtension(GeneralSubtrees permitted,
                                     GeneralSubtrees excluded)
             throws IOException {
+        if (permitted == null && excluded == null) {
+            throw new IllegalArgumentException(
+                    "permitted and excluded cannot both be null");
+        }
         this.permitted = permitted;
         this.excluded = excluded;
 
@@ -282,6 +286,8 @@ public class NameConstraintsExtension extends Extension
             return;
         }
 
+        boolean updated = false;
+
         /*
          * If excludedSubtrees is present in the certificate, set the
          * excluded subtrees state variable to the union of its previous
@@ -290,12 +296,15 @@ public class NameConstraintsExtension extends Extension
 
         GeneralSubtrees newExcluded = newConstraints.getExcludedSubtrees();
         if (excluded == null) {
-            excluded = (newExcluded != null) ?
-                    (GeneralSubtrees)newExcluded.clone() : null;
+            if (newExcluded != null) {
+                excluded = (GeneralSubtrees) newExcluded.clone();
+                updated = true;
+            }
         } else {
             if (newExcluded != null) {
                 // Merge new excluded with current excluded (union)
                 excluded.union(newExcluded);
+                updated = true;
             }
         }
 
@@ -307,8 +316,10 @@ public class NameConstraintsExtension extends Extension
 
         GeneralSubtrees newPermitted = newConstraints.getPermittedSubtrees();
         if (permitted == null) {
-            permitted = (newPermitted != null) ?
-                    (GeneralSubtrees)newPermitted.clone() : null;
+            if (newPermitted != null) {
+                permitted = (GeneralSubtrees) newPermitted.clone();
+                updated = true;
+            }
         } else {
             if (newPermitted != null) {
                 // Merge new permitted with current permitted (intersection)
@@ -321,6 +332,7 @@ public class NameConstraintsExtension extends Extension
                     } else {
                         excluded = (GeneralSubtrees)newExcluded.clone();
                     }
+                    updated = true;
                 }
             }
         }
@@ -331,12 +343,14 @@ public class NameConstraintsExtension extends Extension
         // less space.
         if (permitted != null) {
             permitted.reduce(excluded);
+            updated = true;
         }
 
         // The NameConstraints have been changed, so re-encode them.  Methods in
         // this class assume that the encodings have already been done.
-        encodeThis();
-
+        if (updated) {
+            encodeThis();
+        }
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyConstraintsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyConstraintsExtension.java
@@ -104,7 +104,7 @@ public class PolicyConstraintsExtension extends Extension {
     /**
      * Create a PolicyConstraintsExtension object with specified
      * criticality and both require explicit policy and inhibit
-     * policy mapping.
+     * policy mapping. At least one should be provided (not -1).
      *
      * @param critical true if the extension is to be treated as critical.
      * @param require require explicit policy (-1 for optional).
@@ -112,6 +112,10 @@ public class PolicyConstraintsExtension extends Extension {
      */
     public PolicyConstraintsExtension(Boolean critical, int require, int inhibit)
             throws IOException {
+        if (require == -1 && inhibit == -1) {
+            throw new IllegalArgumentException(
+                    "require and inhibit cannot both be -1");
+        }
         this.require = require;
         this.inhibit = inhibit;
         this.extensionId = PKIXExtensions.PolicyConstraints_Id;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyInformation.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyInformation.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.security.cert.PolicyQualifierInfo;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -88,7 +89,7 @@ public class PolicyInformation {
         }
         this.policyQualifiers =
                 new LinkedHashSet<>(policyQualifiers);
-        this.policyIdentifier = policyIdentifier;
+        this.policyIdentifier = Objects.requireNonNull(policyIdentifier);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyMappingsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyMappingsExtension.java
@@ -76,23 +76,17 @@ public class PolicyMappingsExtension extends Extension {
     /**
      * Create a PolicyMappings with the List of CertificatePolicyMap.
      *
-     * @param maps the List of CertificatePolicyMap.
+     * @param maps the List of CertificatePolicyMap, cannot be null or empty.
      */
     public PolicyMappingsExtension(List<CertificatePolicyMap> maps)
             throws IOException {
+        if (maps == null || maps.isEmpty()) {
+            throw new IllegalArgumentException("maps cannot be null or empty");
+        }
         this.maps = maps;
         this.extensionId = PKIXExtensions.PolicyMappings_Id;
         this.critical = true;
         encodeThis();
-    }
-
-    /**
-     * Create a default PolicyMappingsExtension.
-     */
-    public PolicyMappingsExtension() {
-        extensionId = PKIXExtensions.PolicyMappings_Id;
-        critical = true;
-        maps = Collections.emptyList();
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PrivateKeyUsageExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PrivateKeyUsageExtension.java
@@ -95,15 +95,20 @@ public class PrivateKeyUsageExtension extends Extension {
     }
 
     /**
-     * The default constructor for PrivateKeyUsageExtension.
+     * The default constructor for PrivateKeyUsageExtension. At least one
+     * of the arguments must be non null.
      *
      * @param notBefore the date/time before which the private key
-     *         should not be used.
+     *         should not be used
      * @param notAfter the date/time after which the private key
      *         should not be used.
      */
     public PrivateKeyUsageExtension(Date notBefore, Date notAfter)
             throws IOException {
+        if (notBefore == null && notAfter == null) {
+            throw new IllegalArgumentException(
+                    "notBefore and notAfter cannot both be null");
+        }
         this.notBefore = notBefore;
         this.notAfter = notAfter;
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectAlternativeNameExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectAlternativeNameExtension.java
@@ -85,25 +85,18 @@ public class SubjectAlternativeNameExtension extends Extension {
      * criticality and GeneralNames.
      *
      * @param critical true if the extension is to be treated as critical.
-     * @param names the GeneralNames for the subject.
+     * @param names the GeneralNames for the subject, cannot be null or empty.
      * @exception IOException on error.
      */
     public SubjectAlternativeNameExtension(Boolean critical, GeneralNames names)
             throws IOException {
+        if (names == null || names.isEmpty()) {
+            throw new IllegalArgumentException("names cannot be null or empty");
+        }
         this.names = names;
         this.extensionId = PKIXExtensions.SubjectAlternativeName_Id;
         this.critical = critical.booleanValue();
         encodeThis();
-    }
-
-    /**
-     * Create a default SubjectAlternativeNameExtension. The extension
-     * is marked non-critical.
-     */
-    public SubjectAlternativeNameExtension() {
-        extensionId = PKIXExtensions.SubjectAlternativeName_Id;
-        critical = false;
-        names = new GeneralNames();
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectInfoAccessExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectInfoAccessExtension.java
@@ -78,11 +78,16 @@ public class SubjectInfoAccessExtension extends Extension {
      * Create an SubjectInfoAccessExtension from a List of
      * AccessDescription; the criticality is set to false.
      *
-     * @param accessDescriptions the List of AccessDescription
+     * @param accessDescriptions the List of AccessDescription,
+     *                           cannot be null or empty.
      * @throws IOException on error
      */
     public SubjectInfoAccessExtension(
             List<AccessDescription> accessDescriptions) throws IOException {
+        if (accessDescriptions == null || accessDescriptions.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "accessDescriptions cannot be null or empty");
+        }
         this.extensionId = PKIXExtensions.SubjectInfoAccess_Id;
         this.critical = false;
         this.accessDescriptions = accessDescriptions;


### PR DESCRIPTION
This is a backport of [JDK-8296742]: Illegal X509 Extension should not be created.

This PR will resolve #92.

[JDK-8296742]:
<https://bugs.openjdk.org/browse/JDK-8296742>