### PR TITLE
TKSS-168: May not depend on RSASSA-PSS signature and ALPN on runtime

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAKeyPairGenerator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAKeyPairGenerator.java
@@ -37,6 +37,8 @@ import com.tencent.kona.sun.security.util.SecurityProviderConstants;
 import com.tencent.kona.sun.security.jca.JCAUtil;
 import com.tencent.kona.sun.security.rsa.RSAUtil.KeyType;
 
+import static com.tencent.kona.sun.security.rsa.RSAUtil.SUPPORT_PSS;
+
 /**
  * RSA keypair generation. Standard algorithm, minimum key length 512 bit.
  * We generate two random primes until we find two where phi is relative
@@ -97,7 +99,7 @@ abstract class RSAKeyPairGenerator extends KeyPairGeneratorSpi {
         RSAKeyGenParameterSpec rsaSpec = (RSAKeyGenParameterSpec)params;
         int tmpKeySize = rsaSpec.getKeysize();
         BigInteger tmpPubExp = rsaSpec.getPublicExponent();
-        AlgorithmParameterSpec tmpParams = rsaSpec.getKeyParams();
+        AlgorithmParameterSpec tmpParams = SUPPORT_PSS ? rsaSpec.getKeyParams() : null;
 
         // use the new approach for even key sizes >= 2048 AND when the
         // public exponent is within FIPS valid range

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAPrivateCrtKeyImpl.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAPrivateCrtKeyImpl.java
@@ -292,7 +292,7 @@ public final class RSAPrivateCrtKeyImpl
     }
 
     // see JCA doc
-    @Override
+//    @Override
     public AlgorithmParameterSpec getParams() {
         return keyParams;
     }

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAPrivateKeyImpl.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAPrivateKeyImpl.java
@@ -129,7 +129,7 @@ public final class RSAPrivateKeyImpl extends PKCS8Key implements RSAPrivateKey {
     }
 
     // see JCA doc
-    @Override
+//    @Override
     public AlgorithmParameterSpec getParams() {
         return keyParams;
     }

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAPublicKeyImpl.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAPublicKeyImpl.java
@@ -190,7 +190,7 @@ public final class RSAPublicKeyImpl extends X509Key implements RSAPublicKey {
     }
 
     // see JCA doc
-    @Override
+//    @Override
     public AlgorithmParameterSpec getParams() {
         return keyParams;
     }

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSASignature.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSASignature.java
@@ -37,6 +37,8 @@ import com.tencent.kona.sun.security.util.ObjectIdentifier;
 import com.tencent.kona.sun.security.x509.AlgorithmId;
 import com.tencent.kona.sun.security.rsa.RSAUtil.KeyType;
 
+import static com.tencent.kona.sun.security.rsa.RSAUtil.SUPPORT_PSS;
+
 /**
  * PKCS#1 v1.5 RSA signatures with the various message digest algorithms.
  * This file contains an abstract base class with all the logic plus
@@ -122,7 +124,8 @@ abstract class RSASignature extends SignatureSpi {
     private void initCommon(RSAKey rsaKey, SecureRandom random)
             throws InvalidKeyException {
         try {
-            RSAUtil.checkParamsAgainstType(KeyType.RSA, rsaKey.getParams());
+            RSAUtil.checkParamsAgainstType(KeyType.RSA,
+                    SUPPORT_PSS ? rsaKey.getParams() : null);
         } catch (ProviderException e) {
             throw new InvalidKeyException("Invalid key for RSA signatures", e);
         }

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAUtil.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAUtil.java
@@ -206,4 +206,17 @@ public class RSAUtil {
         }
         return values[1].getOctetString();
     }
+
+    static final boolean SUPPORT_PSS = supportPSS();
+
+    private static boolean supportPSS() {
+        boolean supported;
+        try {
+            RSAPublicKeySpec.class.getMethod("getParams");
+            supported = true;
+        } catch (NoSuchMethodException e) {
+            supported = false;
+        }
+        return supported;
+    }
 }

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLConfiguration.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLConfiguration.java
@@ -46,6 +46,8 @@ import javax.net.ssl.SSLSocket;
 import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.sun.security.action.GetPropertyAction;
 
+import static com.tencent.kona.sun.security.ssl.Utilities.SUPPORT_ALPN;
+
 /**
  * SSL/(D)TLS configuration.
  */
