### PR TITLE
TKSS-181: Backport of JDK-8300939: sun/security/provider/certpath/OCSP/OCSPNoContentLength.java fails due to network errors

### DIFF
--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertPathValidatorTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertPathValidatorTest.java
@@ -291,8 +291,8 @@ public class CertPathValidatorTest {
         SimpleOCSPServer ocspServer = createOCSPServer(
                 issuerCertName, issuerKeyName);
         ocspServer.start();
-        while(!ocspServer.isServerReady()) {
-            TimeUnit.MILLISECONDS.sleep(100);
+        if (!ocspServer.awaitServerReady(5, TimeUnit.SECONDS)) {
+            throw new RuntimeException("OCSP server is not started");
         }
 
         X509Certificate eeCert = TestUtils.certAsFile(certName);


### PR DESCRIPTION
This is a backport of [JDK-8300939]: sun/security/provider/certpath/OCSP/OCSPNoContentLength.java fails due to network errors.

This PR will resolve #181.

[JDK-8300939]:
<https://bugs.openjdk.org/browse/JDK-8300939>