### PR TITLE
TKSS-99: Backport JDK-8297065: DerOutputStream operations should not throw IOExceptions

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECPrivateKeyImpl.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECPrivateKeyImpl.java
@@ -104,44 +104,37 @@ public final class ECPrivateKeyImpl extends PKCS8Key implements ECPrivateKey {
     private void makeEncoding(byte[] s) throws InvalidKeyException {
         algid = new AlgorithmId
                 (AlgorithmId.EC_oid, ECParameters.getAlgorithmParameters(params));
-        try {
-            DerOutputStream out = new DerOutputStream();
-            out.putInteger(1); // version 1
-            byte[] privBytes = s.clone();
-            ArrayUtil.reverse(privBytes);
-            out.putOctetString(privBytes);
-            DerValue val =
-                    new DerValue(DerValue.tag_Sequence, out.toByteArray());
-            key = val.toByteArray();
-        } catch (IOException exc) {
-            // should never occur
-            throw new InvalidKeyException(exc);
-        }
+        DerOutputStream out = new DerOutputStream();
+        out.putInteger(1); // version 1
+        byte[] privBytes = s.clone();
+        ArrayUtil.reverse(privBytes);
+        out.putOctetString(privBytes);
+        Arrays.fill(privBytes, (byte) 0);
+        DerValue val = DerValue.wrap(DerValue.tag_Sequence, out);
+        key = val.toByteArray();
+        val.clear();
     }
 
     private void makeEncoding(BigInteger s) throws InvalidKeyException {
-        algid = new AlgorithmId
-                (AlgorithmId.EC_oid, ECParameters.getAlgorithmParameters(params));
-        try {
-            byte[] sArr = s.toByteArray();
-            // convert to fixed-length array
-            int numOctets = (params.getOrder().bitLength() + 7) / 8;
-            byte[] sOctets = new byte[numOctets];
-            int inPos = Math.max(sArr.length - sOctets.length, 0);
-            int outPos = Math.max(sOctets.length - sArr.length, 0);
-            int length = Math.min(sArr.length, sOctets.length);
-            System.arraycopy(sArr, inPos, sOctets, outPos, length);
+        algid = new AlgorithmId(AlgorithmId.EC_oid,
+                ECParameters.getAlgorithmParameters(params));
+        byte[] sArr = s.toByteArray();
+        // convert to fixed-length array
+        int numOctets = (params.getOrder().bitLength() + 7) / 8;
+        byte[] sOctets = new byte[numOctets];
+        int inPos = Math.max(sArr.length - sOctets.length, 0);
+        int outPos = Math.max(sOctets.length - sArr.length, 0);
+        int length = Math.min(sArr.length, sOctets.length);
+        System.arraycopy(sArr, inPos, sOctets, outPos, length);
+        Arrays.fill(sArr, (byte) 0);
 
-            DerOutputStream out = new DerOutputStream();
-            out.putInteger(1); // version 1
-            out.putOctetString(sOctets);
-            DerValue val =
-                    new DerValue(DerValue.tag_Sequence, out.toByteArray());
-            key = val.toByteArray();
-        } catch (IOException exc) {
-            // should never occur
-            throw new InvalidKeyException(exc);
-        }
+        DerOutputStream out = new DerOutputStream();
+        out.putInteger(1); // version 1
+        out.putOctetString(sOctets);
+        Arrays.fill(sOctets, (byte) 0);
+        DerValue val = DerValue.wrap(DerValue.tag_Sequence, out);
+        key = val.toByteArray();
+        val.clear();
     }
 
     // see JCA doc

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS8Key.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS8Key.java
@@ -199,8 +199,7 @@ public class PKCS8Key implements PrivateKey {
      * or {@code null} if an encoding error occurs.
      */
     public byte[] getEncoded() {
-        byte[] b = getEncodedInternal();
-        return (b == null) ? null : b.clone();
+        return getEncodedInternal().clone();
     }
 
     /**
@@ -218,17 +217,13 @@ public class PKCS8Key implements PrivateKey {
      */
     private synchronized byte[] getEncodedInternal() {
         if (encodedKey == null) {
-            try {
-                DerOutputStream tmp = new DerOutputStream();
-                tmp.putInteger(V1);
-                algid.encode(tmp);
-                tmp.putOctetString(key);
-                DerValue out = DerValue.wrap(DerValue.tag_Sequence, tmp);
-                encodedKey = out.toByteArray();
-                out.clear();
-            } catch (IOException e) {
-                // encodedKey is still null
-            }
+            DerOutputStream tmp = new DerOutputStream();
+            tmp.putInteger(V1);
+            algid.encode(tmp);
+            tmp.putOctetString(key);
+            DerValue out = DerValue.wrap(DerValue.tag_Sequence, tmp);
+            encodedKey = out.toByteArray();
+            out.clear();
         }
         return encodedKey;
     }

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAPrivateCrtKeyImpl.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAPrivateCrtKeyImpl.java
@@ -197,49 +197,44 @@ public final class RSAPrivateCrtKeyImpl
         this.type = type;
         this.keyParams = keyParams;
 
-        try {
-            byte[][] nbytes = new byte[8][];
-            nbytes[0] = n.toByteArray();
-            nbytes[1] = e.toByteArray();
-            nbytes[2] = d.toByteArray();
-            nbytes[3] = p.toByteArray();
-            nbytes[4] = q.toByteArray();
-            nbytes[5] = pe.toByteArray();
-            nbytes[6] = qe.toByteArray();
-            nbytes[7] = coeff.toByteArray();
+        byte[][] nbytes = new byte[8][];
+        nbytes[0] = n.toByteArray();
+        nbytes[1] = e.toByteArray();
+        nbytes[2] = d.toByteArray();
+        nbytes[3] = p.toByteArray();
+        nbytes[4] = q.toByteArray();
+        nbytes[5] = pe.toByteArray();
+        nbytes[6] = qe.toByteArray();
+        nbytes[7] = coeff.toByteArray();
 
-            // Initiate with a big enough size so there's no need to
-            // reallocate memory later and thus can be cleaned up
-            // reliably.
-            DerOutputStream out = new DerOutputStream(
-                    nbytes[0].length + nbytes[1].length +
-                    nbytes[2].length + nbytes[3].length +
-                    nbytes[4].length + nbytes[5].length +
-                    nbytes[6].length + nbytes[7].length +
-                    100); // Enough for version(3) and 8 tag+length(3 or 4)
-            out.putInteger(0); // version must be 0
-            out.putInteger(nbytes[0]);
-            out.putInteger(nbytes[1]);
-            out.putInteger(nbytes[2]);
-            out.putInteger(nbytes[3]);
-            out.putInteger(nbytes[4]);
-            out.putInteger(nbytes[5]);
-            out.putInteger(nbytes[6]);
-            out.putInteger(nbytes[7]);
-            // Private values from [2] on.
-            Arrays.fill(nbytes[2], (byte)0);
-            Arrays.fill(nbytes[3], (byte)0);
-            Arrays.fill(nbytes[4], (byte)0);
-            Arrays.fill(nbytes[5], (byte)0);
-            Arrays.fill(nbytes[6], (byte)0);
-            Arrays.fill(nbytes[7], (byte)0);
-            DerValue val = DerValue.wrap(DerValue.tag_Sequence, out);
-            key = val.toByteArray();
-            val.clear();
-        } catch (IOException exc) {
-            // should never occur
-            throw new InvalidKeyException(exc);
-        }
+        // Initiate with a big enough size so there's no need to
+        // reallocate memory later and thus can be cleaned up
+        // reliably.
+        DerOutputStream out = new DerOutputStream(
+                nbytes[0].length + nbytes[1].length +
+                nbytes[2].length + nbytes[3].length +
+                nbytes[4].length + nbytes[5].length +
+                nbytes[6].length + nbytes[7].length +
+                100); // Enough for version(3) and 8 tag+length(3 or 4)
+        out.putInteger(0); // version must be 0
+        out.putInteger(nbytes[0]);
+        out.putInteger(nbytes[1]);
+        out.putInteger(nbytes[2]);
+        out.putInteger(nbytes[3]);
+        out.putInteger(nbytes[4]);
+        out.putInteger(nbytes[5]);
+        out.putInteger(nbytes[6]);
+        out.putInteger(nbytes[7]);
+        // Private values from [2] on.
+        Arrays.fill(nbytes[2], (byte)0);
+        Arrays.fill(nbytes[3], (byte)0);
+        Arrays.fill(nbytes[4], (byte)0);
+        Arrays.fill(nbytes[5], (byte)0);
+        Arrays.fill(nbytes[6], (byte)0);
+        Arrays.fill(nbytes[7], (byte)0);
+        DerValue val = DerValue.wrap(DerValue.tag_Sequence, out);
+        key = val.toByteArray();
+        val.clear();
     }
 
     // see JCA doc

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAPrivateKeyImpl.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAPrivateKeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,31 +88,26 @@ public final class RSAPrivateKeyImpl extends PKCS8Key implements RSAPrivateKey {
         this.type = type;
         this.keyParams = keyParams;
 
-        try {
-            // generate the key encoding
-            byte[] nbytes = n.toByteArray();
-            byte[] dbytes = d.toByteArray();
-            DerOutputStream out = new DerOutputStream(
-                    nbytes.length + dbytes.length + 50);
-                    // Enough for 7 zeroes (21) and 2 tag+length(4)
-            out.putInteger(0); // version must be 0
-            out.putInteger(nbytes);
-            Arrays.fill(nbytes, (byte)0);
-            out.putInteger(0);
-            out.putInteger(dbytes);
-            Arrays.fill(dbytes, (byte)0);
-            out.putInteger(0);
-            out.putInteger(0);
-            out.putInteger(0);
-            out.putInteger(0);
-            out.putInteger(0);
-            DerValue val = DerValue.wrap(DerValue.tag_Sequence, out);
-            key = val.toByteArray();
-            val.clear();
-        } catch (IOException exc) {
-            // should never occur
-            throw new InvalidKeyException(exc);
-        }
+        // generate the key encoding
+        byte[] nbytes = n.toByteArray();
+        byte[] dbytes = d.toByteArray();
+        DerOutputStream out = new DerOutputStream(
+                nbytes.length + dbytes.length + 50);
+                // Enough for 7 zeroes (21) and 2 tag+length(4)
+        out.putInteger(0); // version must be 0
+        out.putInteger(nbytes);
+        Arrays.fill(nbytes, (byte)0);
+        out.putInteger(0);
+        out.putInteger(dbytes);
+        Arrays.fill(dbytes, (byte)0);
+        out.putInteger(0);
+        out.putInteger(0);
+        out.putInteger(0);
+        out.putInteger(0);
+        out.putInteger(0);
+        DerValue val = DerValue.wrap(DerValue.tag_Sequence, out);
+        key = val.toByteArray();
+        val.clear();
     }
 
     // see JCA doc

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAPublicKeyImpl.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAPublicKeyImpl.java
@@ -126,19 +126,14 @@ public final class RSAPublicKeyImpl extends X509Key implements RSAPublicKey {
         this.type = type;
         this.keyParams = keyParams;
 
-        try {
-            // generate the key encoding
-            DerOutputStream out = new DerOutputStream();
-            out.putInteger(n);
-            out.putInteger(e);
-            byte[] keyArray =
+        // generate the key encoding
+        DerOutputStream out = new DerOutputStream();
+        out.putInteger(n);
+        out.putInteger(e);
+        byte[] keyArray =
                 new DerValue(DerValue.tag_Sequence,
-                             out.toByteArray()).toByteArray();
-            setKey(new BitArray(keyArray.length*8, keyArray));
-        } catch (IOException exc) {
-            // should never occur
-            throw new InvalidKeyException(exc);
-        }
+                         out.toByteArray()).toByteArray();
+        setKey(new BitArray(keyArray.length*8, keyArray));
     }
 
     /**

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSASignature.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSASignature.java
@@ -194,8 +194,6 @@ abstract class RSASignature extends SignatureSpi {
             return RSACore.rsa(padded, privateKey, true);
         } catch (GeneralSecurityException e) {
             throw new SignatureException("Could not sign data", e);
-        } catch (IOException e) {
-            throw new SignatureException("Could not encode data", e);
         }
     }
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAUtil.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAUtil.java
@@ -172,8 +172,7 @@ public class RSAUtil {
      * Encode the digest, return the to-be-signed data.
      * Also used by the PKCS#11 provider.
      */
