### PR TITLE
TKSS-216: Add JMH benchmark for BouncyCastle SM3 engine

### DIFF
--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM3EnginePerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM3EnginePerfTest.java
@@ -2,6 +2,7 @@ package com.tencent.kona.crypto.perf;
 
 import com.tencent.kona.crypto.TestUtils;
 import com.tencent.kona.crypto.provider.SM3Engine;
+import org.bouncycastle.crypto.digests.SM3Digest;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -42,10 +43,29 @@ public class SM3EnginePerfTest {
         }
     }
 
+    @State(Scope.Benchmark)
+    public static class EngineHolderBC {
+
+        SM3Digest engine;
+        byte[] digest = new byte[32];
+
+        @Setup(Level.Trial)
+        public void setup() throws Exception {
+            engine = new SM3Digest();
+        }
+    }
+
     @Benchmark
     public byte[] digest(EngineHolder holder) {
-        holder.engine.update(MESSAGE);
-        holder.engine.doFinal(holder.digest);
+        holder.engine.update(MESSAGE, 0, MESSAGE.length);
+        holder.engine.doFinal(holder.digest, 0);
+        return holder.digest;
+    }
+
+    @Benchmark
+    public byte[] digestBC(EngineHolderBC holder) {
+        holder.engine.update(MESSAGE, 0, MESSAGE.length);
+        holder.engine.doFinal(holder.digest, 0);
         return holder.digest;
     }
 }


### PR DESCRIPTION
Add a benchmark for BouncyCastle SM3 engine, exactly `org.bouncycastle.crypto.digests.SM3Digest`, to JMH test SM3MessageDigestPerfTest.

This PR will resolve #216.