### PR TITLE
TKSS-110: Backport JDK-8281236: (D)TLS key exchange named groups

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateVerify.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateVerify.java
@@ -592,6 +592,7 @@ final class CertificateVerify {
             ClientHandshakeContext chc = (ClientHandshakeContext)context;
             Map.Entry<SignatureScheme, Signature> schemeAndSigner =
                     SignatureScheme.getSignerOfPreferableAlgorithm(
+                    chc.sslConfig,
                     chc.algorithmConstraints,
                     chc.peerRequestedSignatureSchemes,
                     x509Possession,
@@ -911,6 +912,7 @@ final class CertificateVerify {
 
             Map.Entry<SignatureScheme, Signature> schemeAndSigner =
                     SignatureScheme.getSignerOfPreferableAlgorithm(
+                    context.sslConfig,
                     context.algorithmConstraints,
                     context.peerRequestedSignatureSchemes,
                     x509Possession,

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/DHKeyExchange.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/DHKeyExchange.java
@@ -43,7 +43,7 @@ import javax.crypto.spec.DHPublicKeySpec;
 
 import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.sun.security.action.GetPropertyAction;
-import com.tencent.kona.sun.security.ssl.SupportedGroupsExtension.SupportedGroups;
+import com.tencent.kona.sun.security.ssl.NamedGroup.NamedGroupSpec;
 import com.tencent.kona.sun.security.util.KeyUtil;
 
 final class DHKeyExchange {
@@ -314,12 +314,13 @@ final class DHKeyExchange {
             if (!useLegacyEphemeralDHKeys &&
                     (context.clientRequestedNamedGroups != null) &&
                     (!context.clientRequestedNamedGroups.isEmpty())) {
-                preferableNamedGroup =
-                        SupportedGroups.getPreferredGroup(context.negotiatedProtocol,
-                                context.algorithmConstraints,
-                                new NamedGroup.NamedGroupSpec[] {
-                                    NamedGroup.NamedGroupSpec.NAMED_GROUP_FFDHE },
-                                context.clientRequestedNamedGroups);
+                preferableNamedGroup = NamedGroup.getPreferredGroup(
+                        context.sslConfig,
+                        context.negotiatedProtocol,
+                        context.algorithmConstraints,
+                        new NamedGroupSpec [] {
+                            NamedGroupSpec.NAMED_GROUP_FFDHE },
+                        context.clientRequestedNamedGroups);
                 if (preferableNamedGroup != null) {
                     return new DHEPossession(preferableNamedGroup,
                                 context.sslContext.getSecureRandom());

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/DHServerKeyExchange.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/DHServerKeyExchange.java
@@ -125,6 +125,7 @@ final class DHServerKeyExchange {
                 if (useExplicitSigAlgorithm) {
                     Map.Entry<SignatureScheme, Signature> schemeAndSigner =
                             SignatureScheme.getSignerOfPreferableAlgorithm(
+                                    shc.sslConfig,
                                     shc.algorithmConstraints,
                                     shc.peerRequestedSignatureSchemes,
                                     x509Possession,

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ECDHKeyExchange.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ECDHKeyExchange.java
@@ -237,14 +237,16 @@ final class ECDHKeyExchange {
             // Find most preferred EC or XEC groups
             if ((context.clientRequestedNamedGroups != null) &&
                     (!context.clientRequestedNamedGroups.isEmpty())) {
-                preferableNamedGroup = SupportedGroupsExtension.SupportedGroups.getPreferredGroup(
+                preferableNamedGroup = NamedGroup.getPreferredGroup(
+                        context.sslConfig,
                         context.negotiatedProtocol,
                         context.algorithmConstraints,
                         new NamedGroup.NamedGroupSpec[] {
                             NamedGroup.NamedGroupSpec.NAMED_GROUP_ECDHE },
                         context.clientRequestedNamedGroups);
             } else {
-                preferableNamedGroup = SupportedGroupsExtension.SupportedGroups.getPreferredGroup(
+                preferableNamedGroup = NamedGroup.getPreferredGroup(
+                        context.sslConfig,
                         context.negotiatedProtocol,
                         context.algorithmConstraints,
                         new NamedGroup.NamedGroupSpec[] {

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ECDHServerKeyExchange.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ECDHServerKeyExchange.java
@@ -137,6 +137,7 @@ final class ECDHServerKeyExchange {
                 if (useExplicitSigAlgorithm) {
                     Map.Entry<SignatureScheme, Signature> schemeAndSigner =
                             SignatureScheme.getSignerOfPreferableAlgorithm(
+                                shc.sslConfig,
                                 shc.algorithmConstraints,
                                 shc.peerRequestedSignatureSchemes,
                                 x509Possession,
@@ -202,7 +203,7 @@ final class ECDHServerKeyExchange {
                     "Unknown named group ID: " + namedGroupId);
             }
 
-            if (!SupportedGroupsExtension.SupportedGroups.isSupported(namedGroup)) {
+            if (!NamedGroup.isEnabled(chc.sslConfig, namedGroup)) {
                 throw chc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
                     "Unsupported named group: " + namedGroup);
             }

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/KeyShareExtension.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/KeyShareExtension.java
@@ -345,7 +345,7 @@ final class KeyShareExtension {
             List<SSLCredentials> credentials = new LinkedList<>();
             for (KeyShareEntry entry : spec.clientShares) {
                 NamedGroup ng = NamedGroup.valueOf(entry.namedGroupId);
-                if (ng == null || !SupportedGroupsExtension.SupportedGroups.isActivatable(
+                if (ng == null || !NamedGroup.isActivatable(shc.sslConfig,
                         shc.algorithmConstraints, ng)) {
                     if (SSLLogger.isOn &&
                             SSLLogger.isOn("ssl,handshake")) {
@@ -648,7 +648,7 @@ final class KeyShareExtension {
             SHKeyShareSpec spec = new SHKeyShareSpec(chc, buffer);
             KeyShareEntry keyShare = spec.serverShare;
             NamedGroup ng = NamedGroup.valueOf(keyShare.namedGroupId);
-            if (ng == null || !SupportedGroupsExtension.SupportedGroups.isActivatable(
+            if (ng == null || !NamedGroup.isActivatable(chc.sslConfig,
                     chc.algorithmConstraints, ng)) {
                 throw chc.conContext.fatal(Alert.UNEXPECTED_MESSAGE,
                         "Unsupported named group: " +
@@ -802,7 +802,7 @@ final class KeyShareExtension {
 
             NamedGroup selectedGroup = null;
             for (NamedGroup ng : shc.clientRequestedNamedGroups) {
-                if (SupportedGroupsExtension.SupportedGroups.isActivatable(
+                if (NamedGroup.isActivatable(shc.sslConfig,
                         shc.algorithmConstraints, ng)) {
                     if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
                         SSLLogger.fine(

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/NamedGroup.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/NamedGroup.java
@@ -28,12 +28,14 @@ import javax.crypto.spec.DHParameterSpec;
 import java.io.IOException;
 import java.security.*;
 import java.security.spec.*;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
 import com.tencent.kona.crypto.CryptoInsts;
+import com.tencent.kona.sun.security.action.GetPropertyAction;
 import com.tencent.kona.sun.security.util.CurveDB;
 
 
@@ -245,9 +247,9 @@ enum NamedGroup {
 
     // Constructor used for all NamedGroup types
     NamedGroup(int id, String name,
-               NamedGroupSpec namedGroupSpec,
-               ProtocolVersion[] supportedProtocols,
-               AlgorithmParameterSpec keAlgParamSpec) {
+            NamedGroupSpec namedGroupSpec,
+            ProtocolVersion[] supportedProtocols,
+            AlgorithmParameterSpec keAlgParamSpec) {
         this.id = id;
         this.name = name;
         this.spec = namedGroupSpec;
@@ -388,6 +390,126 @@ enum NamedGroup {
         }
 
         return "UNDEFINED-NAMED-GROUP(" + id + ")";
+    }
+
+    public static List<NamedGroup> namesOf(String[] namedGroups) {
+        if (namedGroups == null) {
+            return null;
+        }
+
+        if (namedGroups.length == 0) {
+            return Collections.emptyList();
+        }
+
+        List<NamedGroup> ngs = new ArrayList<>(namedGroups.length);
+        for (String ss : namedGroups) {
+            NamedGroup ng = NamedGroup.nameOf(ss);
+            if (ng == null || !ng.isAvailable) {
+                if (SSLLogger.isOn &&
+                        SSLLogger.isOn("ssl,handshake,verbose")) {
+                    SSLLogger.finest(
+                            "Ignore the named group (" + ss
+                                    + "), unsupported or unavailable");
+                }
+
+                continue;
+            }
+
+            ngs.add(ng);
+        }
+
+        return Collections.unmodifiableList(ngs);
+    }
+
+    // Is there any supported group permitted by the constraints?
+    static boolean isActivatable(SSLConfiguration sslConfig,
+            AlgorithmConstraints constraints, NamedGroupSpec type) {
+
+        boolean hasFFDHEGroups = false;
+        for (String ng : sslConfig.namedGroups) {
+            NamedGroup namedGroup = NamedGroup.nameOf(ng);
+            if (namedGroup != null &&
+                namedGroup.isAvailable && namedGroup.spec == type) {
+                if (namedGroup.isPermitted(constraints)) {
+                    return true;
+                }
+
+                if (!hasFFDHEGroups &&
+                        (type == NamedGroupSpec.NAMED_GROUP_FFDHE)) {
+                    hasFFDHEGroups = true;
+                }
+            }
+        }
+
+        // For compatibility, if no FFDHE groups are defined, the non-FFDHE
+        // compatible mode (using DHE cipher suite without FFDHE extension)
+        // is allowed.
+        //
+        // Note that the constraints checking on DHE parameters will be
+        // performed during key exchanging in a handshake.
+        return !hasFFDHEGroups && type == NamedGroupSpec.NAMED_GROUP_FFDHE;
+    }
+
+    // Is the named group permitted by the constraints?
+    static boolean isActivatable(
+            SSLConfiguration sslConfig,
+            AlgorithmConstraints constraints, NamedGroup namedGroup) {
+        if (!namedGroup.isAvailable || !isEnabled(sslConfig, namedGroup)) {
+            return false;
+        }
+
+        return namedGroup.isPermitted(constraints);
+    }
+
+    // Is the named group supported?
+    static boolean isEnabled(SSLConfiguration sslConfig,
+                             NamedGroup namedGroup) {
+        for (String ng : sslConfig.namedGroups) {
+            if (namedGroup.name.equalsIgnoreCase(ng)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Get preferred named group from the configured named groups for the
+    // negotiated protocol and named group types.
+    static NamedGroup getPreferredGroup(
+            SSLConfiguration sslConfig,
+            ProtocolVersion negotiatedProtocol,
+            AlgorithmConstraints constraints, NamedGroupSpec[] types) {
+        for (String name : sslConfig.namedGroups) {
+            NamedGroup ng = NamedGroup.nameOf(name);
+            if (ng != null && ng.isAvailable &&
+                    (NamedGroupSpec.arrayContains(types, ng.spec)) &&
+                    ng.isAvailable(negotiatedProtocol) &&
+                    ng.isPermitted(constraints)) {
+                return ng;
+            }
+        }
+
+        return null;
+    }
+
+    // Get preferred named group from the requested and configured named
+    // groups for the negotiated protocol and named group types.
+    static NamedGroup getPreferredGroup(
+            SSLConfiguration sslConfig,
+            ProtocolVersion negotiatedProtocol,
+            AlgorithmConstraints constraints, NamedGroupSpec[] types,
+            List<NamedGroup> requestedNamedGroups) {
+        for (NamedGroup namedGroup : requestedNamedGroups) {
+            if ((namedGroup.isAvailable &&
+                    NamedGroupSpec.arrayContains(types, namedGroup.spec)) &&
+                    namedGroup.isAvailable(negotiatedProtocol) &&
+                    isEnabled(sslConfig, namedGroup) &&
+                    namedGroup.isPermitted(constraints)) {
+                return namedGroup;
+            }
+        }
+
+        return null;
     }
 
     // Is the NamedGroup available for the protocols desired?
@@ -607,6 +729,91 @@ enum NamedGroup {
         public SSLKeyDerivation createKeyDerivation(
                 HandshakeContext hc) throws IOException {
             return ECDHKeyExchange.ecdheKAGenerator.createKeyDerivation(hc);
+        }
+    }
+
+    static final class SupportedGroups {
+        // the supported named groups, non-null immutable list
+        static final String[] namedGroups;
+
+        static {
+            // The value of the System Property defines a list of enabled named
+            // groups in preference order, separated with comma.  For example:
+            //
+            //      jdk.tls.namedGroups="secp521r1, secp256r1, ffdhe2048"
+            //
+            // If the System Property is not defined or the value is empty, the
+            // default groups and preferences will be used.
+            String property = GetPropertyAction
+                    .privilegedGetProperty("jdk.tls.namedGroups");
+            if (property != null && !property.isEmpty()) {
+                // remove double quote marks from beginning/end of the property
+                if (property.length() > 1 && property.charAt(0) == '"' &&
+                        property.charAt(property.length() - 1) == '"') {
+                    property = property.substring(1, property.length() - 1);
+                }
+            }
+
+            ArrayList<String> groupList;
+            if (property != null && !property.isEmpty()) {
+                String[] groups = property.split(",");
+                groupList = new ArrayList<>(groups.length);
+                for (String group : groups) {
+                    group = group.trim();
+                    if (!group.isEmpty()) {
+                        NamedGroup namedGroup = nameOf(group);
+                        if (namedGroup != null) {
+                            if (namedGroup.isAvailable) {
+                                groupList.add(namedGroup.name);
+                            }
+                        }   // ignore unknown groups
+                    }
+                }
+
+                if (groupList.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "System property jdk.tls.namedGroups(" +
+                            property + ") contains no supported named groups");
+                }
+            } else {        // default groups
+                NamedGroup[] groups = new NamedGroup[] {
+
+                        // Primary XDH (RFC 7748) curves
+//                        X25519,
+
+                        // Primary NIST Suite B curves
+                        SECP256_R1,
+                        SECP384_R1,
+                        SECP521_R1,
+
+                        // SM2 curve
+                        CURVESM2,
+
+                        // Secondary XDH curves
+//                        X448,
+
+                        // FFDHE (RFC 7919)
+//                        FFDHE_2048,
+//                        FFDHE_3072,
+//                        FFDHE_4096,
+//                        FFDHE_6144,
+//                        FFDHE_8192,
+                    };
+
+                groupList = new ArrayList<>(groups.length);
+                for (NamedGroup group : groups) {
+                    if (group.isAvailable) {
+                        groupList.add(group.name);
+                    }
+                }
+
+                if (groupList.isEmpty() &&
+                        SSLLogger.isOn && SSLLogger.isOn("ssl")) {
+                    SSLLogger.warning("No default named groups");
+                }
+            }
+
+            namedGroups = groupList.toArray(new String[0]);
         }
     }
 }

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2EKeyExchange.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2EKeyExchange.java
@@ -214,14 +214,16 @@ public class SM2EKeyExchange {
             // Find most preferred EC or XEC groups
             if ((context.clientRequestedNamedGroups != null) &&
                     (!context.clientRequestedNamedGroups.isEmpty())) {
-                preferableNamedGroup = SupportedGroupsExtension.SupportedGroups.getPreferredGroup(
+                preferableNamedGroup = NamedGroup.getPreferredGroup(
+                        context.sslConfig,
                         context.negotiatedProtocol,
                         context.algorithmConstraints,
                         new NamedGroup.NamedGroupSpec[] {
                             NamedGroup.NamedGroupSpec.NAMED_GROUP_ECDHE },
                         context.clientRequestedNamedGroups);
             } else {
-                preferableNamedGroup = SupportedGroupsExtension.SupportedGroups.getPreferredGroup(
+                preferableNamedGroup = NamedGroup.getPreferredGroup(
+                        context.sslConfig,
                         context.negotiatedProtocol,
                         context.algorithmConstraints,
                         new NamedGroup.NamedGroupSpec[] {

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2EServerKeyExchange.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2EServerKeyExchange.java
@@ -111,6 +111,7 @@ public class SM2EServerKeyExchange {
             if (useExplicitSigAlgorithm) {
                 Map.Entry<SignatureScheme, Signature> schemeAndSigner =
                         SignatureScheme.getSignerOfPreferableAlgorithm(
+                            shc.sslConfig,
                             shc.algorithmConstraints,
                             shc.peerRequestedSignatureSchemes,
                             sm2ePossession.popEncPrivateKey,
@@ -185,7 +186,7 @@ public class SM2EServerKeyExchange {
                     "Unknown named group ID: " + namedGroupId);
             }
 
-            if (!SupportedGroupsExtension.SupportedGroups.isSupported(namedGroup)) {
+            if (!NamedGroup.isEnabled(chc.sslConfig, namedGroup)) {
                 throw chc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
                     "Unsupported named group: " + namedGroup);
             }

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLConfiguration.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLConfiguration.java
@@ -67,6 +67,9 @@ final class SSLConfiguration implements Cloneable {
     // "signature_algorithms_cert" extensions
     List<SignatureScheme>       signatureSchemes;
 
+    // the configured named groups for the "supported_groups" extensions
+    String[]                   namedGroups;
+
     // the maximum protocol version of enabled protocols
     ProtocolVersion             maximumProtocolVersion;
 
@@ -112,6 +115,10 @@ final class SSLConfiguration implements Cloneable {
     static final int maxCertificateChainLength = Utilities.privilegedGetIntegerProperty(
             "com.tencent.kona.ssl.maxCertificateChainLength", 10);
 
+    // To switch off the supported_groups extension for DHE cipher suite.
+    static final boolean enableFFDHE =
+            Utilities.getBooleanProperty("jsse.enableFFDHE", true);
+
     // Is the extended_master_secret extension supported?
     static {
         boolean supportExtendedMasterSecret = Utilities.getBooleanProperty(
@@ -149,6 +156,7 @@ final class SSLConfiguration implements Cloneable {
         this.signatureSchemes = isClientMode ?
                 CustomizedClientSignatureSchemes.signatureSchemes :
                 CustomizedServerSignatureSchemes.signatureSchemes;
+        this.namedGroups = NamedGroup.SupportedGroups.namedGroups;
         this.maximumProtocolVersion = ProtocolVersion.NONE;
         for (ProtocolVersion pv : enabledProtocols) {
             if (pv.compareTo(maximumProtocolVersion) > 0) {
@@ -259,6 +267,18 @@ final class SSLConfiguration implements Cloneable {
         if (sa != null) {
             this.applicationProtocols = sa;
         }   // otherwise, use the default values
+
+//        String[] ngs = params.getNamedGroups();
+//        if (ngs != null) {
+//            // Note if 'ngs' is empty, then no named groups should be
+//            // specified over the connections.
+//            this.namedGroups = ngs;
+//        } else {    // Otherwise, use the default values.
+//            this.namedGroups = NamedGroup.SupportedGroups.namedGroups;
+//        }
+        // Just use the default named groups
+        // due to the new APIs on namedGroups in SSLParameters are not supported
+        this.namedGroups = NamedGroup.SupportedGroups.namedGroups;
 
         this.preferLocalCipherSuites = params.getUseCipherSuitesOrder();
 //        this.enableRetransmissions = params.getEnableRetransmissions();

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLKeyExchange.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLKeyExchange.java
@@ -590,23 +590,13 @@ final class SSLKeyExchange implements SSLKeyAgreementGenerator,
 
     private static final class T13KeyAgreement implements SSLKeyAgreement {
         private final NamedGroup namedGroup;
-        static final Map<NamedGroup, T13KeyAgreement>
-                supportedKeyShares = new HashMap<>();
-
-        static {
-            for (NamedGroup namedGroup :
-                    SupportedGroupsExtension.SupportedGroups.supportedNamedGroups) {
-                supportedKeyShares.put(
-                        namedGroup, new T13KeyAgreement(namedGroup));
-            }
-        }
 
         private T13KeyAgreement(NamedGroup namedGroup) {
             this.namedGroup = namedGroup;
         }
 
         static T13KeyAgreement valueOf(NamedGroup namedGroup) {
-            return supportedKeyShares.get(namedGroup);
+            return new T13KeyAgreement(namedGroup);
         }
 
         @Override

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SupportedGroupsExtension.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SupportedGroupsExtension.java
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.ssl;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.security.AlgorithmConstraints;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,7 +34,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import javax.net.ssl.SSLProtocolException;
-import com.tencent.kona.sun.security.action.GetPropertyAction;
+import com.tencent.kona.sun.security.ssl.NamedGroup.NamedGroupSpec;
+import com.tencent.kona.sun.security.ssl.NamedGroup.SupportedGroups;
 
 /**
  * Pack of the "supported_groups" extensions [RFC 4492/7919].
@@ -147,173 +147,6 @@ final class SupportedGroupsExtension {
         }
     }
 
-    static class SupportedGroups {
-        // To switch off the supported_groups extension for DHE cipher suite.
-        static final boolean enableFFDHE =
-                Utilities.getBooleanProperty("jsse.enableFFDHE", true);
-
-        // the supported named groups
-        static final NamedGroup[] supportedNamedGroups;
-
-        static {
-            // The value of the System Property defines a list of enabled named
-            // groups in preference order, separated with comma.  For example:
-            //
-            //      com.tencent.kona.ssl.namedGroups="secp521r1, secp256r1, ffdhe2048"
-            //
-            // If the System Property is not defined or the value is empty, the
-            // default groups and preferences will be used.
-            String property = GetPropertyAction
-                    .privilegedGetProperty("com.tencent.kona.ssl.namedGroups");
-            if (property != null && !property.isEmpty()) {
-                // remove double quote marks from beginning/end of the property
-                if (property.length() > 1 && property.charAt(0) == '"' &&
-                        property.charAt(property.length() - 1) == '"') {
-                    property = property.substring(1, property.length() - 1);
-                }
-            }
-
-            ArrayList<NamedGroup> groupList;
-            if (property != null && !property.isEmpty()) {
-                String[] groups = property.split(",");
-                groupList = new ArrayList<>(groups.length);
-                for (String group : groups) {
-                    group = group.trim();
-                    if (!group.isEmpty()) {
-                        NamedGroup namedGroup = NamedGroup.nameOf(group);
-                        if (namedGroup != null) {
-                            if (namedGroup.isAvailable) {
-                                groupList.add(namedGroup);
-                            }
-                        }   // ignore unknown groups
-                    }
-                }
-
-                if (groupList.isEmpty()) {
-                    throw new IllegalArgumentException(
-                            "System property com.tencent.kona.ssl.namedGroups(" +
-                            property + ") contains no supported named groups");
-                }
-            } else {        // default groups
-                NamedGroup[] groups = new NamedGroup[] {
-
-                        // SM2 curves
-                        NamedGroup.CURVESM2,
-                        NamedGroup.SM2P256V1,
-                        NamedGroup.TA_SM2CURVE,
-
-                        // Primary NIST Suite B curves
-                        NamedGroup.SECP256_R1,
-                        NamedGroup.SECP384_R1,
-                        NamedGroup.SECP521_R1,
-
-                        // FFDHE (RFC 7919)
-//                        NamedGroup.FFDHE_2048,
-//                        NamedGroup.FFDHE_3072,
-//                        NamedGroup.FFDHE_4096,
-//                        NamedGroup.FFDHE_6144,
-//                        NamedGroup.FFDHE_8192,
-                    };
-
-                groupList = new ArrayList<>(groups.length);
-                for (NamedGroup group : groups) {
-                    if (group.isAvailable) {
-                        groupList.add(group);
-                    }
-                }
-
-                if (groupList.isEmpty() &&
-                        SSLLogger.isOn && SSLLogger.isOn("ssl")) {
-                    SSLLogger.warning("No default named groups");
-                }
-            }
-
-            supportedNamedGroups = new NamedGroup[groupList.size()];
-            int i = 0;
-            for (NamedGroup namedGroup : groupList) {
-                supportedNamedGroups[i++] = namedGroup;
-            }
-        }
-
-        // Is there any supported group permitted by the constraints?
-        static boolean isActivatable(
-                AlgorithmConstraints constraints, NamedGroup.NamedGroupSpec type) {
-
-            boolean hasFFDHEGroups = false;
-            for (NamedGroup namedGroup : supportedNamedGroups) {
-                if (namedGroup.isAvailable && namedGroup.spec == type) {
-                    if (namedGroup.isPermitted(constraints)) {
-                        return true;
-                    }
-
-                    if (!hasFFDHEGroups &&
-                            (type == NamedGroup.NamedGroupSpec.NAMED_GROUP_FFDHE)) {
-                        hasFFDHEGroups = true;
-                    }
-                }
-            }
-
-            // For compatibility, if no FFDHE groups are defined, the non-FFDHE
-            // compatible mode (using DHE cipher suite without FFDHE extension)
-            // is allowed.
-            //
-            // Note that the constraints checking on DHE parameters will be
-            // performed during key exchanging in a handshake.
-            return !hasFFDHEGroups && type == NamedGroup.NamedGroupSpec.NAMED_GROUP_FFDHE;
-        }
-
-        // Is the named group permitted by the constraints?
-        static boolean isActivatable(
-                AlgorithmConstraints constraints, NamedGroup namedGroup) {
-            if (!namedGroup.isAvailable || !isSupported(namedGroup)) {
-                return false;
-            }
-
-            return namedGroup.isPermitted(constraints);
-        }
-
-        // Is the named group supported?
-        static boolean isSupported(NamedGroup namedGroup) {
-            for (NamedGroup group : supportedNamedGroups) {
-                if (namedGroup.id == group.id) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        static NamedGroup getPreferredGroup(
-                ProtocolVersion negotiatedProtocol,
-                AlgorithmConstraints constraints, NamedGroup.NamedGroupSpec[] types,
-                List<NamedGroup> requestedNamedGroups) {
-            for (NamedGroup namedGroup : requestedNamedGroups) {
-                if ((NamedGroup.NamedGroupSpec.arrayContains(types, namedGroup.spec)) &&
-                        namedGroup.isAvailable(negotiatedProtocol) &&
-                        isSupported(namedGroup) &&
-                        namedGroup.isPermitted(constraints)) {
-                    return namedGroup;
-                }
-            }
-
-            return null;
-        }
-
-        static NamedGroup getPreferredGroup(
-                ProtocolVersion negotiatedProtocol,
-                AlgorithmConstraints constraints, NamedGroup.NamedGroupSpec[] types) {
-            for (NamedGroup namedGroup : supportedNamedGroups) {
-                if ((NamedGroup.NamedGroupSpec.arrayContains(types, namedGroup.spec)) &&
-                        namedGroup.isAvailable(negotiatedProtocol) &&
-                        namedGroup.isPermitted(constraints)) {
-                    return namedGroup;
-                }
-            }
-
-            return null;
-        }
-    }
-
     /**
      * Network data producer of a "supported_groups" extension in
      * the ClientHello handshake message.
@@ -342,10 +175,19 @@ final class SupportedGroupsExtension {
 
             // Produce the extension.
             ArrayList<NamedGroup> namedGroups =
-                new ArrayList<>(SupportedGroups.supportedNamedGroups.length);
-            for (NamedGroup ng : SupportedGroups.supportedNamedGroups) {
-                if ((!SupportedGroups.enableFFDHE) &&
-                    (ng.spec == NamedGroup.NamedGroupSpec.NAMED_GROUP_FFDHE)) {
+                    new ArrayList<>(chc.sslConfig.namedGroups.length);
+            for (String name : chc.sslConfig.namedGroups) {
+                NamedGroup ng = NamedGroup.nameOf(name);
+                if (ng == null) {
+                    if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
+                        SSLLogger.fine(
+                                "Ignore unspecified named group: " + name);
+                    }
+                    continue;
+                }
+
+                if ((!SSLConfiguration.enableFFDHE) &&
+                    (ng.spec == NamedGroupSpec.NAMED_GROUP_FFDHE)) {
                     continue;
                 }
 
@@ -491,10 +333,20 @@ final class SupportedGroupsExtension {
             // Contains all groups the server supports, regardless of whether
             // they are currently supported by the client.
             ArrayList<NamedGroup> namedGroups = new ArrayList<>(
-                    SupportedGroups.supportedNamedGroups.length);
-            for (NamedGroup ng : SupportedGroups.supportedNamedGroups) {
-                if ((!SupportedGroups.enableFFDHE) &&
-                    (ng.spec == NamedGroup.NamedGroupSpec.NAMED_GROUP_FFDHE)) {
+                    shc.sslConfig.namedGroups.length);
+            for (String name : shc.sslConfig.namedGroups) {
+                NamedGroup ng = NamedGroup.nameOf(name);
+                if (ng == null) {
+                    if (SSLLogger.isOn &&
+                            SSLLogger.isOn("ssl,handshake")) {
+                        SSLLogger.fine(
+                                "Ignore unspecified named group: " + name);
+                    }
+                    continue;
+                }
+
+                if ((!SSLConfiguration.enableFFDHE) &&
+                    (ng.spec == NamedGroupSpec.NAMED_GROUP_FFDHE)) {
                     continue;
                 }
 

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPAuthentication.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPAuthentication.java
@@ -425,7 +425,7 @@ final class TLCPAuthentication implements SSLAuthentication {
                 ((ECPublicKey) publicKey).getParams();
         NamedGroup namedGroup = NamedGroup.valueOf(params);
         if (namedGroup != NamedGroup.CURVESM2  // Only accept curveSM2
-                || (!SupportedGroupsExtension.SupportedGroups.isSupported(namedGroup))
+                || (!NamedGroup.isEnabled(hc.sslConfig, namedGroup))
                 || ((hc.clientRequestedNamedGroups != null)
                         && !hc.clientRequestedNamedGroups.contains(namedGroup))) {
 

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/X509Authentication.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/X509Authentication.java
@@ -315,7 +315,7 @@ enum X509Authentication implements SSLAuthentication {
                         ((ECPublicKey) serverPublicKey).getParams();
                 NamedGroup namedGroup = NamedGroup.valueOf(params);
                 if ((namedGroup == null) ||
-                        (!SupportedGroupsExtension.SupportedGroups.isSupported(namedGroup)) ||
+                        (!NamedGroup.isEnabled(shc.sslConfig, namedGroup)) ||
                         ((shc.clientRequestedNamedGroups != null) &&
                                 !shc.clientRequestedNamedGroups.contains(namedGroup))) {
 


### PR DESCRIPTION
This is a backport of [JDK-8281236]: (D)TLS key exchange named groups.

Although it should not use the new JDK public APIs on named groups in class javax.net.ssl.SSLParameters, it would be better to sync the code changes in package sun.security.ssl as much as possible.

This PR will resolve #110.

[JDK-8281236]:
<https://bugs.openjdk.org/browse/JDK-8281236>