-    public static byte[] encodeSignature(ObjectIdentifier oid, byte[] digest)
-            throws IOException {
+    public static byte[] encodeSignature(ObjectIdentifier oid, byte[] digest) {
         DerOutputStream out = new DerOutputStream();
         new AlgorithmId(oid).encode(out);
         out.putOctetString(digest);

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerEncoder.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerEncoder.java
@@ -25,8 +25,6 @@
 
 package com.tencent.kona.sun.security.util;
 
-import java.io.IOException;
-
 /**
  * Interface to an object that knows how to write its own DER
  * encoding to an output stream.
@@ -40,7 +38,6 @@ public interface DerEncoder {
      *
      * @param out  the stream on which the DER encoding is written.
      */
-    void encode(DerOutputStream out)
-        throws IOException;
+    void encode(DerOutputStream out);
 
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerOutputStream.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerOutputStream.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.util;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
@@ -55,8 +54,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * @author Amit Kapoor
  * @author Hemma Prafullchandra
  */
-public class DerOutputStream
-extends ByteArrayOutputStream implements DerEncoder {
+public final class DerOutputStream
+        extends ByteArrayOutputStream implements DerEncoder {
     /**
      * Construct a DER output stream.
      *
@@ -78,7 +77,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      *          <em>DerValue.tag_Sequence</em>
      * @param buf buffered data, which must be DER-encoded
      */
-    public DerOutputStream write(byte tag, byte[] buf) throws IOException {
+    public DerOutputStream write(byte tag, byte[] buf) {
         write(tag);
         putLength(buf.length);
         write(buf, 0, buf.length);
@@ -94,7 +93,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      *          <em>DerValue.tag_Sequence</em>
      * @param out buffered data
      */
-    public DerOutputStream write(byte tag, DerOutputStream out) throws IOException {
+    public DerOutputStream write(byte tag, DerOutputStream out) {
         write(tag);
         putLength(out.count);
         write(out.buf, 0, out.count);
@@ -118,8 +117,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * explicit tagging the form is always constructed.
      * @param value original value being implicitly tagged
      */
-    public DerOutputStream writeImplicit(byte tag, DerOutputStream value)
-    throws IOException {
+    public DerOutputStream writeImplicit(byte tag, DerOutputStream value) {
         write(tag);
         write(value.buf, 1, value.count-1);
         return this;
@@ -128,7 +126,7 @@ extends ByteArrayOutputStream implements DerEncoder {
     /**
      * Marshals pre-encoded DER value onto the output stream.
      */
-    public DerOutputStream putDerValue(DerValue val) throws IOException {
+    public DerOutputStream putDerValue(DerValue val) {
         val.encode(this);
         return this;
     }
@@ -144,7 +142,7 @@ extends ByteArrayOutputStream implements DerEncoder {
     /**
      * Marshals a DER boolean on the output stream.
      */
-    public DerOutputStream putBoolean(boolean val) throws IOException {
+    public DerOutputStream putBoolean(boolean val) {
         write(DerValue.tag_Boolean);
         putLength(1);
         if (val) {
@@ -159,7 +157,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * Marshals a DER enumerated on the output stream.
      * @param i the enumerated value.
      */
-    public DerOutputStream putEnumerated(int i) throws IOException {
+    public DerOutputStream putEnumerated(int i) {
         write(DerValue.tag_Enumerated);
         putIntegerContents(i);
         return this;
@@ -170,7 +168,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param i the integer in the form of a BigInteger.
      */
-    public DerOutputStream putInteger(BigInteger i) throws IOException {
+    public DerOutputStream putInteger(BigInteger i) {
         write(DerValue.tag_Integer);
         byte[]    buf = i.toByteArray(); // least number  of bytes
         putLength(buf.length);
@@ -183,7 +181,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param buf the integer in bytes, equivalent to BigInteger::toByteArray.
      */
-    public DerOutputStream putInteger(byte[] buf) throws IOException {
+    public DerOutputStream putInteger(byte[] buf) {
         write(DerValue.tag_Integer);
         putLength(buf.length);
         write(buf, 0, buf.length);
@@ -194,7 +192,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * Marshals a DER integer on the output stream.
      * @param i the integer in the form of an Integer.
      */
-    public DerOutputStream putInteger(Integer i) throws IOException {
+    public DerOutputStream putInteger(Integer i) {
         putInteger(i.intValue());
         return this;
     }
@@ -203,13 +201,13 @@ extends ByteArrayOutputStream implements DerEncoder {
      * Marshals a DER integer on the output stream.
      * @param i the integer.
      */
-    public DerOutputStream putInteger(int i) throws IOException {
+    public DerOutputStream putInteger(int i) {
         write(DerValue.tag_Integer);
         putIntegerContents(i);
         return this;
     }
 
-    private void putIntegerContents(int i) throws IOException {
+    private void putIntegerContents(int i) {
 
         byte[] bytes = new byte[4];
         int start = 0;
@@ -259,11 +257,11 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param bits the bit string, MSB first
      */
-    public DerOutputStream putBitString(byte[] bits) throws IOException {
+    public DerOutputStream putBitString(byte[] bits) {
         write(DerValue.tag_BitString);
         putLength(bits.length + 1);
         write(0);               // all of last octet is used
-        write(bits);
+        write(bits, 0, bits.length);
         return this;
     }
 
@@ -273,13 +271,13 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param ba the bit string, MSB first
      */
-    public DerOutputStream putUnalignedBitString(BitArray ba) throws IOException {
+    public DerOutputStream putUnalignedBitString(BitArray ba) {
         byte[] bits = ba.toByteArray();
 
         write(DerValue.tag_BitString);
         putLength(bits.length + 1);
         write(bits.length*8 - ba.length()); // excess bits in last octet
-        write(bits);
+        write(bits, 0, bits.length);
         return this;
     }
 
@@ -289,7 +287,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param ba the bit string, MSB first
      */
-    public DerOutputStream putTruncatedUnalignedBitString(BitArray ba) throws IOException {
+    public DerOutputStream putTruncatedUnalignedBitString(BitArray ba) {
         putUnalignedBitString(ba.truncate());
         return this;
     }
@@ -299,7 +297,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * @param octets the octet string
      */
-    public DerOutputStream putOctetString(byte[] octets) throws IOException {
+    public DerOutputStream putOctetString(byte[] octets) {
         write(DerValue.tag_OctetString, octets);
         return this;
     }
@@ -308,7 +306,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * Marshals a DER "null" value on the output stream.  These are
      * often used to indicate optional values which have been omitted.
      */
-    public DerOutputStream putNull() throws IOException {
+    public DerOutputStream putNull() {
         write(DerValue.tag_Null);
         putLength(0);
         return this;
@@ -318,7 +316,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * Marshals an object identifier (OID) on the output stream.
      * Corresponds to the ASN.1 "OBJECT IDENTIFIER" construct.
      */
-    public DerOutputStream putOID(ObjectIdentifier oid) throws IOException {
+    public DerOutputStream putOID(ObjectIdentifier oid) {
         oid.encode(this);
         return this;
     }
@@ -328,7 +326,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * the ASN.1 "SEQUENCE" (zero to N values) and "SEQUENCE OF"
      * (one to N values) constructs.
      */
-    public DerOutputStream putSequence(DerValue[] seq) throws IOException {
+    public DerOutputStream putSequence(DerValue[] seq) {
         DerOutputStream bytes = new DerOutputStream();
         int i;
 
@@ -345,7 +343,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      * For DER encoding, use orderedPutSet() or orderedPutSetOf().
      */
-    public DerOutputStream putSet(DerValue[] set) throws IOException {
+    public DerOutputStream putSet(DerValue[] set) {
         DerOutputStream bytes = new DerOutputStream();
         int i;
 
@@ -365,7 +363,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * This method supports the ASN.1 "SET OF" construct, but not
      * "SET", which uses a different order.
      */
-    public DerOutputStream putOrderedSetOf(byte tag, DerEncoder[] set) throws IOException {
+    public DerOutputStream putOrderedSetOf(byte tag, DerEncoder[] set) {
         return putOrderedSet(tag, set, lexOrder);
     }
 
@@ -379,7 +377,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * This method supports the ASN.1 "SET" construct, but not
      * "SET OF", which uses a different order.
      */
-    public DerOutputStream putOrderedSet(byte tag, DerEncoder[] set) throws IOException {
+    public DerOutputStream putOrderedSet(byte tag, DerEncoder[] set) {
         return putOrderedSet(tag, set, tagOrder);
     }
 
@@ -402,7 +400,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * @param order the order to use when sorting encodings of components.
      */
     private DerOutputStream putOrderedSet(byte tag, DerEncoder[] set,
-                               Comparator<byte[]> order) throws IOException {
+                               Comparator<byte[]> order) {
         DerOutputStream[] streams = new DerOutputStream[set.length];
 
         for (int i = 0; i < set.length; i++) {
@@ -419,7 +417,7 @@ extends ByteArrayOutputStream implements DerEncoder {
 
         DerOutputStream bytes = new DerOutputStream();
         for (int i = 0; i < streams.length; i++) {
-            bytes.write(bufs[i]);
+            bytes.write(bufs[i], 0, bufs[i].length);
         }
         return write(tag, bytes);
     }
@@ -427,21 +425,21 @@ extends ByteArrayOutputStream implements DerEncoder {
     /**
      * Marshals a string as a DER encoded UTF8String.
      */
-    public DerOutputStream putUTF8String(String s) throws IOException {
+    public DerOutputStream putUTF8String(String s) {
         return writeString(s, DerValue.tag_UTF8String, UTF_8);
     }
 
     /**
      * Marshals a string as a DER encoded PrintableString.
      */
-    public DerOutputStream putPrintableString(String s) throws IOException {
+    public DerOutputStream putPrintableString(String s) {
         return writeString(s, DerValue.tag_PrintableString, US_ASCII);
     }
 
     /**
      * Marshals a string as a DER encoded T61String.
      */
-    public DerOutputStream putT61String(String s) throws IOException {
+    public DerOutputStream putT61String(String s) {
         /*
          * Works for characters that are defined in both ASCII and
          * T61.
@@ -452,21 +450,21 @@ extends ByteArrayOutputStream implements DerEncoder {
     /**
      * Marshals a string as a DER encoded IA5String.
      */
-    public DerOutputStream putIA5String(String s) throws IOException {
+    public DerOutputStream putIA5String(String s) {
         return writeString(s, DerValue.tag_IA5String, US_ASCII);
     }
 
     /**
      * Marshals a string as a DER encoded BMPString.
      */
-    public DerOutputStream putBMPString(String s) throws IOException {
+    public DerOutputStream putBMPString(String s) {
         return writeString(s, DerValue.tag_BMPString, UTF_16BE);
     }
 
     /**
      * Marshals a string as a DER encoded GeneralString.
      */
-    public DerOutputStream putGeneralString(String s) throws IOException {
+    public DerOutputStream putGeneralString(String s) {
         return writeString(s, DerValue.tag_GeneralString, US_ASCII);
     }
 
@@ -478,13 +476,12 @@ extends ByteArrayOutputStream implements DerEncoder {
      * @param charset the charset that should be used corresponding to
      * the above tag.
      */
-    private DerOutputStream writeString(String s, byte stringTag, Charset charset)
-        throws IOException {
+    private DerOutputStream writeString(String s, byte stringTag, Charset charset) {
 
         byte[] data = s.getBytes(charset);
         write(stringTag);
         putLength(data.length);
-        write(data);
+        write(data, 0, data.length);
         return this;
     }
 
@@ -494,7 +491,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * <P>YYMMDDhhmmss{Z|+hhmm|-hhmm} ... emits only using Zulu time
      * and with seconds (even if seconds=0) as per RFC 5280.
      */
-    public DerOutputStream putUTCTime(Date d) throws IOException {
+    public DerOutputStream putUTCTime(Date d) {
         return putTime(d, DerValue.tag_UtcTime);
     }
 
@@ -504,7 +501,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * <P>YYYYMMDDhhmmss{Z|+hhmm|-hhmm} ... emits only using Zulu time
      * and with seconds (even if seconds=0) as per RFC 5280.
      */
-    public DerOutputStream putGeneralizedTime(Date d) throws IOException {
+    public DerOutputStream putGeneralizedTime(Date d) {
         return putTime(d, DerValue.tag_GeneralizedTime);
     }
 
@@ -515,7 +512,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      * @param d the date to be marshalled
      * @param tag the tag for UTC Time or Generalized Time
      */
-    private DerOutputStream putTime(Date d, byte tag) throws IOException {
+    private DerOutputStream putTime(Date d, byte tag) {
 
         /*
          * Format the date.
@@ -541,7 +538,7 @@ extends ByteArrayOutputStream implements DerEncoder {
 
         write(tag);
         putLength(time.length);
-        write(time);
+        write(time, 0, time.length);
         return this;
     }
 
@@ -549,9 +546,8 @@ extends ByteArrayOutputStream implements DerEncoder {
      * Put the encoding of the length in the stream.
      *
      * @param len the length of the attribute.
-     * @exception IOException on writing errors.
      */
-    public void putLength(int len) throws IOException {
+    public void putLength(int len) {
         if (len < 128) {
             write((byte)len);
 
@@ -582,19 +578,17 @@ extends ByteArrayOutputStream implements DerEncoder {
     /**
      *  Write the current contents of this <code>DerOutputStream</code>
      *  to an <code>OutputStream</code>.
-     *
-     *  @exception IOException on output error.
      */
-    public void encode(DerOutputStream out) throws IOException {
-        out.write(toByteArray());
+    public void encode(DerOutputStream out) {
+        byte[] bytes = toByteArray();
+        out.write(bytes, 0, bytes.length);
     }
 
     /**
      * Write a DerEncoder onto the output stream.
      * @param encoder the DerEncoder
-     * @throws IOException on output error
      */
-    public DerOutputStream write(DerEncoder encoder) throws IOException {
+    public DerOutputStream write(DerEncoder encoder) {
         encoder.encode(this);
         return this;
     }

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerValue.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerValue.java
@@ -513,7 +513,7 @@ public class DerValue {
     /**
      * Encode an ASN1/DER encoded datum onto a DER output stream.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         out.write(tag);
         out.putLength(end - start);
         out.write(buffer, start, end - start);
@@ -807,7 +807,7 @@ public class DerValue {
      * Helper routine to return all the bytes contained in the
      * DerInputStream associated with this object.
      */
-    public byte[] getDataBytes() throws IOException {
+    public byte[] getDataBytes() {
         data.pos = data.end; // Compatibility. Reach end.
         return Arrays.copyOfRange(buffer, start, end);
     }
@@ -1187,7 +1187,7 @@ public class DerValue {
      *
      * @return DER-encoded value, including tag and length.
      */
-    public byte[] toByteArray() throws IOException {
+    public byte[] toByteArray() {
         data.pos = data.start; // Compatibility. At head.
         // Minimize content duplication by writing out tag and length only
         DerOutputStream out = new DerOutputStream();

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/NamedCurve.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/NamedCurve.java
@@ -25,7 +25,6 @@
 
 package com.tencent.kona.sun.security.util;
 
-import java.io.IOException;
 import java.math.BigInteger;
 
 import java.security.spec.*;
@@ -58,11 +57,7 @@ public final class NamedCurve extends ECParameterSpec {
         this.oid = ko.value();
 
         DerOutputStream out = new DerOutputStream();
-        try {
-            out.putOID(Oid.of(ko));
-        } catch (IOException e) {
-            throw new RuntimeException("Internal error", e);
-        }
+        out.putOID(Oid.of(ko));
         encoded = out.toByteArray();
     }
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/ObjectIdentifier.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/ObjectIdentifier.java
@@ -322,7 +322,7 @@ public final class ObjectIdentifier implements Serializable {
     /*
      * n.b. the only public interface is DerOutputStream.putOID()
      */
-    void encode(DerOutputStream out) throws IOException {
+    void encode(DerOutputStream out) {
         out.write (DerValue.tag_ObjectId, encoding);
     }
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/AlgorithmId.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/AlgorithmId.java
@@ -162,7 +162,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * @exception IOException on encoding error.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         DerOutputStream bytes = new DerOutputStream();
 
         bytes.putOID(algid);
@@ -223,7 +223,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
                 bytes.putNull();
             }
         } else {
-            bytes.write(encodedParams);
+            bytes.write(encodedParams, 0, encodedParams.length);
         }
         out.write(DerValue.tag_Sequence, bytes);
     }
@@ -232,7 +232,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
     /**
      * Returns the DER-encoded X.509 AlgorithmId as a byte array.
      */
-    public final byte[] encode() throws IOException {
+    public final byte[] encode() {
         DerOutputStream out = new DerOutputStream();
         encode(out);
         return out.toByteArray();

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/X509Key.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/X509Key.java
@@ -39,6 +39,7 @@ import java.security.spec.X509EncodedKeySpec;
 
 import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.sun.security.util.BitArray;
+import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
 import com.tencent.kona.sun.security.util.HexDumpEncoder;
@@ -58,7 +59,7 @@ import com.tencent.kona.sun.security.util.HexDumpEncoder;
  *
  * @author David Brownell
  */
-public class X509Key implements PublicKey {
+public class X509Key implements PublicKey, DerEncoder {
 
     /** use serialVersionUID from JDK 1.1. for interoperability */
     private static final long serialVersionUID = -5359250853002055002L;
@@ -102,8 +103,7 @@ public class X509Key implements PublicKey {
      * data is stored and transmitted losslessly, but no knowledge
      * about this particular algorithm is available.
      */
-    private X509Key(AlgorithmId algid, BitArray key)
-            throws InvalidKeyException {
+    private X509Key(AlgorithmId algid, BitArray key) {
         this.algid = algid;
         setKey(key);
         encode();
@@ -192,10 +192,9 @@ public class X509Key implements PublicKey {
      * values using the X509Key member functions, such as <code>parse</code>
      * and <code>decode</code>.
      *
-     * @exception IOException on parsing errors.
      * @exception InvalidKeyException on invalid key encodings.
      */
-    protected void parseKeyBits() throws IOException, InvalidKeyException {
+    protected void parseKeyBits() throws InvalidKeyException {
         encode();
     }
 
@@ -289,11 +288,8 @@ public class X509Key implements PublicKey {
 
     /**
      * Encode SubjectPublicKeyInfo sequence on the DER output stream.
-     *
-     * @exception IOException on encoding errors.
      */
-    public final void encode(DerOutputStream out) throws IOException
-    {
+    public final void encode(DerOutputStream out) {
         encode(out, this.algid, getKey());
     }
 
@@ -301,26 +297,15 @@ public class X509Key implements PublicKey {
      * Returns the DER-encoded form of the key as a byte array.
      */
     public byte[] getEncoded() {
-        try {
-            return getEncodedInternal().clone();
-        } catch (InvalidKeyException e) {
-            // XXX
-        }
-        return null;
+        return getEncodedInternal().clone();
     }
 
-    public byte[] getEncodedInternal() throws InvalidKeyException {
+    public byte[] getEncodedInternal() {
         byte[] encoded = encodedKey;
         if (encoded == null) {
-            try {
-                DerOutputStream out = new DerOutputStream();
-                encode(out);
-                encoded = out.toByteArray();
-            } catch (IOException e) {
-                throw new InvalidKeyException("IOException : " +
-                        e.getMessage());
-            }
-            encodedKey = encoded;
+            DerOutputStream out = new DerOutputStream();
+            encode(out);
+            encodedKey = encoded = out.toByteArray();
         }
         return encoded;
     }
@@ -334,10 +319,8 @@ public class X509Key implements PublicKey {
 
     /**
      * Returns the DER-encoded form of the key as a byte array.
-     *
-     * @exception InvalidKeyException on encoding errors.
      */
-    public byte[] encode() throws InvalidKeyException {
+    public byte[] encode() {
         return getEncodedInternal().clone();
     }
 
@@ -428,18 +411,14 @@ public class X509Key implements PublicKey {
         if (!(obj instanceof Key)) {
             return false;
         }
-        try {
-            byte[] thisEncoded = this.getEncodedInternal();
-            byte[] otherEncoded;
-            if (obj instanceof X509Key) {
-                otherEncoded = ((X509Key)obj).getEncodedInternal();
-            } else {
-                otherEncoded = ((Key)obj).getEncoded();
-            }
-            return Arrays.equals(thisEncoded, otherEncoded);
-        } catch (InvalidKeyException e) {
-            return false;
+        byte[] thisEncoded = this.getEncodedInternal();
+        byte[] otherEncoded;
+        if (obj instanceof X509Key) {
+            otherEncoded = ((X509Key) obj).getEncodedInternal();
+        } else {
+            otherEncoded = ((Key) obj).getEncoded();
         }
+        return Arrays.equals(thisEncoded, otherEncoded);
     }
 
     /**
@@ -447,24 +426,18 @@ public class X509Key implements PublicKey {
      * which are equal will also have the same hashcode.
      */
     public int hashCode() {
-        try {
-            byte[] b1 = getEncodedInternal();
-            int r = b1.length;
-            for (int i = 0; i < b1.length; i++) {
-                r += (b1[i] & 0xff) * 37;
-            }
-            return r;
-        } catch (InvalidKeyException e) {
-            // should not happen
-            return 0;
+        byte[] b1 = getEncodedInternal();
+        int r = b1.length;
+        for (int i = 0; i < b1.length; i++) {
+            r += (b1[i] & 0xff) * 37;
         }
+        return r;
     }
 
     /*
      * Produce SubjectPublicKey encoding from algorithm id and key material.
      */
-    static void encode(DerOutputStream out, AlgorithmId algid, BitArray key)
-            throws IOException {
+    static void encode(DerOutputStream out, AlgorithmId algid, BitArray key) {
         DerOutputStream tmp = new DerOutputStream();
         algid.encode(tmp);
         tmp.putUnalignedBitString(key);

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/ContentInfo.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/ContentInfo.java
@@ -27,6 +27,7 @@ package com.tencent.kona.sun.security.pkcs;
 
 import java.io.*;
 
+import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerInputStream;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -40,7 +41,7 @@ import com.tencent.kona.sun.security.util.Oid;
  * @author Benjamin Renaud
  */
 
-public class ContentInfo {
+public class ContentInfo implements DerEncoder {
 
     // pkcs7 pre-defined content types
     public static final ObjectIdentifier PKCS7_OID =
@@ -171,7 +172,8 @@ public class ContentInfo {
         throw new IOException("content type is not DATA: " + contentType);
     }
 
-    public void encode(DerOutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) {
         DerOutputStream contentDerCode;
         DerOutputStream seq;
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/EncryptedPrivateKeyInfo.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/EncryptedPrivateKeyInfo.java
@@ -116,9 +116,7 @@ public class EncryptedPrivateKeyInfo {
     /**
      * Returns the ASN.1 encoding of this class.
      */
-    public byte[] getEncoded()
-            throws IOException
-    {
+    public byte[] getEncoded() {
         if (this.encoded != null) return this.encoded.clone();
 
         DerOutputStream out = new DerOutputStream();
@@ -142,20 +140,16 @@ public class EncryptedPrivateKeyInfo {
             return true;
         if (!(other instanceof EncryptedPrivateKeyInfo))
             return false;
-        try {
-            byte[] thisEncrInfo = this.getEncoded();
-            byte[] otherEncrInfo
-                    = ((EncryptedPrivateKeyInfo)other).getEncoded();
+        byte[] thisEncrInfo = this.getEncoded();
+        byte[] otherEncrInfo
+                = ((EncryptedPrivateKeyInfo) other).getEncoded();
 
-            if (thisEncrInfo.length != otherEncrInfo.length)
-                return false;
-            for (int i = 0; i < thisEncrInfo.length; i++)
-                if (thisEncrInfo[i] != otherEncrInfo[i])
-                    return false;
-            return true;
-        } catch (IOException e) {
+        if (thisEncrInfo.length != otherEncrInfo.length)
             return false;
-        }
+        for (int i = 0; i < thisEncrInfo.length; i++)
+            if (thisEncrInfo[i] != otherEncrInfo[i])
+                return false;
+        return true;
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS7.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS7.java
@@ -473,18 +473,6 @@ public class PKCS7 {
     }
 
     /**
-     * Encodes the signed data to an output stream.
-     *
-     * @param out the output stream to write the encoded data to.
-     * @exception IOException on encoding errors.
-     */
-    public void encodeSignedData(OutputStream out) throws IOException {
-        DerOutputStream derout = new DerOutputStream();
-        encodeSignedData(derout);
-        out.write(derout.toByteArray());
-    }
-
-    /**
      * Encodes the signed data to a DerOutputStream.
      *
      * @param out the DerOutputStream to write the encoded data to.
@@ -877,7 +865,7 @@ public class PKCS7 {
                 : new ContentInfo(content);
         PKCS7 pkcs7 = new PKCS7(algorithms, contentInfo,
                 signerChain, signerInfos);
-        ByteArrayOutputStream p7out = new ByteArrayOutputStream();
+        DerOutputStream p7out = new DerOutputStream();
         pkcs7.encodeSignedData(p7out);
 
         return p7out.toByteArray();

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS9Attribute.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS9Attribute.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.pkcs;
 
 import java.io.IOException;
-import java.security.cert.CertificateException;
 import java.util.Date;
 
 import com.tencent.kona.sun.security.util.Debug;
@@ -538,12 +537,13 @@ public class PKCS9Attribute implements DerEncoder {
      * should be encoded as <code>T61String</code>s.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         DerOutputStream temp = new DerOutputStream();
         temp.putOID(oid);
         switch (index) {
             case -1:    // Unknown
-                temp.write((byte[])value);
+                byte[] bytes = (byte[]) value;
+                temp.write(bytes, 0, bytes.length);
                 break;
             case 1:     // email address
             case 2:     // unstructured name

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS9Attributes.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS9Attributes.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.pkcs;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Hashtable;
 
 import com.tencent.kona.sun.security.util.DerEncoder;
@@ -232,15 +231,13 @@ public class PKCS9Attributes {
      *
      * @param tag the implicit tag to use in the DER encoding.
      * @param out the output stream on which to put the DER encoding.
-     *
-     * @exception IOException  on output error.
      */
-    public void encode(byte tag, OutputStream out) throws IOException {
+    public void encode(byte tag, DerOutputStream out) {
         out.write(tag);
         out.write(derEncoding, 1, derEncoding.length -1);
     }
 
-    private byte[] generateDerEncoding() throws IOException {
+    private byte[] generateDerEncoding() {
         DerOutputStream out = new DerOutputStream();
         DerEncoder[] attribVals = attributes.values().toArray(new DerEncoder[0]);
         out.putOrderedSetOf(DerValue.tag_SetOf, attribVals);
@@ -251,7 +248,7 @@ public class PKCS9Attributes {
      * Return the DER encoding of this attribute set, tagged with
      * DerValue.tag_SetOf.
      */
-    public byte[] getDerEncoding() throws IOException {
+    public byte[] getDerEncoding() {
         return derEncoding.clone();
 
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/SignerInfo.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/SignerInfo.java
@@ -239,11 +239,9 @@ public class SignerInfo implements DerEncoder {
      *
      * @param out
      * the output stream on which to write the DER encoding.
-     *
-     * @exception IOException on encoding error.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         DerOutputStream seq = new DerOutputStream();
         seq.putInteger(version);
         DerOutputStream issuerAndSerialNumber = new DerOutputStream();
@@ -434,16 +432,11 @@ public class SignerInfo implements DerEncoder {
             boolean[] keyUsageBits = cert.getKeyUsage();
             if (keyUsageBits != null) {
                 KeyUsageExtension keyUsage;
-                try {
-                    // We don't care whether this extension was marked
-                    // critical in the certificate.
-                    // We're interested only in its value (i.e., the bits set)
-                    // and treat the extension as critical.
-                    keyUsage = new KeyUsageExtension(keyUsageBits);
-                } catch (IOException ioe) {
-                    throw new SignatureException("Failed to parse keyUsage "
-                            + "extension");
-                }
+                // We don't care whether this extension was marked
+                // critical in the certificate.
+                // We're interested only in its value (i.e., the bits set)
+                // and treat the extension as critical.
+                keyUsage = new KeyUsageExtension(keyUsageBits);
 
                 boolean digSigAllowed
                         = keyUsage.get(KeyUsageExtension.DIGITAL_SIGNATURE);

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs12/MacData.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs12/MacData.java
@@ -138,7 +138,7 @@ class MacData {
      * @exception IOException if error occurs when constructing its
      * ASN.1 encoding.
      */
-    public byte[] getEncoded() throws NoSuchAlgorithmException, IOException
+    public byte[] getEncoded() throws NoSuchAlgorithmException
     {
         if (this.encoded != null)
             return this.encoded.clone();

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs12/PKCS12KeyStore.java
@@ -837,38 +837,6 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
     }
 
     /*
-     * parse Algorithm Parameters
-     */
-    private AlgorithmParameters parseAlgParameters(ObjectIdentifier algorithm,
-                                                   DerInputStream in) throws IOException
-    {
-        AlgorithmParameters algParams = null;
-        try {
-            DerValue params;
-            if (in.available() == 0) {
-                params = null;
-            } else {
-                params = in.getDerValue();
-                if (params.tag == DerValue.tag_Null) {
-                    params = null;
-                }
-            }
-            if (params != null) {
-                if (algorithm.equals((Object) pbes2_OID)) {
-                    algParams = CryptoInsts.getAlgorithmParameters("PBES2");
-                } else {
-                    algParams = CryptoInsts.getAlgorithmParameters("PBE");
-                }
-                algParams.init(params.toByteArray());
-            }
-        } catch (Exception e) {
-            throw new IOException("parseAlgParameters failed: " +
-                    e.getMessage(), e);
-        }
-        return algParams;
-    }
-
-    /*
      * Generate PBE key
      */
     private SecretKey getPBEKey(char[] password) throws IOException
@@ -1215,7 +1183,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
         DerOutputStream version = new DerOutputStream();
         version.putInteger(VERSION_3);
         byte[] pfxVersion = version.toByteArray();
-        pfx.write(pfxVersion);
+        pfx.write(pfxVersion, 0, pfxVersion.length);
 
         // -- Create AuthSafe
         DerOutputStream authSafe = new DerOutputStream();

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/KeyProtector.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/KeyProtector.java
@@ -95,7 +95,6 @@ import com.tencent.kona.sun.security.util.KnownOIDs;
  *
  * @see java.security.KeyStore
  * @see JavaKeyStore
- * @see KeyTool
  *
  * @since 1.2
  */
@@ -210,14 +209,9 @@ final class KeyProtector {
 
         // wrap the protected private key in a PKCS#8-style
         // EncryptedPrivateKeyInfo, and returns its encoding
-        AlgorithmId encrAlg;
-        try {
-            encrAlg = new AlgorithmId(Oid.of
-                    (KnownOIDs.JAVASOFT_JDKKeyProtector));
-            return new EncryptedPrivateKeyInfo(encrAlg,encrKey).getEncoded();
-        } catch (IOException ioe) {
-            throw new KeyStoreException(ioe.getMessage());
-        }
+        AlgorithmId encrAlg = new AlgorithmId(Oid.of
+                (KnownOIDs.JAVASOFT_JDKKeyProtector));
+        return new EncryptedPrivateKeyInfo(encrAlg,encrKey).getEncoded();
     }
 
     /*

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/CertId.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/CertId.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import javax.security.auth.x500.X500Principal;
 
 import com.tencent.kona.crypto.CryptoInsts;
+import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerInputStream;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -60,7 +61,7 @@ import com.tencent.kona.sun.security.x509.SerialNumber;
  * @author      Ram Marti
  */
 
-public class CertId {
+public class CertId implements DerEncoder {
 
     private static final boolean debug = false;
     private static final AlgorithmId SHA1_ALGID
@@ -159,7 +160,8 @@ public class CertId {
      * Encode the CertId using ASN.1 DER.
      * The hash algorithm used is SHA-1.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) {
 
         DerOutputStream tmp = new DerOutputStream();
         hashAlgId.encode(tmp);

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AVA.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AVA.java
@@ -634,15 +634,11 @@ public class AVA implements DerEncoder {
      * DER encode this object onto an output stream.
      * Implements the <code>DerEncoder</code> interface.
      *
-     * @param out
-     * the output stream on which to write the DER encoding.
-     *
-     * @exception IOException on encoding error.
+     * @param out the output stream on which to write the DER encoding.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
-        DerOutputStream         tmp = new DerOutputStream();
-        DerOutputStream         tmp2 = new DerOutputStream();
+    public void encode(DerOutputStream out) {
+        DerOutputStream tmp = new DerOutputStream();
 
         tmp.putOID(oid);
         value.encode(tmp);
@@ -720,12 +716,7 @@ public class AVA implements DerEncoder {
         if ((typeAndValue.charAt(0) >= '0' && typeAndValue.charAt(0) <= '9') ||
                 !isDerString(value, false))
         {
-            byte[] data;
-            try {
-                data = value.toByteArray();
-            } catch (IOException ie) {
-                throw new IllegalArgumentException("DER Value conversion");
-            }
+            byte[] data = value.toByteArray();
             typeAndValue.append('#');
             HexFormat.of().formatHex(typeAndValue, data);
         } else {
@@ -737,12 +728,7 @@ public class AVA implements DerEncoder {
              * NOTE: this implementation only emits DirectoryStrings of the
              * types returned by isDerString().
              */
-            String valStr;
-            try {
-                valStr = new String(value.getDataBytes(), UTF_8);
-            } catch (IOException ie) {
-                throw new IllegalArgumentException("DER Value conversion");
-            }
+            String valStr = new String(value.getDataBytes(), UTF_8);
 
             /*
              * 2.4 (cont): If the UTF-8 string does not have any of the
@@ -855,12 +841,7 @@ public class AVA implements DerEncoder {
         if ((typeAndValue.charAt(0) >= '0' && typeAndValue.charAt(0) <= '9') ||
                 !isDerString(value, true))
         {
-            byte[] data;
-            try {
-                data = value.toByteArray();
-            } catch (IOException ie) {
-                throw new IllegalArgumentException("DER Value conversion");
-            }
+            byte[] data = value.toByteArray();
             typeAndValue.append('#');
             HexFormat.of().formatHex(typeAndValue, data);
         } else {
@@ -872,12 +853,7 @@ public class AVA implements DerEncoder {
              * NOTE: this implementation only emits DirectoryStrings of the
              * types returned by isDerString().
              */
-            String valStr;
-            try {
-                valStr = new String(value.getDataBytes(), UTF_8);
-            } catch (IOException ie) {
-                throw new IllegalArgumentException("DER Value conversion");
-            }
+            String valStr = new String(value.getDataBytes(), UTF_8);
 
             /*
              * 2.4 (cont): If the UTF-8 string does not have any of the

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AccessDescription.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AccessDescription.java
@@ -77,7 +77,7 @@ public final class AccessDescription {
         return accessLocation;
     }
 
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         DerOutputStream tmp = new DerOutputStream();
         tmp.putOID(accessMethod);
         accessLocation.encode(tmp);

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityInfoAccessExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityInfoAccessExtension.java
@@ -76,10 +76,9 @@ public class AuthorityInfoAccessExtension extends Extension {
      *
      * @param accessDescriptions the List of AccessDescription,
      *                           cannot be null or empty.
-     * @throws IOException on error
      */
     public AuthorityInfoAccessExtension(
-            List<AccessDescription> accessDescriptions) throws IOException {
+            List<AccessDescription> accessDescriptions) {
         if (accessDescriptions == null || accessDescriptions.isEmpty()) {
             throw new IllegalArgumentException("accessDescriptions is null or empty");
         }
@@ -137,10 +136,9 @@ public class AuthorityInfoAccessExtension extends Extension {
      * Write the extension to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.AuthInfoAccess_Id;
             this.critical = false;
@@ -150,7 +148,7 @@ public class AuthorityInfoAccessExtension extends Extension {
     }
 
     // Encode this extension value
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (accessDescriptions.isEmpty()) {
             this.extensionValue = null;
         } else {

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityKeyIdentifierExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AuthorityKeyIdentifierExtension.java
@@ -66,7 +66,7 @@ public class AuthorityKeyIdentifierExtension extends Extension {
     private SerialNumber serialNum = null;
 
     // Encode only the extension value
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (id == null && names == null && serialNum == null) {
             this.extensionValue = null;
             return;
@@ -79,15 +79,11 @@ public class AuthorityKeyIdentifierExtension extends Extension {
             tmp.writeImplicit(DerValue.createTag(DerValue.TAG_CONTEXT,
                               false, TAG_ID), tmp1);
         }
-        try {
-            if (names != null) {
-                DerOutputStream tmp1 = new DerOutputStream();
-                names.encode(tmp1);
-                tmp.writeImplicit(DerValue.createTag(DerValue.TAG_CONTEXT,
-                                  true, TAG_NAMES), tmp1);
-            }
-        } catch (Exception e) {
-            throw new IOException(e.toString());
+        if (names != null) {
+            DerOutputStream tmp1 = new DerOutputStream();
+            names.encode(tmp1);
+            tmp.writeImplicit(DerValue.createTag(DerValue.TAG_CONTEXT,
+                              true, TAG_NAMES), tmp1);
         }
         if (serialNum != null) {
             DerOutputStream tmp1 = new DerOutputStream();
@@ -107,11 +103,9 @@ public class AuthorityKeyIdentifierExtension extends Extension {
      * @param names the GeneralNames associated with this extension
      * @param sn the CertificateSerialNumber associated with
      *         this extension.
-     * @exception IOException on error.
      */
     public AuthorityKeyIdentifierExtension(KeyIdentifier kid, GeneralNames names,
-                                           SerialNumber sn)
-            throws IOException {
+                                           SerialNumber sn) {
         if (kid == null && names == null && sn == null) {
             throw new IllegalArgumentException(
                     "AuthorityKeyIdentifierExtension cannot be empty");
@@ -203,10 +197,9 @@ public class AuthorityKeyIdentifierExtension extends Extension {
      * Write the extension to the OutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on error.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (this.extensionValue == null) {
             extensionId = PKIXExtensions.AuthorityKey_Id;
             critical = false;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/BasicConstraintsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/BasicConstraintsExtension.java
@@ -57,7 +57,7 @@ public class BasicConstraintsExtension extends Extension {
     private int pathLen = -1;
 
     // Encode this extension value
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         DerOutputStream out = new DerOutputStream();
         DerOutputStream tmp = new DerOutputStream();
 
@@ -79,7 +79,7 @@ public class BasicConstraintsExtension extends Extension {
      * @param ca true, if the subject of the Certificate is a CA.
      * @param len specifies the depth of the certification path.
      */
-    public BasicConstraintsExtension(boolean ca, int len) throws IOException {
+    public BasicConstraintsExtension(boolean ca, int len) {
         this(Boolean.valueOf(ca), ca, len);
     }
 
@@ -90,8 +90,7 @@ public class BasicConstraintsExtension extends Extension {
      * @param ca true, if the subject of the Certificate is a CA.
      * @param len specifies the depth of the certification path.
      */
-    public BasicConstraintsExtension(Boolean critical, boolean ca, int len)
-            throws IOException {
+    public BasicConstraintsExtension(Boolean critical, boolean ca, int len) {
         this.ca = ca;
         this.pathLen = len;
         this.extensionId = PKIXExtensions.BasicConstraints_Id;
@@ -179,7 +178,7 @@ public class BasicConstraintsExtension extends Extension {
      * @param out the DerOutputStream to encode the extension to.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (extensionValue == null) {
              this.extensionId = PKIXExtensions.BasicConstraints_Id;
              critical = ca;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLDistributionPointsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLDistributionPointsExtension.java
@@ -96,7 +96,7 @@ public class CRLDistributionPointsExtension extends Extension {
      * @throws IOException on error
      */
     public CRLDistributionPointsExtension(
-            List<DistributionPoint> distributionPoints) throws IOException {
+            List<DistributionPoint> distributionPoints) {
 
         this(false, distributionPoints);
     }
@@ -108,10 +108,9 @@ public class CRLDistributionPointsExtension extends Extension {
      * @param isCritical the criticality setting.
      * @param distributionPoints the list of distribution points,
      *                           cannot be null or empty.
-     * @throws IOException on error
      */
     public CRLDistributionPointsExtension(boolean isCritical,
-            List<DistributionPoint> distributionPoints) throws IOException {
+            List<DistributionPoint> distributionPoints) {
 
         this(PKIXExtensions.CRLDistributionPoints_Id, isCritical,
                 distributionPoints, NAME);
@@ -122,7 +121,7 @@ public class CRLDistributionPointsExtension extends Extension {
      */
     protected CRLDistributionPointsExtension(ObjectIdentifier extensionId,
             boolean isCritical, List<DistributionPoint> distributionPoints,
-            String extensionName) throws IOException {
+            String extensionName) {
 
         if (distributionPoints == null || distributionPoints.isEmpty()) {
             throw new IllegalArgumentException(
@@ -191,7 +190,7 @@ public class CRLDistributionPointsExtension extends Extension {
      * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         encode(out, PKIXExtensions.CRLDistributionPoints_Id, false);
     }
 
@@ -200,7 +199,7 @@ public class CRLDistributionPointsExtension extends Extension {
      * (Also called by the subclass)
      */
     protected void encode(DerOutputStream out, ObjectIdentifier extensionId,
-            boolean isCritical) throws IOException {
+            boolean isCritical) {
 
         if (this.extensionValue == null) {
             this.extensionId = extensionId;
@@ -218,7 +217,7 @@ public class CRLDistributionPointsExtension extends Extension {
     }
 
     // Encode this extension value
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (distributionPoints.isEmpty()) {
             this.extensionValue = null;
         } else {

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLExtensions.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLExtensions.java
@@ -139,30 +139,25 @@ public class CRLExtensions {
      * @param out the DerOutputStream to marshal the contents to.
      * @param isExplicit the tag indicating whether this is an entry
      * extension (false) or a CRL extension (true).
-     * @exception CRLException on encoding errors.
      */
-    public void encode(OutputStream out, boolean isExplicit)
-            throws CRLException {
-        try {
-            DerOutputStream extOut = new DerOutputStream();
-            for (Extension ext : map.values()) {
-                ext.encode(extOut);
-            }
-
-            DerOutputStream seq = new DerOutputStream();
-            seq.write(DerValue.tag_Sequence, extOut);
-
-            DerOutputStream tmp = new DerOutputStream();
-            if (isExplicit)
-                tmp.write(DerValue.createTag(DerValue.TAG_CONTEXT,
-                        true, (byte)0), seq);
-            else
-                tmp = seq;
-
-            out.write(tmp.toByteArray());
-        } catch (IOException e) {
-            throw new CRLException("Encoding error: " + e.toString());
+    public void encode(DerOutputStream out, boolean isExplicit) {
+        DerOutputStream extOut = new DerOutputStream();
+        for (Extension ext : map.values()) {
+            ext.encode(extOut);
         }
+
+        DerOutputStream seq = new DerOutputStream();
+        seq.write(DerValue.tag_Sequence, extOut);
+
+        DerOutputStream tmp = new DerOutputStream();
+        if (isExplicit)
+            tmp.write(DerValue.createTag(DerValue.TAG_CONTEXT,
+                    true, (byte) 0), seq);
+        else
+            tmp = seq;
+
+        byte[] bytes = tmp.toByteArray();
+        out.write(bytes, 0, bytes.length);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLNumberExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLNumberExtension.java
@@ -56,7 +56,7 @@ public class CRLNumberExtension extends Extension {
     private final String extensionLabel;
 
     // Encode this extension value
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (crlNumber == null) {
             this.extensionValue = null;
             return;
@@ -72,7 +72,7 @@ public class CRLNumberExtension extends Extension {
      *
      * @param crlNum the value to be set for the extension.
      */
-    public CRLNumberExtension(int crlNum) throws IOException {
+    public CRLNumberExtension(int crlNum) {
         this(PKIXExtensions.CRLNumber_Id, false, BigInteger.valueOf(crlNum),
                 NAME, LABEL);
     }
@@ -83,7 +83,7 @@ public class CRLNumberExtension extends Extension {
      *
      * @param crlNum the value to be set for the extension, cannot be null
      */
-    public CRLNumberExtension(BigInteger crlNum) throws IOException {
+    public CRLNumberExtension(BigInteger crlNum) {
         this(PKIXExtensions.CRLNumber_Id, false, crlNum, NAME, LABEL);
     }
 
@@ -92,7 +92,7 @@ public class CRLNumberExtension extends Extension {
      */
     protected CRLNumberExtension(ObjectIdentifier extensionId,
             boolean isCritical, BigInteger crlNum, String extensionName,
-            String extensionLabel) throws IOException {
+            String extensionLabel) {
 
         if (crlNum == null) {
             throw new IllegalArgumentException("CRL number cannot be null");
@@ -161,10 +161,9 @@ public class CRLNumberExtension extends Extension {
      * Write the extension to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         encode(out, PKIXExtensions.CRLNumber_Id, true);
     }
 
@@ -173,7 +172,7 @@ public class CRLNumberExtension extends Extension {
      * (Also called by the subclass)
      */
     protected void encode(DerOutputStream out, ObjectIdentifier extensionId,
-            boolean isCritical) throws IOException {
+            boolean isCritical) {
 
        if (this.extensionValue == null) {
            this.extensionId = extensionId;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLReasonCodeExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLReasonCodeExtension.java
@@ -46,7 +46,7 @@ public class CRLReasonCodeExtension extends Extension {
 
     private int reasonCode;
 
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (reasonCode == 0) {
             this.extensionValue = null;
             return;
@@ -72,8 +72,7 @@ public class CRLReasonCodeExtension extends Extension {
      * @param critical true if the extension is to be treated as critical.
      * @param reason the enumerated value for the reason code, must be positive.
      */
-    public CRLReasonCodeExtension(boolean critical, int reason)
-            throws IOException {
+    public CRLReasonCodeExtension(boolean critical, int reason) {
         if (reason <= 0) {
             throw new IllegalArgumentException("reason code must be positive");
         }
@@ -111,10 +110,9 @@ public class CRLReasonCodeExtension extends Extension {
      * Write the extension to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.ReasonCode_Id;
             this.critical = false;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateAlgorithmId.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateAlgorithmId.java
@@ -96,10 +96,9 @@ public class CertificateAlgorithmId implements DerEncoder {
      * Encode the algorithm identifier in DER form to the stream.
      *
      * @param out the DerOutputStream to marshal the contents to.
-     * @exception IOException on errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         algId.encode(out);
     }
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateExtensions.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateExtensions.java
@@ -139,12 +139,9 @@ public class CertificateExtensions implements DerEncoder {
     /**
      * Encode the extensions in DER form to the stream, setting
      * the context specific tag as needed in the X.509 v3 certificate.
-     *
-     * @param out the DerOutputStream to marshal the contents to.
-     * @exception IOException on errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         encode(out, false);
     }
 
@@ -153,11 +150,9 @@ public class CertificateExtensions implements DerEncoder {
      *
      * @param out the DerOutputStream to marshal the contents to.
      * @param isCertReq if true then no context specific tag is added.
-     * @exception IOException on errors.
      */
-    public void encode(DerOutputStream out, boolean isCertReq)
-            throws IOException {
-                DerOutputStream extOut = new DerOutputStream();
+    public void encode(DerOutputStream out, boolean isCertReq) {
+        DerOutputStream extOut = new DerOutputStream();
         for (Extension ext : map.values()) {
             ext.encode(extOut);
         }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateIssuerExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateIssuerExtension.java
@@ -66,7 +66,7 @@ public class CertificateIssuerExtension extends Extension {
     /**
      * Encode this extension
      */
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (names == null || names.isEmpty()) {
             this.extensionValue = null;
             return;
@@ -81,9 +81,8 @@ public class CertificateIssuerExtension extends Extension {
      * Criticality is automatically set to true.
      *
      * @param issuer the certificate issuer, cannot be null or empty.
-     * @throws IOException on error
      */
-    public CertificateIssuerExtension(GeneralNames issuer) throws IOException {
+    public CertificateIssuerExtension(GeneralNames issuer) {
         if (issuer == null || issuer.isEmpty()) {
             throw new IllegalArgumentException("issuer cannot be null or empty");
         }
@@ -128,10 +127,9 @@ public class CertificateIssuerExtension extends Extension {
      * Write the extension to the OutputStream.
      *
      * @param out the DerOutputStream to write the extension to
-     * @exception IOException on encoding errors
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.CertificateIssuer_Id;
             critical = true;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePoliciesExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePoliciesExtension.java
@@ -74,7 +74,7 @@ public class CertificatePoliciesExtension extends Extension {
     private List<PolicyInformation> certPolicies;
 
     // Encode this extension value.
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (certPolicies == null || certPolicies.isEmpty()) {
             this.extensionValue = null;
         } else {
@@ -96,8 +96,7 @@ public class CertificatePoliciesExtension extends Extension {
      *
      * @param certPolicies the List of PolicyInformation.
      */
-    public CertificatePoliciesExtension(List<PolicyInformation> certPolicies)
-            throws IOException {
+    public CertificatePoliciesExtension(List<PolicyInformation> certPolicies) {
         this(Boolean.FALSE, certPolicies);
     }
 
@@ -109,7 +108,7 @@ public class CertificatePoliciesExtension extends Extension {
      * @param certPolicies the List of PolicyInformation, cannot be null or empty.
      */
     public CertificatePoliciesExtension(Boolean critical,
-            List<PolicyInformation> certPolicies) throws IOException {
+            List<PolicyInformation> certPolicies) {
         if (certPolicies == null || certPolicies.isEmpty()) {
             throw new IllegalArgumentException(
                     "certificate policies cannot be null or empty");
@@ -168,10 +167,9 @@ public class CertificatePoliciesExtension extends Extension {
      * Write the extension to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (extensionValue == null) {
           extensionId = PKIXExtensions.CertificatePolicies_Id;
           critical = false;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePolicyId.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePolicyId.java
@@ -28,6 +28,7 @@ package com.tencent.kona.sun.security.x509;
 import java.io.IOException;
 import java.util.Objects;
 
+import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
 import com.tencent.kona.sun.security.util.ObjectIdentifier;
@@ -38,7 +39,7 @@ import com.tencent.kona.sun.security.util.ObjectIdentifier;
  * @author Amit Kapoor
  * @author Hemma Prafullchandra
  */
-public class CertificatePolicyId {
+public class CertificatePolicyId implements DerEncoder {
     private final ObjectIdentifier id;
 
     /**
@@ -79,9 +80,9 @@ public class CertificatePolicyId {
      * Write the CertificatePolicyId to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the object to.
-     * @exception IOException on errors.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) {
         out.putOID(id);
     }
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePolicyMap.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePolicyMap.java
@@ -28,6 +28,7 @@ package com.tencent.kona.sun.security.x509;
 import java.io.IOException;
 import java.util.Objects;
 
+import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
 
@@ -37,7 +38,7 @@ import com.tencent.kona.sun.security.util.DerValue;
  * @author Amit Kapoor
  * @author Hemma Prafullchandra
  */
-public class CertificatePolicyMap {
+public class CertificatePolicyMap implements DerEncoder {
     private final CertificatePolicyId issuerDomain;
     private final CertificatePolicyId subjectDomain;
 
@@ -96,7 +97,8 @@ public class CertificatePolicyMap {
      * @param out the DerOutputStream to write the object to.
      * @exception IOException on errors.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) {
         DerOutputStream tmp = new DerOutputStream();
 
         issuerDomain.encode(tmp);

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePolicySet.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePolicySet.java
@@ -30,6 +30,7 @@ import java.util.Vector;
 import java.util.List;
 import java.util.Collections;
 
+import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerInputStream;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -40,7 +41,7 @@ import com.tencent.kona.sun.security.util.DerValue;
  * @author Amit Kapoor
  * @author Hemma Prafullchandra
  */
-public class CertificatePolicySet {
+public class CertificatePolicySet implements DerEncoder {
 
     private final Vector<CertificatePolicyId> ids;
 
@@ -83,7 +84,8 @@ public class CertificatePolicySet {
      *
      * @param out the DerOutputStream to encode the data to.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) {
         DerOutputStream tmp = new DerOutputStream();
 
         for (int i = 0; i < ids.size(); i++) {

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateSerialNumber.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateSerialNumber.java
@@ -106,10 +106,9 @@ public class CertificateSerialNumber implements DerEncoder {
      * Encode the serial number in DER form to the stream.
      *
      * @param out the DerOutputStream to marshal the contents to.
-     * @exception IOException on errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         serial.encode(out);
     }
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateSubjectName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateSubjectName.java
@@ -93,10 +93,9 @@ public class CertificateSubjectName implements DerEncoder {
      * Encode the name in DER form to the stream.
      *
      * @param out the DerOutputStream to marshal the contents to.
-     * @exception IOException on errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         dnName.encode(out);
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateValidity.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateValidity.java
@@ -125,10 +125,9 @@ public class CertificateValidity implements DerEncoder {
      * Encode the CertificateValidity period in DER form to the stream.
      *
      * @param out the DerOutputStream to marshal the contents to.
-     * @exception IOException on errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
 
         DerOutputStream pair = new DerOutputStream();
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateVersion.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateVersion.java
@@ -148,10 +148,9 @@ public class CertificateVersion implements DerEncoder {
      * Encode the CertificateVersion period in DER form to the stream.
      *
      * @param out the DerOutputStream to marshal the contents to.
-     * @exception IOException on errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         // Nothing for default
         if (version == V1) {
             return;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateX509Key.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateX509Key.java
@@ -90,11 +90,11 @@ public class CertificateX509Key implements DerEncoder {
      * Encode the key in DER form to the stream.
      *
      * @param out the DerOutputStream to marshal the contents to.
-     * @exception IOException on errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
-        out.write(key.getEncoded());
+    public void encode(DerOutputStream out) {
+        byte[] bytes = key.getEncoded();
+        out.write(bytes, 0, bytes.length);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DNSName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DNSName.java
@@ -151,9 +151,9 @@ public class DNSName implements GeneralNameInterface {
      * Encode the DNSName into the DerOutputStream.
      *
      * @param out the DER stream to encode the DNSName to.
-     * @exception IOException on encoding errors.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) {
         out.putIA5String(name);
     }
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DeltaCRLIndicatorExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DeltaCRLIndicatorExtension.java
@@ -69,7 +69,7 @@ public class DeltaCRLIndicatorExtension extends CRLNumberExtension {
      *
      * @param crlNum the value to be set for the extension.
      */
-    public DeltaCRLIndicatorExtension(int crlNum) throws IOException {
+    public DeltaCRLIndicatorExtension(int crlNum) {
         super(PKIXExtensions.DeltaCRLIndicator_Id, true,
                 BigInteger.valueOf(crlNum), NAME, LABEL);
     }
@@ -80,7 +80,7 @@ public class DeltaCRLIndicatorExtension extends CRLNumberExtension {
      *
      * @param crlNum the value to be set for the extension.
      */
-    public DeltaCRLIndicatorExtension(BigInteger crlNum) throws IOException {
+    public DeltaCRLIndicatorExtension(BigInteger crlNum) {
         super(PKIXExtensions.DeltaCRLIndicator_Id, true, crlNum, NAME, LABEL);
     }
 
@@ -104,7 +104,8 @@ public class DeltaCRLIndicatorExtension extends CRLNumberExtension {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) {
         super.encode(out, PKIXExtensions.DeltaCRLIndicator_Id, true);
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DistributionPoint.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DistributionPoint.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.*;
 
 import com.tencent.kona.sun.security.util.BitArray;
+import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
 
@@ -93,7 +94,7 @@ import com.tencent.kona.sun.security.util.DerValue;
  * @since 1.4.2
  * @see CRLDistributionPointsExtension
  */
-public class DistributionPoint {
+public class DistributionPoint implements DerEncoder {
 
     // reason flag bits
     // NOTE that these are NOT quite the same as the CRL reason code extension
@@ -275,9 +276,8 @@ public class DistributionPoint {
      * Write the DistributionPoint value to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on error.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         DerOutputStream tagged = new DerOutputStream();
 
         // NOTE: only one of pointNames and pointRDN can be set

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DistributionPointName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DistributionPointName.java
@@ -28,6 +28,7 @@ package com.tencent.kona.sun.security.x509;
 import java.io.IOException;
 import java.util.*;
 
+import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
 
@@ -78,7 +79,7 @@ import com.tencent.kona.sun.security.util.DerValue;
  * @see IssuingDistributionPointExtension
  * @since 1.6
  */
-public class DistributionPointName {
+public class DistributionPointName implements DerEncoder {
 
     // ASN.1 context specific tag values
     private static final byte TAG_FULL_NAME = 0;
@@ -164,9 +165,8 @@ public class DistributionPointName {
      * Encodes the distribution point name and writes it to the DerOutputStream.
      *
      * @param out the output stream.
-     * @exception IOException on encoding error.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
 
         DerOutputStream theChoice = new DerOutputStream();
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/EDIPartyName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/EDIPartyName.java
@@ -126,9 +126,8 @@ public class EDIPartyName implements GeneralNameInterface {
      * Encode the EDI party name into the DerOutputStream.
      *
      * @param out the DER stream to encode the EDIPartyName to.
-     * @exception IOException on encoding errors.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         DerOutputStream tagged = new DerOutputStream();
         DerOutputStream tmp = new DerOutputStream();
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/ExtendedKeyUsageExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/ExtendedKeyUsageExtension.java
@@ -86,7 +86,7 @@ public class ExtendedKeyUsageExtension extends Extension {
     private Vector<ObjectIdentifier> keyUsages;
 
     // Encode this extension value.
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (keyUsages == null || keyUsages.isEmpty()) {
             this.extensionValue = null;
             return;
@@ -108,8 +108,7 @@ public class ExtendedKeyUsageExtension extends Extension {
      *
      * @param keyUsages the Vector of KeyUsages (ObjectIdentifiers)
      */
-    public ExtendedKeyUsageExtension(Vector<ObjectIdentifier> keyUsages)
-            throws IOException {
+    public ExtendedKeyUsageExtension(Vector<ObjectIdentifier> keyUsages) {
         this(Boolean.FALSE, keyUsages);
     }
 
@@ -121,8 +120,7 @@ public class ExtendedKeyUsageExtension extends Extension {
      * @param keyUsages the Vector of KeyUsages (ObjectIdentifiers),
      *                  cannot be null or empty.
      */
-    public ExtendedKeyUsageExtension(Boolean critical, Vector<ObjectIdentifier> keyUsages)
-            throws IOException {
+    public ExtendedKeyUsageExtension(Boolean critical, Vector<ObjectIdentifier> keyUsages) {
         if (keyUsages == null || keyUsages.isEmpty()) {
             throw new IllegalArgumentException(
                     "key usages cannot be null or empty");
@@ -188,10 +186,9 @@ public class ExtendedKeyUsageExtension extends Extension {
      * Write the extension to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (extensionValue == null) {
           extensionId = PKIXExtensions.ExtendedKeyUsage_Id;
           critical = false;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/Extension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/Extension.java
@@ -173,10 +173,9 @@ public class Extension implements java.security.cert.Extension, DerEncoder {
      * Write the extension to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
 
         Objects.requireNonNull(extensionId,
                 "No OID to encode for the extension");

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/FreshestCRLExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/FreshestCRLExtension.java
@@ -65,8 +65,7 @@ public class FreshestCRLExtension extends CRLDistributionPointsExtension {
      *
      * @param distributionPoints the list of delta CRL distribution points.
      */
-    public FreshestCRLExtension(List<DistributionPoint> distributionPoints)
-            throws IOException {
+    public FreshestCRLExtension(List<DistributionPoint> distributionPoints) {
 
         super(PKIXExtensions.FreshestCRL_Id, false, distributionPoints, NAME);
     }
@@ -88,10 +87,9 @@ public class FreshestCRLExtension extends CRLDistributionPointsExtension {
      * Writes the extension to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         super.encode(out, PKIXExtensions.FreshestCRL_Id, false);
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralName.java
@@ -27,6 +27,7 @@ package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
 
+import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
 
@@ -50,7 +51,7 @@ import com.tencent.kona.sun.security.util.DerValue;
  * @author Amit Kapoor
  * @author Hemma Prafullchandra
  */
-public class GeneralName {
+public class GeneralName implements DerEncoder {
 
     // Private data members
     private final GeneralNameInterface name;
@@ -232,9 +233,9 @@ public class GeneralName {
      * Encode the name to the specified DerOutputStream.
      *
      * @param out the DerOutputStream to encode the GeneralName to.
-     * @exception IOException on encoding errors.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) {
         DerOutputStream tmp = new DerOutputStream();
         name.encode(tmp);
         int nameType = name.getType();

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralNameInterface.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralNameInterface.java
@@ -25,8 +25,7 @@
 
 package com.tencent.kona.sun.security.x509;
 
-import java.io.IOException;
-
+import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 
 /**
@@ -36,7 +35,7 @@ import com.tencent.kona.sun.security.util.DerOutputStream;
  * @author Amit Kapoor
  * @author Hemma Prafullchandra
  */
-public interface GeneralNameInterface {
+public interface GeneralNameInterface extends DerEncoder {
     /**
      * The list of names supported.
      */
@@ -64,15 +63,6 @@ public interface GeneralNameInterface {
      * defined above.
      */
     int getType();
-
-    /**
-     * Encode the name to the specified DerOutputStream.
-     *
-     * @param out the DerOutputStream to encode the GeneralName to.
-     * @exception IOException thrown if the GeneralName could not be
-     *            encoded.
-     */
-    void encode(DerOutputStream out) throws IOException;
 
     /**
      * Return type of constraint inputName places on this name:<ul>

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralNames.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralNames.java
@@ -110,9 +110,8 @@ public class GeneralNames {
      * Write the extension to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on error.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (isEmpty()) {
             return;
         }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralSubtree.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralSubtree.java
@@ -28,6 +28,7 @@ package com.tencent.kona.sun.security.x509;
 import java.io.*;
 import java.util.Objects;
 
+import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
 
@@ -44,7 +45,7 @@ import com.tencent.kona.sun.security.util.DerValue;
  * @author Amit Kapoor
  * @author Hemma Prafullchandra
  */
-public class GeneralSubtree {
+public class GeneralSubtree implements DerEncoder {
     private static final byte TAG_MIN = 0;
     private static final byte TAG_MAX = 1;
     private static final int  MIN_DEFAULT = 0;
@@ -196,7 +197,8 @@ public class GeneralSubtree {
      *
      * @param out the DerOutputStream to encode this object to.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) {
         DerOutputStream seq = new DerOutputStream();
 
         name.encode(seq);

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralSubtrees.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralSubtrees.java
@@ -28,6 +28,7 @@ package com.tencent.kona.sun.security.x509;
 import java.io.*;
 import java.util.*;
 
+import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
 import com.tencent.kona.sun.security.util.ObjectIdentifier;
@@ -45,7 +46,7 @@ import com.tencent.kona.sun.security.util.ObjectIdentifier;
  * @author Hemma Prafullchandra
  * @author Andreas Sterbenz
  */
-public class GeneralSubtrees implements Cloneable {
+public class GeneralSubtrees implements Cloneable, DerEncoder {
 
     private final List<GeneralSubtree> trees;
 
@@ -134,7 +135,7 @@ public class GeneralSubtrees implements Cloneable {
      *
      * @param out the DerOutputStream to encode this object to.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         DerOutputStream seq = new DerOutputStream();
 
         for (int i = 0, n = size(); i < n; i++) {

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IPAddressName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IPAddressName.java
@@ -227,9 +227,8 @@ public class IPAddressName implements GeneralNameInterface {
      * Encode the IPAddress name into the DerOutputStream.
      *
      * @param out the DER stream to encode the IPAddressName to.
-     * @exception IOException on encoding errors.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         out.putOctetString(address);
     }
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InhibitAnyPolicyExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InhibitAnyPolicyExtension.java
@@ -74,7 +74,7 @@ public class InhibitAnyPolicyExtension extends Extension {
     private int skipCerts = Integer.MAX_VALUE;
 
     // Encode this extension value
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         DerOutputStream out = new DerOutputStream();
         out.putInteger(skipCerts);
         this.extensionValue = out.toByteArray();
@@ -86,7 +86,7 @@ public class InhibitAnyPolicyExtension extends Extension {
      * @param skipCerts specifies the depth of the certification path.
      *                  Use value of -1 to request unlimited depth.
      */
-    public InhibitAnyPolicyExtension(int skipCerts) throws IOException {
+    public InhibitAnyPolicyExtension(int skipCerts) {
         if (skipCerts < -1)
             throw new IllegalArgumentException("Invalid value for skipCerts");
         if (skipCerts == -1)
@@ -149,7 +149,7 @@ public class InhibitAnyPolicyExtension extends Extension {
      * @param out the DerOutputStream to encode the extension to.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (extensionValue == null) {
             this.extensionId = PKIXExtensions.InhibitAnyPolicy_Id;
             critical = true;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InvalidityDateExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/InvalidityDateExtension.java
@@ -65,7 +65,7 @@ public class InvalidityDateExtension extends Extension {
 
     private Date date;
 
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (date == null) {
             this.extensionValue = null;
             return;
@@ -81,7 +81,7 @@ public class InvalidityDateExtension extends Extension {
      *
      * @param date the invalidity date
      */
-    public InvalidityDateExtension(Date date) throws IOException {
+    public InvalidityDateExtension(Date date) {
         this(false, date);
     }
 
@@ -91,8 +91,7 @@ public class InvalidityDateExtension extends Extension {
      * @param critical true if the extension is to be treated as critical.
      * @param date the invalidity date, cannot be null.
      */
-    public InvalidityDateExtension(boolean critical, Date date)
-            throws IOException {
+    public InvalidityDateExtension(boolean critical, Date date) {
         if (date == null) {
             throw new IllegalArgumentException("date cannot be null");
         }
@@ -141,10 +140,9 @@ public class InvalidityDateExtension extends Extension {
      * Write the extension to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to
-     * @exception IOException on encoding errors
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.InvalidityDate_Id;
             this.critical = false;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuerAlternativeNameExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuerAlternativeNameExtension.java
@@ -53,7 +53,7 @@ public class IssuerAlternativeNameExtension extends Extension {
     GeneralNames names;
 
     // Encode this extension
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (names == null || names.isEmpty()) {
             this.extensionValue = null;
             return;
@@ -67,10 +67,8 @@ public class IssuerAlternativeNameExtension extends Extension {
      * Create a IssuerAlternativeNameExtension with the passed GeneralNames.
      *
      * @param names the GeneralNames for the issuer.
-     * @exception IOException on error.
      */
-    public IssuerAlternativeNameExtension(GeneralNames names)
-            throws IOException {
+    public IssuerAlternativeNameExtension(GeneralNames names) {
         this(false, names);
     }
 
@@ -80,10 +78,8 @@ public class IssuerAlternativeNameExtension extends Extension {
      *
      * @param critical true if the extension is to be treated as critical.
      * @param names the GeneralNames for the issuer, cannot be null or empty.
-     * @exception IOException on error.
      */
-    public IssuerAlternativeNameExtension(Boolean critical, GeneralNames names)
-            throws IOException {
+    public IssuerAlternativeNameExtension(Boolean critical, GeneralNames names) {
         if (names == null || names.isEmpty()) {
             throw new IllegalArgumentException("names cannot be null or empty");
         }
@@ -139,10 +135,9 @@ public class IssuerAlternativeNameExtension extends Extension {
      * Write the extension to the OutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding error.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.IssuerAlternativeName_Id;
             critical = false;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuingDistributionPointExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IssuingDistributionPointExtension.java
@@ -112,13 +112,11 @@ public class IssuingDistributionPointExtension extends Extension {
      *        <code>hasOnlyUserCerts</code>, <code>hasOnlyCACerts</code>,
      *        <code>hasOnlyAttributeCerts</code> is set to <code>true</code>,
      *        or all arguments are either <code>null</code> or <code>false</code>.
-     * @throws IOException on encoding error.
      */
     public IssuingDistributionPointExtension(
             DistributionPointName distributionPoint, ReasonFlags revocationReasons,
             boolean hasOnlyUserCerts, boolean hasOnlyCACerts,
-            boolean hasOnlyAttributeCerts, boolean isIndirectCRL)
-            throws IOException {
+            boolean hasOnlyAttributeCerts, boolean isIndirectCRL) {
 
         if (distributionPoint == null &&
                 revocationReasons == null &&
@@ -222,10 +220,9 @@ public class IssuingDistributionPointExtension extends Extension {
      * DerOutputStream.
      *
      * @param out the output stream.
-     * @exception IOException on encoding error.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.IssuingDistributionPoint_Id;
             this.critical = false;
@@ -264,7 +261,7 @@ public class IssuingDistributionPointExtension extends Extension {
     }
 
     // Encodes this extension value
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
 
         if (distributionPoint == null &&
                 revocationReasons == null &&

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/KeyIdentifier.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/KeyIdentifier.java
@@ -125,9 +125,8 @@ public class KeyIdentifier {
      * Write the KeyIdentifier to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the object to.
-     * @exception IOException
      */
-    void encode(DerOutputStream out) throws IOException {
+    void encode(DerOutputStream out) {
         out.putOctetString(octetString);
     }
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/KeyUsageExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/KeyUsageExtension.java
@@ -61,7 +61,7 @@ public class KeyUsageExtension extends Extension {
     private boolean[] bitString;
 
     // Encode this extension value
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         DerOutputStream os = new DerOutputStream();
         os.putTruncatedUnalignedBitString(new BitArray(this.bitString));
         this.extensionValue = os.toByteArray();
@@ -96,7 +96,7 @@ public class KeyUsageExtension extends Extension {
      *
      * @param bitString the bits to be set for the extension.
      */
-    public KeyUsageExtension(byte[] bitString) throws IOException {
+    public KeyUsageExtension(byte[] bitString) {
         this.bitString =
                 new BitArray(bitString.length*8,bitString).toBooleanArray();
         this.extensionId = PKIXExtensions.KeyUsage_Id;
@@ -110,7 +110,7 @@ public class KeyUsageExtension extends Extension {
      *
      * @param bitString the bits to be set for the extension.
      */
-    public KeyUsageExtension(boolean[] bitString) throws IOException {
+    public KeyUsageExtension(boolean[] bitString) {
         this.bitString = bitString;
         this.extensionId = PKIXExtensions.KeyUsage_Id;
         this.critical = true;
@@ -123,7 +123,7 @@ public class KeyUsageExtension extends Extension {
      *
      * @param bitString the bits to be set for the extension.
      */
-    public KeyUsageExtension(BitArray bitString) throws IOException {
+    public KeyUsageExtension(BitArray bitString) {
         this.bitString = bitString.toBooleanArray();
         this.extensionId = PKIXExtensions.KeyUsage_Id;
         this.critical = true;
@@ -273,10 +273,9 @@ public class KeyUsageExtension extends Extension {
      * Write the extension to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (this.extensionValue == null) {
            this.extensionId = PKIXExtensions.KeyUsage_Id;
            this.critical = true;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/NameConstraintsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/NameConstraintsExtension.java
@@ -103,7 +103,7 @@ public class NameConstraintsExtension extends Extension
     }
 
     // Encode this extension value.
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         minMaxValid = false;
         if (permitted == null && excluded == null) {
             this.extensionValue = null;
@@ -137,8 +137,7 @@ public class NameConstraintsExtension extends Extension
      * @param excluded the excluded GeneralSubtrees (null for optional).
      */
     public NameConstraintsExtension(GeneralSubtrees permitted,
-                                    GeneralSubtrees excluded)
-            throws IOException {
+                                    GeneralSubtrees excluded) {
         if (permitted == null && excluded == null) {
             throw new IllegalArgumentException(
                     "permitted and excluded cannot both be null");
@@ -228,10 +227,9 @@ public class NameConstraintsExtension extends Extension
      * Write the extension to the OutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.NameConstraints_Id;
             this.critical = true;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/NetscapeCertTypeExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/NetscapeCertTypeExtension.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.util.*;
 
 import com.tencent.kona.sun.security.util.BitArray;
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -91,13 +90,6 @@ public class NetscapeCertTypeExtension extends Extension {
             new MapEntry(OBJECT_SIGNING_CA, 7),
     };
 
-    private static final Vector<String> mAttributeNames = new Vector<>();
-    static {
-        for (MapEntry entry : mMapData) {
-            mAttributeNames.add(entry.mName);
-        }
-    }
-
     private static int getPosition(String name) throws IOException {
         for (int i = 0; i < mMapData.length; i++) {
             if (name.equalsIgnoreCase(mMapData[i].mName))
@@ -108,7 +100,7 @@ public class NetscapeCertTypeExtension extends Extension {
     }
 
     // Encode this extension value
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         DerOutputStream os = new DerOutputStream();
         os.putTruncatedUnalignedBitString(new BitArray(this.bitString));
         this.extensionValue = os.toByteArray();
@@ -143,7 +135,7 @@ public class NetscapeCertTypeExtension extends Extension {
      *
      * @param bitString the bits to be set for the extension.
      */
-    public NetscapeCertTypeExtension(byte[] bitString) throws IOException {
+    public NetscapeCertTypeExtension(byte[] bitString) {
         this.bitString =
                 new BitArray(bitString.length*8, bitString).toBooleanArray();
         this.extensionId = NetscapeCertType_Id;
@@ -157,7 +149,7 @@ public class NetscapeCertTypeExtension extends Extension {
      *
      * @param bitString the bits to be set for the extension.
      */
-    public NetscapeCertTypeExtension(boolean[] bitString) throws IOException {
+    public NetscapeCertTypeExtension(boolean[] bitString) {
         this.bitString = bitString;
         this.extensionId = NetscapeCertType_Id;
         this.critical = true;
@@ -243,10 +235,9 @@ public class NetscapeCertTypeExtension extends Extension {
      * Write the extension to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (this.extensionValue == null) {
             this.extensionId = NetscapeCertType_Id;
             this.critical = true;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/OIDName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/OIDName.java
@@ -89,9 +89,9 @@ public class OIDName implements GeneralNameInterface {
      * Encode the OID name into the DerOutputStream.
      *
      * @param out the DER stream to encode the OIDName to.
-     * @exception IOException on encoding errors.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) {
         out.putOID(oid);
     }
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/OtherName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/OtherName.java
@@ -154,13 +154,11 @@ public class OtherName implements GeneralNameInterface {
      * Encode the Other name into the DerOutputStream.
      *
      * @param out the DER stream to encode the Other-Name to.
-     * @exception IOException on encoding errors.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (gni != null) {
             // This OtherName has a supported class
             gni.encode(out);
-            return;
         } else {
             // This OtherName has no supporting class
             DerOutputStream tmp = new DerOutputStream();

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyConstraintsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyConstraintsExtension.java
@@ -64,7 +64,7 @@ public class PolicyConstraintsExtension extends Extension {
     private int inhibit = -1;
 
     // Encode this extension value.
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (require == -1 && inhibit == -1) {
             this.extensionValue = null;
             return;
@@ -96,8 +96,7 @@ public class PolicyConstraintsExtension extends Extension {
      * @param require require explicit policy (-1 for optional).
      * @param inhibit inhibit policy mapping (-1 for optional).
      */
-    public PolicyConstraintsExtension(int require, int inhibit)
-            throws IOException {
+    public PolicyConstraintsExtension(int require, int inhibit) {
         this(Boolean.TRUE, require, inhibit);
     }
 
@@ -110,8 +109,7 @@ public class PolicyConstraintsExtension extends Extension {
      * @param require require explicit policy (-1 for optional).
      * @param inhibit inhibit policy mapping (-1 for optional).
      */
-    public PolicyConstraintsExtension(Boolean critical, int require, int inhibit)
-            throws IOException {
+    public PolicyConstraintsExtension(Boolean critical, int require, int inhibit) {
         if (require == -1 && inhibit == -1) {
             throw new IllegalArgumentException(
                     "require and inhibit cannot both be -1");
@@ -192,10 +190,9 @@ public class PolicyConstraintsExtension extends Extension {
      * Write the extension to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (extensionValue == null) {
           extensionId = PKIXExtensions.PolicyConstraints_Id;
           critical = true;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyInformation.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyInformation.java
@@ -32,6 +32,7 @@ import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
 
@@ -60,7 +61,7 @@ import com.tencent.kona.sun.security.util.DerValue;
  * @author Anne Anderson
  * @since       1.4
  */
-public class PolicyInformation {
+public class PolicyInformation implements DerEncoder {
 
     // Attribute names
     public static final String NAME       = "PolicyInformation";
@@ -180,15 +181,15 @@ public class PolicyInformation {
      * Write the PolicyInformation to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         DerOutputStream tmp = new DerOutputStream();
         policyIdentifier.encode(tmp);
         if (!policyQualifiers.isEmpty()) {
             DerOutputStream tmp2 = new DerOutputStream();
             for (PolicyQualifierInfo pq : policyQualifiers) {
-                tmp2.write(pq.getEncoded());
+                byte[] bufBytes = pq.getEncoded();
+                tmp2.write(bufBytes, 0, bufBytes.length);
             }
             tmp.write(DerValue.tag_Sequence, tmp2);
         }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyMappingsExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyMappingsExtension.java
@@ -57,7 +57,7 @@ public class PolicyMappingsExtension extends Extension {
     private List<CertificatePolicyMap> maps;
 
     // Encode this extension value
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (maps == null || maps.isEmpty()) {
             this.extensionValue = null;
             return;
@@ -78,8 +78,7 @@ public class PolicyMappingsExtension extends Extension {
      *
      * @param maps the List of CertificatePolicyMap, cannot be null or empty.
      */
-    public PolicyMappingsExtension(List<CertificatePolicyMap> maps)
-            throws IOException {
+    public PolicyMappingsExtension(List<CertificatePolicyMap> maps) {
         if (maps == null || maps.isEmpty()) {
             throw new IllegalArgumentException("maps cannot be null or empty");
         }
@@ -129,10 +128,9 @@ public class PolicyMappingsExtension extends Extension {
      * Write the extension to the OutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.PolicyMappings_Id;
             critical = true;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PrivateKeyUsageExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PrivateKeyUsageExtension.java
@@ -70,7 +70,7 @@ public class PrivateKeyUsageExtension extends Extension {
     private Date        notAfter = null;
 
     // Encode this extension value.
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (notBefore == null && notAfter == null) {
             this.extensionValue = null;
             return;
@@ -103,8 +103,7 @@ public class PrivateKeyUsageExtension extends Extension {
      * @param notAfter the date/time after which the private key
      *         should not be used.
      */
-    public PrivateKeyUsageExtension(Date notBefore, Date notAfter)
-            throws IOException {
+    public PrivateKeyUsageExtension(Date notBefore, Date notAfter) {
         if (notBefore == null && notAfter == null) {
             throw new IllegalArgumentException(
                     "notBefore and notAfter cannot both be null");
@@ -232,10 +231,9 @@ public class PrivateKeyUsageExtension extends Extension {
      * Write the extension to the OutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.PrivateKeyUsage_Id;
             critical = false;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/RDN.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/RDN.java
@@ -337,9 +337,8 @@ public class RDN {
      * Encode the RDN in DER-encoded form.
      *
      * @param out DerOutputStream to which RDN is to be written
-     * @throws IOException on error
      */
-    void encode(DerOutputStream out) throws IOException {
+    void encode(DerOutputStream out) {
         out.putOrderedSetOf(DerValue.tag_Set, assertion);
     }
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/RFC822Name.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/RFC822Name.java
@@ -115,9 +115,8 @@ public class RFC822Name implements GeneralNameInterface
      * Encode the RFC822 name into the DerOutputStream.
      *
      * @param out the DER stream to encode the RFC822Name to.
-     * @exception IOException on encoding errors.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         out.putIA5String(name);
     }
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/ReasonFlags.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/ReasonFlags.java
@@ -28,6 +28,7 @@ package com.tencent.kona.sun.security.x509;
 import java.io.IOException;
 
 import com.tencent.kona.sun.security.util.BitArray;
+import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerInputStream;
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.util.DerValue;
@@ -53,7 +54,7 @@ import com.tencent.kona.sun.security.util.DerValue;
  *
  * @author Hemma Prafullchandra
  */
-public class ReasonFlags {
+public class ReasonFlags implements DerEncoder {
 
     /**
      * Reasons
@@ -231,9 +232,8 @@ public class ReasonFlags {
      * Write the extension to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         out.putTruncatedUnalignedBitString(new BitArray(this.bitString));
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SerialNumber.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SerialNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,9 +111,8 @@ public class SerialNumber {
      * Encode the SerialNumber in DER form to the stream.
      *
      * @param out the DerOutputStream to marshal the contents to.
-     * @exception IOException on errors.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         out.putInteger(serialNum);
     }
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectAlternativeNameExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectAlternativeNameExtension.java
@@ -58,7 +58,7 @@ public class SubjectAlternativeNameExtension extends Extension {
     GeneralNames        names;
 
     // Encode this extension
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (names == null || names.isEmpty()) {
             this.extensionValue = null;
             return;
@@ -73,10 +73,8 @@ public class SubjectAlternativeNameExtension extends Extension {
      * The extension is marked non-critical.
      *
      * @param names the GeneralNames for the subject.
-     * @exception IOException on error.
      */
-    public SubjectAlternativeNameExtension(GeneralNames names)
-            throws IOException {
+    public SubjectAlternativeNameExtension(GeneralNames names) {
         this(Boolean.FALSE, names);
     }
 
@@ -86,10 +84,8 @@ public class SubjectAlternativeNameExtension extends Extension {
      *
      * @param critical true if the extension is to be treated as critical.
      * @param names the GeneralNames for the subject, cannot be null or empty.
-     * @exception IOException on error.
      */
-    public SubjectAlternativeNameExtension(Boolean critical, GeneralNames names)
-            throws IOException {
+    public SubjectAlternativeNameExtension(Boolean critical, GeneralNames names) {
         if (names == null || names.isEmpty()) {
             throw new IllegalArgumentException("names cannot be null or empty");
         }
@@ -143,10 +139,9 @@ public class SubjectAlternativeNameExtension extends Extension {
      * Write the extension to the OutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.SubjectAlternativeName_Id;
             critical = false;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectInfoAccessExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectInfoAccessExtension.java
@@ -83,7 +83,7 @@ public class SubjectInfoAccessExtension extends Extension {
      * @throws IOException on error
      */
     public SubjectInfoAccessExtension(
-            List<AccessDescription> accessDescriptions) throws IOException {
+            List<AccessDescription> accessDescriptions) {
         if (accessDescriptions == null || accessDescriptions.isEmpty()) {
             throw new IllegalArgumentException(
                     "accessDescriptions cannot be null or empty");
@@ -143,10 +143,9 @@ public class SubjectInfoAccessExtension extends Extension {
      * Write the extension to the DerOutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.SubjectInfoAccess_Id;
             this.critical = false;
@@ -156,7 +155,7 @@ public class SubjectInfoAccessExtension extends Extension {
     }
 
     // Encode this extension value
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (accessDescriptions.isEmpty()) {
             this.extensionValue = null;
         } else {

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectKeyIdentifierExtension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SubjectKeyIdentifierExtension.java
@@ -58,7 +58,7 @@ public class SubjectKeyIdentifierExtension extends Extension {
     private KeyIdentifier id;
 
     // Encode this extension value
-    private void encodeThis() throws IOException {
+    private void encodeThis() {
         if (id == null) {
             this.extensionValue = null;
             return;
@@ -73,8 +73,7 @@ public class SubjectKeyIdentifierExtension extends Extension {
      * The criticality is set to False.
      * @param octetString the octet string identifying the key identifier.
      */
-    public SubjectKeyIdentifierExtension(byte[] octetString)
-            throws IOException {
+    public SubjectKeyIdentifierExtension(byte[] octetString) {
         id = new KeyIdentifier(octetString);
 
         this.extensionId = PKIXExtensions.SubjectKey_Id;
@@ -111,10 +110,9 @@ public class SubjectKeyIdentifierExtension extends Extension {
      * Write the extension to the OutputStream.
      *
      * @param out the DerOutputStream to write the extension to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.SubjectKey_Id;
             critical = false;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/URIName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/URIName.java
@@ -198,9 +198,8 @@ public class URIName implements GeneralNameInterface {
      * Encode the URI name into the DerOutputStream.
      *
      * @param out the DER stream to encode the URIName to.
-     * @exception IOException on encoding errors.
      */
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         out.putIA5String(uri.toASCIIString());
     }
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/UniqueIdentity.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/UniqueIdentity.java
@@ -92,9 +92,8 @@ public class UniqueIdentity {
      *
      * @param out the DerOutputStream to marshal the contents to.
      * @param tag encode it under the following tag.
-     * @exception IOException on errors.
      */
-    public void encode(DerOutputStream out, byte tag) throws IOException {
+    public void encode(DerOutputStream out, byte tag) {
         byte[] bytes = id.toByteArray();
         int excessBits = bytes.length*8 - id.length();
 
@@ -102,7 +101,7 @@ public class UniqueIdentity {
         out.putLength(bytes.length + 1);
 
         out.write(excessBits);
-        out.write(bytes);
+        out.write(bytes, 0, bytes.length);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X400Address.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X400Address.java
@@ -365,10 +365,9 @@ public class X400Address implements GeneralNameInterface {
      * Encode the X400 name into the DerOutputStream.
      *
      * @param out the DER stream to encode the X400Address to.
-     * @exception IOException on encoding errors.
      */
     @Override
-    public void encode(DerOutputStream out) throws IOException {
+    public void encode(DerOutputStream out) {
         out.putDerValue(derValue);
     }
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X500Name.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X500Name.java
@@ -830,7 +830,8 @@ public class X500Name implements GeneralNameInterface, Principal {
      *
      * @param out where to put the DER-encoded X.500 name
      */
-    public void encode(DerOutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) {
         DerOutputStream tmp = new DerOutputStream();
         for (int i = 0; i < names.length; i++) {
             names[i].encode(tmp);

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLEntryImpl.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLEntryImpl.java
@@ -157,47 +157,40 @@ public class X509CRLEntryImpl extends X509CRLEntry
      *
      * @param outStrm an output stream to which the encoded revoked
      * certificate is written.
-     * @exception CRLException on encoding errors.
      */
-    public void encode(DerOutputStream outStrm) throws CRLException {
-        try {
-            if (revokedCert == null) {
-                DerOutputStream tmp = new DerOutputStream();
-                // sequence { serialNumber, revocationDate, extensions }
-                serialNumber.encode(tmp);
+    public void encode(DerOutputStream outStrm) {
+        if (revokedCert == null) {
+            DerOutputStream tmp = new DerOutputStream();
+            // sequence { serialNumber, revocationDate, extensions }
+            serialNumber.encode(tmp);
 
-                if (revocationDate.getTime() < CertificateValidity.YR_2050) {
-                    tmp.putUTCTime(revocationDate);
-                } else {
-                    tmp.putGeneralizedTime(revocationDate);
-                }
-
-                if (extensions != null)
-                    extensions.encode(tmp, isExplicit);
-
-                DerOutputStream seq = new DerOutputStream();
-                seq.write(DerValue.tag_Sequence, tmp);
-
-                revokedCert = seq.toByteArray();
+            if (revocationDate.getTime() < CertificateValidity.YR_2050) {
+                tmp.putUTCTime(revocationDate);
+            } else {
+                tmp.putGeneralizedTime(revocationDate);
             }
-            outStrm.write(revokedCert);
-        } catch (IOException e) {
-            throw new CRLException("Encoding error: " + e.toString());
+
+            if (extensions != null)
+                extensions.encode(tmp, isExplicit);
+
+            DerOutputStream seq = new DerOutputStream();
+            seq.write(DerValue.tag_Sequence, tmp);
+
+            revokedCert = seq.toByteArray();
         }
+        outStrm.write(revokedCert, 0, revokedCert.length);
     }
 
     /**
      * Returns the ASN.1 DER-encoded form of this CRL Entry,
      * which corresponds to the inner SEQUENCE.
-     *
-     * @exception CRLException if an encoding error occurs.
      */
-    public byte[] getEncoded() throws CRLException {
+    public byte[] getEncoded() {
         return getEncoded0().clone();
     }
 
     // Called internally to avoid clone
-    private byte[] getEncoded0() throws CRLException {
+    private byte[] getEncoded0() {
         if (revokedCert == null)
             this.encode(new DerOutputStream());
         return revokedCert;
@@ -529,17 +522,13 @@ public class X509CRLEntryImpl extends X509CRLEntry
         if (compSerial != 0) {
             return compSerial;
         }
-        try {
-            byte[] thisEncoded = this.getEncoded0();
-            byte[] thatEncoded = that.getEncoded0();
-            for (int i=0; i<thisEncoded.length && i<thatEncoded.length; i++) {
-                int a = thisEncoded[i] & 0xff;
-                int b = thatEncoded[i] & 0xff;
-                if (a != b) return a-b;
-            }
-            return thisEncoded.length -thatEncoded.length;
-        } catch (CRLException ce) {
-            return -1;
+        byte[] thisEncoded = this.getEncoded0();
+        byte[] thatEncoded = that.getEncoded0();
+        for (int i=0; i<thisEncoded.length && i<thatEncoded.length; i++) {
+            int a = thisEncoded[i] & 0xff;
+            int b = thatEncoded[i] & 0xff;
+            if (a != b) return a-b;
         }
+        return thisEncoded.length -thatEncoded.length;
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLImpl.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLImpl.java
@@ -306,48 +306,43 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
          * @exception CRLException on encoding errors.
          */
         public byte[] encodeInfo() throws CRLException {
-            try {
-                DerOutputStream tmp = new DerOutputStream();
-                DerOutputStream rCerts = new DerOutputStream();
-                DerOutputStream seq = new DerOutputStream();
+            DerOutputStream tmp = new DerOutputStream();
+            DerOutputStream rCerts = new DerOutputStream();
+            DerOutputStream seq = new DerOutputStream();
 
-                if (version != 0) // v2 crl encode version
-                    tmp.putInteger(version);
-                infoSigAlgId.encode(tmp);
-                if ((version == 0) && (issuer.toString() == null))
-                    throw new CRLException("Null Issuer DN not allowed in v1 CRL");
-                issuer.encode(tmp);
+            if (version != 0) // v2 crl encode version
+                tmp.putInteger(version);
+            infoSigAlgId.encode(tmp);
+            if ((version == 0) && (issuer.toString() == null))
+                throw new CRLException("Null Issuer DN not allowed in v1 CRL");
+            issuer.encode(tmp);
 
-                if (thisUpdate.getTime() < CertificateValidity.YR_2050)
-                    tmp.putUTCTime(thisUpdate);
+            if (thisUpdate.getTime() < CertificateValidity.YR_2050)
+                tmp.putUTCTime(thisUpdate);
+            else
+                tmp.putGeneralizedTime(thisUpdate);
+
+            if (nextUpdate != null) {
+                if (nextUpdate.getTime() < CertificateValidity.YR_2050)
+                    tmp.putUTCTime(nextUpdate);
                 else
-                    tmp.putGeneralizedTime(thisUpdate);
-
-                if (nextUpdate != null) {
-                    if (nextUpdate.getTime() < CertificateValidity.YR_2050)
-                        tmp.putUTCTime(nextUpdate);
-                    else
-                        tmp.putGeneralizedTime(nextUpdate);
-                }
-
-                if (!revokedList.isEmpty()) {
-                    for (X509CRLEntry entry : revokedList) {
-                        ((X509CRLEntryImpl)entry).encode(rCerts);
-                    }
-                    tmp.write(DerValue.tag_Sequence, rCerts);
-                }
-
-                if (extensions != null)
-                    extensions.encode(tmp, isExplicit);
-
-                seq.write(DerValue.tag_Sequence, tmp);
-
-                return seq.toByteArray();
-            } catch (IOException e) {
-                throw new CRLException("Encoding error: " + e.getMessage());
+                    tmp.putGeneralizedTime(nextUpdate);
             }
-        }
 
+            if (!revokedList.isEmpty()) {
+                for (X509CRLEntry entry : revokedList) {
+                    ((X509CRLEntryImpl) entry).encode(rCerts);
+                }
+                tmp.write(DerValue.tag_Sequence, rCerts);
+            }
+
+            if (extensions != null)
+                extensions.encode(tmp, isExplicit);
+
+            seq.write(DerValue.tag_Sequence, tmp);
+
+            return seq.toByteArray();
+        }
     }
 
     private static final boolean isExplicit = true;
@@ -609,36 +604,31 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
     public static X509CRLImpl newSigned(TBSCertList info, PrivateKey key, String algorithm, String provider)
             throws CRLException, NoSuchAlgorithmException, InvalidKeyException,
                    NoSuchProviderException, SignatureException {
-        try {
-            Signature sigEngine = SignatureUtil.fromKey(algorithm, key, provider);
-            AlgorithmId sigAlgId = SignatureUtil.fromSignature(sigEngine, key);
-            info.infoSigAlgId = sigAlgId;
+        Signature sigEngine = SignatureUtil.fromKey(algorithm, key, provider);
+        AlgorithmId sigAlgId = SignatureUtil.fromSignature(sigEngine, key);
+        info.infoSigAlgId = sigAlgId;
 
-            DerOutputStream out = new DerOutputStream();
-            DerOutputStream tmp = new DerOutputStream();
+        DerOutputStream out = new DerOutputStream();
+        DerOutputStream tmp = new DerOutputStream();
 
-            // encode crl info
-            byte[] tbsCertList = info.encodeInfo();
-            tmp.write(tbsCertList, 0, tbsCertList.length);
+        // encode crl info
+        byte[] tbsCertList = info.encodeInfo();
+        tmp.write(tbsCertList, 0, tbsCertList.length);
 
-            // encode algorithm identifier
-            sigAlgId.encode(tmp);
+        // encode algorithm identifier
+        sigAlgId.encode(tmp);
 
-            // Create and encode the signature itself.
-            sigEngine.update(tbsCertList, 0, tbsCertList.length);
-            byte[] signature = sigEngine.sign();
-            tmp.putBitString(signature);
+        // Create and encode the signature itself.
+        sigEngine.update(tbsCertList, 0, tbsCertList.length);
+        byte[] signature = sigEngine.sign();
+        tmp.putBitString(signature);
 
-            // Wrap the signed data in a SEQUENCE { data, algorithm, sig }
-            out.write(DerValue.tag_Sequence, tmp);
-            byte[] signedCRL = out.toByteArray();
+        // Wrap the signed data in a SEQUENCE { data, algorithm, sig }
+        out.write(DerValue.tag_Sequence, tmp);
+        byte[] signedCRL = out.toByteArray();
 
-            return new X509CRLImpl(info, sigAlgId, signature,
-                    tbsCertList, signedCRL);
-        } catch (IOException e) {
-            throw new CRLException("Error while encoding data: " +
-                                   e.getMessage());
-        }
+        return new X509CRLImpl(info, sigAlgId, signature,
+                tbsCertList, signedCRL);
     }
 
     /**
@@ -1251,8 +1241,9 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
     }
 
     @Override
-    public void encode(DerOutputStream out) throws IOException {
-        out.write(signedCRL.clone());
+    public void encode(DerOutputStream out) {
+        byte[] bytes = signedCRL.clone();
+        out.write(bytes, 0, bytes.length);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertInfo.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertInfo.java
@@ -148,12 +148,13 @@ public class X509CertInfo {
      * @exception IOException on other errors.
      */
     public void encode(DerOutputStream out)
-            throws CertificateException, IOException {
+            throws CertificateException {
         if (rawCertInfo == null) {
             emit(out);
             rawCertInfo = out.toByteArray();
         } else {
-            out.write(rawCertInfo.clone());
+            byte[] bytes = rawCertInfo.clone();
+            out.write(bytes, 0, bytes.length);
         }
     }
 
@@ -177,7 +178,7 @@ public class X509CertInfo {
                 rawCertInfo = tmp.toByteArray();
             }
             return rawCertInfo.clone();
-        } catch (IOException | CertificateException e) {
+        } catch (CertificateException e) {
             throw new CertificateEncodingException(e.toString());
         }
     }
@@ -471,8 +472,7 @@ public class X509CertInfo {
     /*
      * Marshal the contents of a "raw" certificate into a DER sequence.
      */
-    private void emit(DerOutputStream out)
-            throws CertificateException, IOException {
+    private void emit(DerOutputStream out) throws CertificateException {
         DerOutputStream tmp = new DerOutputStream();
 
         // version number, iff not V1


### PR DESCRIPTION
This is a backport of [JDK-8297065]: DerOutputStream operations should not throw IOExceptions.

This PR will resolve #99.

[JDK-8297065]:
<https://bugs.openjdk.org/browse/JDK-8297065>