### PR TITLE
TKSS-191: Backport of JDK-8296400: pointCrlIssuers might be null in DistributionPointFetcher::verifyURL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,5 +5,5 @@ allprojects {
     }
 
     group = "com.tencent.kona"
-    version = "1.0.7.1"
+    version = "1.0.8-SNAPSHOT"
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/DistributionPointFetcher.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/DistributionPointFetcher.java
@@ -442,7 +442,7 @@ public class DistributionPointFetcher {
                             debug.println("DP relativeName:" + relativeName);
                         }
                         if (indirectCRL) {
-                            if (pointCrlIssuers.size() != 1) {
+                            if (pointCrlIssuers == null || pointCrlIssuers.size() != 1) {
                                 // RFC 5280: there must be only 1 CRL issuer
                                 // name when relativeName is present
                                 if (debug != null) {
@@ -451,6 +451,9 @@ public class DistributionPointFetcher {
                                 }
                                 return false;
                             }
+                            // if pointCrlIssuers is not null, pointCrlIssuer
+                            // will also be non-null or the code would have
+                            // returned before now
                             pointNames = getFullNames
                                     (pointCrlIssuer, relativeName);
                         } else {
@@ -487,6 +490,9 @@ public class DistributionPointFetcher {
                     // verify that one of the names in the IDP matches one of
                     // the names in the cRLIssuer of the cert's DP
                     boolean match = false;
+                    // the DP's fullName and relativeName fields are null
+                    // which means pointCrlIssuers is non-null; the three
+                    // cannot all be missing from a certificate.
                     for (Iterator<GeneralName> t = pointCrlIssuers.iterator();
                          !match && t.hasNext(); ) {
                         GeneralNameInterface crlIssuerName = t.next().getName();


### PR DESCRIPTION
This is a backport of [JDK-8296400]: pointCrlIssuers might be null in DistributionPointFetcher::verifyURL.

This PR will resolve #191.

[JDK-8296400]:
<https://bugs.openjdk.org/browse/JDK-8296400>