### PR TITLE
TKSS-156: GitHub actions support macOS and Windows

### DIFF
--- a/.github/workflows/gradle-build.yaml
+++ b/.github/workflows/gradle-build.yaml
@@ -6,7 +6,7 @@ jobs:
   gradle:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         java-version: [8, 11, 17]
     runs-on: ${{ matrix.os }}
 

--- a/buildSrc/src/main/kotlin/kona-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/kona-common.gradle.kts
@@ -1,3 +1,4 @@
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
@@ -38,6 +39,13 @@ tasks {
         filter {
             includeTestsMatching("*Test")
             includeTestsMatching("*Demo")
+
+            // The TLCP and TLS interop tests are not stable on Windows
+            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                excludeTestsMatching("com.tencent.kona.ssl.hybrid.*")
+                excludeTestsMatching("com.tencent.kona.ssl.tlcp.*")
+                excludeTestsMatching("com.tencent.kona.ssl.tls.*")
+            }
 
             val babasslPathProp = "test.babassl.path"
             val babasslPath = System.getProperty(babasslPathProp, "babassl")


### PR DESCRIPTION
It would be better to run the tests on macOS and Windows while submitting the PRs.

This PR will resolve #156.