### PR TITLE
TKSS-194: Backport of JDK-8182621: JSSE should reject empty TLS plaintexts

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLEngineInputRecord.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLEngineInputRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -263,6 +263,12 @@ final class SSLEngineInputRecord extends InputRecord implements SSLRecord {
         // parse handshake messages
         //
         if (contentType == ContentType.HANDSHAKE.id) {
+            if (contentLen == 0) {
+                // From RFC 8446: "Implementations MUST NOT send zero-length fragments
+                // of Handshake types, even if those fragments contain padding."
+                throw new SSLProtocolException("Handshake packets must not be zero-length");
+            }
+
             ByteBuffer handshakeFrag = fragment;
             if ((handshakeBuffer != null) &&
                     (handshakeBuffer.remaining() != 0)) {

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLSocketInputRecord.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLSocketInputRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -277,6 +277,12 @@ final class SSLSocketInputRecord extends InputRecord implements SSLRecord {
         //
         if (contentType == ContentType.HANDSHAKE.id) {
             ByteBuffer handshakeFrag = fragment;
+            if (contentLen == 0) {
+                // From RFC 8446: "Implementations MUST NOT send zero-length fragments
+                // of Handshake types, even if those fragments contain padding."
+                throw new SSLProtocolException("Handshake fragments must not be zero length.");
+            }
+
             if ((handshakeBuffer != null) &&
                     (handshakeBuffer.remaining() != 0)) {
                 ByteBuffer bb = ByteBuffer.wrap(new byte[


### PR DESCRIPTION
This is a backport of [JDK-8182621]: JSSE should reject empty TLS plaintexts.

This PR will resolve #194.

[JDK-8182621]:
<https://bugs.openjdk.org/browse/JDK-8182621>