### PR TITLE
TKSS-145: Parse X.509-encoded public key

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/pkix/PKIXUtils.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/pkix/PKIXUtils.java
@@ -17,6 +17,7 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 import java.util.Set;
 
@@ -25,8 +26,11 @@ import java.util.Set;
  */
 public class PKIXUtils {
 
-    public static final String PKCS8_KEY_BEGIN = "-----BEGIN PRIVATE KEY-----";
-    public static final String PKCS8_KEY_END = "-----END PRIVATE KEY-----";
+    private static final String PUBLIC_KEY_BEGIN = "-----BEGIN PUBLIC KEY-----";
+    private static final String PUBLIC_KEY_END = "-----END PUBLIC KEY-----";
+
+    private static final String PRIVATE_KEY_BEGIN = "-----BEGIN PRIVATE KEY-----";
+    private static final String PRIVATE_KEY_END = "-----END PRIVATE KEY-----";
 
     public static boolean isSM3withSM2(String algName) {
         return "SM3withSM2".equalsIgnoreCase(algName)
@@ -36,12 +40,23 @@ public class PKIXUtils {
     // Create a PrivateKey from a PKCS#8-encoded PEM.
     public static PrivateKey getPrivateKey(String keyAlgo, String pkcs8Key)
             throws NoSuchAlgorithmException, InvalidKeySpecException {
-        String keyPem = pkcs8Key.replace(PKCS8_KEY_BEGIN, "")
-                .replace(PKCS8_KEY_END, "");
+        String keyPem = pkcs8Key.replace(PRIVATE_KEY_BEGIN, "")
+                .replace(PRIVATE_KEY_END, "");
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPem));
         KeyFactory keyFactory = CryptoInsts.getKeyFactory(keyAlgo);
         return keyFactory.generatePrivate(privateKeySpec);
+    }
+
+    // Create a PublicKey from an X.509-encoded PEM.
+    public static PublicKey getPublicKey(String keyAlgo, String keyPEM)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
+        String keyPem = keyPEM.replace(PUBLIC_KEY_BEGIN, "")
+                .replace(PUBLIC_KEY_END, "");
+        X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(
+                Base64.getMimeDecoder().decode(keyPem));
+        KeyFactory keyFactory = CryptoInsts.getKeyFactory(keyAlgo);
+        return keyFactory.generatePublic(publicKeySpec);
     }
 
     public static PublicKey getPublicKey(Certificate cert)

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/util/PKIXUtilsTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/util/PKIXUtilsTest.java
@@ -15,6 +15,24 @@ import java.security.interfaces.ECPrivateKey;
  */
 public class PKIXUtilsTest {
 
+    private static final String PRIVATE_KEY =
+            "-----BEGIN PRIVATE KEY-----\n" +
+            "MIGHAgEAMBMGByqGSM49AgEGCCqBHM9VAYItBG0wawIBAQQgqiXZE9IGb/jccQdf\n" +
+            "2WYJNk+KVWk8/pPwWx5giD06FX+hRANCAATNugcb6WBQNmZE7VS+Mg54zU07g3m+\n" +
+            "GLAtjsccD0eQ7SwXpjP4nNokax6YIzK5lJ6mrM6Y2GV5AvjaImWbuidW" +
+            "-----END PRIVATE KEY-----";
+
+    private static final String PRIVATE_KEY_WITHOUT_BE =
+            "MIGHAgEAMBMGByqGSM49AgEGCCqBHM9VAYItBG0wawIBAQQgqiXZE9IGb/jccQdf\n" +
+            "2WYJNk+KVWk8/pPwWx5giD06FX+hRANCAATNugcb6WBQNmZE7VS+Mg54zU07g3m+\n" +
+            "GLAtjsccD0eQ7SwXpjP4nNokax6YIzK5lJ6mrM6Y2GV5AvjaImWbuidW";
+
+    private static final String PUBLIC_KEY =
+            "-----BEGIN PUBLIC KEY-----\n" +
+            "MFkwEwYHKoZIzj0CAQYIKoEcz1UBgi0DQgAE8BHoyDr91ptaoN0QRxvYElxdgxzI\n" +
+            "WBTynLUqHouCbT2WD03776IFiEWSi1RdmIq7VvE7f8rpvwosDc/timPkcg==\n" +
+            "-----END PUBLIC KEY-----";
+
     /* The CA certificate.
      *
      * Certificate:
@@ -69,18 +87,6 @@ public class PKIXUtilsTest {
             "hNeTAiEAumIvXbvNbp0rjDmXvYK4B1oRKhLCz1VQAqOcChecilE=\n" +
             "-----END CERTIFICATE-----";
 
-    private static final String KEY =
-            "-----BEGIN PRIVATE KEY-----\n" +
-            "MIGHAgEAMBMGByqGSM49AgEGCCqBHM9VAYItBG0wawIBAQQgqiXZE9IGb/jccQdf\n" +
-            "2WYJNk+KVWk8/pPwWx5giD06FX+hRANCAATNugcb6WBQNmZE7VS+Mg54zU07g3m+\n" +
-            "GLAtjsccD0eQ7SwXpjP4nNokax6YIzK5lJ6mrM6Y2GV5AvjaImWbuidW" +
-            "-----END PRIVATE KEY-----";
-
-    private static final String KEY_WITHOUT_BE =
-            "MIGHAgEAMBMGByqGSM49AgEGCCqBHM9VAYItBG0wawIBAQQgqiXZE9IGb/jccQdf\n" +
-            "2WYJNk+KVWk8/pPwWx5giD06FX+hRANCAATNugcb6WBQNmZE7VS+Mg54zU07g3m+\n" +
-            "GLAtjsccD0eQ7SwXpjP4nNokax6YIzK5lJ6mrM6Y2GV5AvjaImWbuidW";
-
     @BeforeAll
     public static void setup() {
         TestUtils.addProviders();
@@ -88,12 +94,12 @@ public class PKIXUtilsTest {
 
     @Test
     public void testGetPrivateKey() throws Exception {
-        testGetPrivateKey(KEY);
+        testGetPrivateKey(PRIVATE_KEY);
     }
 
     @Test
     public void testGetPrivateKeyWithoutBELines() throws Exception {
-        testGetPrivateKey(KEY_WITHOUT_BE);
+        testGetPrivateKey(PRIVATE_KEY_WITHOUT_BE);
     }
 
     private void testGetPrivateKey(String keyStr) throws Exception {
@@ -103,6 +109,12 @@ public class PKIXUtilsTest {
 
     @Test
     public void testGetPublicKey() throws Exception {
+        PublicKey key = PKIXUtils.getPublicKey("EC", PUBLIC_KEY);
+        Assertions.assertEquals(key.getAlgorithm(), "EC");
+    }
+
+    @Test
+    public void testGetPublicKeyFromCert() throws Exception {
         PublicKey key = PKIXUtils.getPublicKey(CERT);
         Assertions.assertEquals(key.getAlgorithm(), "EC");
     }


### PR DESCRIPTION
Provides a utility for generating a PublicKey instance from a X.509-encoded public key.

This PR will resolves #145.