### PR TITLE
TKSS-179: READMEs just use version placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ repositories {
 }
 
 dependencies {
-    implementation("com.tencent.kona:kona-crypto:1.0.7.1")
-    implementation("com.tencent.kona:kona-pkix:1.0.7.1")
-    implementation("com.tencent.kona:kona-ssl:1.0.7.1")
-    implementation("com.tencent.kona:kona-provider:1.0.7.1")
+    implementation("com.tencent.kona:kona-crypto:<version>")
+    implementation("com.tencent.kona:kona-pkix:<version>")
+    implementation("com.tencent.kona:kona-ssl:<version>")
+    implementation("com.tencent.kona:kona-provider:<version>")
 }
 ```
 
@@ -44,8 +44,8 @@ Note that, it is unnecessary to put all the providers into the classpath. Please
 
 ```
 dependencies {
-    implementation("com.tencent.kona:kona-crypto:1.0.7")
-    implementation("com.tencent.kona:kona-provider:1.0.7")
+    implementation("com.tencent.kona:kona-crypto:<version>")
+    implementation("com.tencent.kona:kona-provider:<version>")
 }
 ```
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -33,10 +33,10 @@ repositories {
 }
 
 dependencies {
-    implementation("com.tencent.kona:kona-crypto:1.0.7.1")
-    implementation("com.tencent.kona:kona-pkix:1.0.7.1")
-    implementation("com.tencent.kona:kona-ssl:1.0.7.1")
-    implementation("com.tencent.kona:kona-provider:1.0.7.1")
+    implementation("com.tencent.kona:kona-crypto:<version>")
+    implementation("com.tencent.kona:kona-pkix:<version>")
+    implementation("com.tencent.kona:kona-ssl:<version>")
+    implementation("com.tencent.kona:kona-provider:<version>")
 }
 ```
 
@@ -44,8 +44,8 @@ dependencies {
 
 ```
 dependencies {
-    implementation("com.tencent.kona:kona-crypto:1.0.7.1")
-    implementation("com.tencent.kona:kona-provider:1.0.7.1")
+    implementation("com.tencent.kona:kona-crypto:<version>")
+    implementation("com.tencent.kona:kona-provider:<version>")
 }
 ```
 


### PR DESCRIPTION
The READMEs just use some version placeholders instead of the exact latest versions.

This PR will resolves #179.