### PR TITLE
TKSS-175: SM2 decryption would raise BadPaddingException on invalid public key

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2Engine.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2Engine.java
@@ -158,7 +158,7 @@ public final class SM2Engine {
         byte[] hArr = toByteArrayLE(COFACTOR);
         ECPoint s = SM2OPS.multiply(pC1, hArr).asAffine().toECPoint();
         if (!SM2OPS.checkOrder(s)) {
-            throw new IllegalArgumentException("The peer public point is invalid");
+            throw new BadPaddingException("The peer public point is invalid");
         }
 
         // B3


### PR DESCRIPTION
If the public key is invalid, SM2Engine::decrypt would raise BadPaddingException rather than a runtime exception like IllegalArgumentException.

This PR will resolve #175.