### PR TITLE
TKSS-208: Upgrade gradle-build-action to version 2.4.2

### DIFF
--- a/.github/workflows/gradle-build.yaml
+++ b/.github/workflows/gradle-build.yaml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
 
       - name: Execute Gradle build
         run: ./gradlew clean build


### PR DESCRIPTION
It would upgrade gradle-build-action to version 2.4.2 due to [a security issue].

This PR will resolve #208.

[a security issue]:
<https://github.com/Tencent/TencentKonaSMSuite/security/dependabot/1>