### PR TITLE
TKSS-226: Backport JDK-8288047: Accelerate Poly1305 on x86_64 using AVX512 instructions

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/IntegerModuloP.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/IntegerModuloP.java
@@ -155,6 +155,11 @@ public interface IntegerModuloP {
     void asByteArray(byte[] result);
 
     /**
+     * Break encapsulation, used for IntrinsicCandidate functions
+     */
+    long[] getLimbs();
+
+    /**
      * Compute the multiplicative inverse of this field element.
      *
      * @return the multiplicative inverse (1 / this)

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomial.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomial.java
@@ -655,6 +655,10 @@ public abstract class IntegerPolynomial implements IntegerFieldModuloP {
             }
             limbsToByteArray(limbs, result);
         }
+
+        public long[] getLimbs() {
+            return limbs;
+        }
     }
 
     protected class MutableElement extends Element


### PR DESCRIPTION
This is a backport of [JDK-8288047]: Accelerate Poly1305 on x86_64 using AVX512 instructions.

Although we don't need this enhancement on Poly1305, just sync with the latest OpenJDK codes.

This PR will resolve #226.

[JDK-8288047]:
<https://bugs.openjdk.org/browse/JDK-8288047>