@@ -210,7 +212,9 @@ final class SSLConfiguration implements Cloneable {
             params.setSNIMatchers(this.sniMatchers);
         }
 
-        params.setApplicationProtocols(this.applicationProtocols);
+        if (SUPPORT_ALPN) {
+            params.setApplicationProtocols(this.applicationProtocols);
+        }
         params.setUseCipherSuitesOrder(this.preferLocalCipherSuites);
 //        params.setEnableRetransmissions(this.enableRetransmissions);
 //        params.setMaximumPacketSize(this.maximumPacketSize);
@@ -266,7 +270,7 @@ final class SSLConfiguration implements Cloneable {
             this.sniMatchers = matchers;
         }   // null if none has been set
 
-        sa = params.getApplicationProtocols();
+        sa = SUPPORT_ALPN ? params.getApplicationProtocols() : null;
         if (sa != null) {
             this.applicationProtocols = sa;
         }   // otherwise, use the default values

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLEngineImpl.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLEngineImpl.java
@@ -1041,7 +1041,7 @@ final class SSLEngineImpl extends SSLEngine implements SSLTransport {
         }
    }
 
-    @Override
+//    @Override
     public String getApplicationProtocol() {
         engineLock.lock();
         try {
@@ -1051,7 +1051,7 @@ final class SSLEngineImpl extends SSLEngine implements SSLTransport {
         }
     }
 
-    @Override
+//    @Override
     public String getHandshakeApplicationProtocol() {
         engineLock.lock();
         try {
@@ -1062,7 +1062,7 @@ final class SSLEngineImpl extends SSLEngine implements SSLTransport {
         }
     }
 
-    @Override
+//    @Override
     public void setHandshakeApplicationProtocolSelector(
             BiFunction<SSLEngine, List<String>, String> selector) {
         engineLock.lock();
@@ -1073,7 +1073,7 @@ final class SSLEngineImpl extends SSLEngine implements SSLTransport {
         }
     }
 
-    @Override
+//    @Override
     public BiFunction<SSLEngine, List<String>, String>
             getHandshakeApplicationProtocolSelector() {
         engineLock.lock();

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/Utilities.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/Utilities.java
@@ -1,5 +1,6 @@
 package com.tencent.kona.sun.security.ssl;
 
+import javax.net.ssl.SSLParameters;
 import java.nio.charset.StandardCharsets;
 
 public class Utilities extends com.tencent.kona.sun.security.util.Utilities {
@@ -7,4 +8,17 @@ public class Utilities extends com.tencent.kona.sun.security.util.Utilities {
     // The ID used by TLS 1.3 handshaking with signature scheme SM3withSM2.
     public static final byte[] TLS13_SM_ID
             = "TLSv1.3+GM+Cipher+Suite".getBytes(StandardCharsets.ISO_8859_1);
+
+    public static final boolean SUPPORT_ALPN = supportALPN();
+
+    private static boolean supportALPN() {
+        boolean supported;
+        try {
+            SSLParameters.class.getMethod("getApplicationProtocols");
+            supported = true;
+        } catch (NoSuchMethodException e) {
+            supported = false;
+        }
+        return supported;
+    }
 }


### PR DESCRIPTION
In order to support older JDK 8 releases, say 8u242, it should allow the codes not to depend on [RSASSA-PSS signature] and [ALPN] implementations on runtime.
Both of these features were introduced by JDK 8u242.

This PR will resolve #168.

[RSASSA-PSS signature]:
<https://bugs.openjdk.org/browse/JDK-8230978>

[ALPN]:
<https://bugs.openjdk.org/browse/JDK-8230977>