### PR TITLE
TKSS-138: Backport JDK-8294527: Some java.security.debug options missing from security docs

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/Debug.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/Debug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,6 +88,7 @@ public class Debug {
         System.err.println("pkcs11keystore");
         System.err.println("              PKCS11 KeyStore debugging");
         System.err.println("pkcs12        PKCS12 KeyStore debugging");
+        System.err.println("properties    Security property and configuration file debugging");
         System.err.println("sunpkcs11     SunPKCS11 provider debugging");
         System.err.println("scl           permissions SecureClassLoader assigns");
         System.err.println("securerandom  SecureRandom");
@@ -122,6 +123,10 @@ public class Debug {
         System.err.println();
         System.err.println("ocsp          dump the OCSP protocol exchanges");
         System.err.println("verbose       verbose debugging");
+        System.err.println();
+        System.err.println("The following can be used with x509:");
+        System.err.println();
+        System.err.println("ava           embed non-printable/non-escaped characters in AVA components as hex strings");
         System.err.println();
         System.err.println("Note: Separate multiple options with a comma");
         System.exit(0);


### PR DESCRIPTION
This is a backport of [JDK-8294527]: Some java.security.debug options missing from security docs.

This PR will resolve #138.

[JDK-8294527]:
<https://bugs.openjdk.org/browse/JDK-8294527>