### PR TITLE
TKSS-228: Remove macOS from GitHub actions

### DIFF
--- a/.github/workflows/gradle-build.yaml
+++ b/.github/workflows/gradle-build.yaml
@@ -6,7 +6,7 @@ jobs:
   gradle:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         java-version: [8, 11, 17]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
It looks GitHub has no enough macOS platforms for running actions.
This problem may block a PR testing for a long time.

This PR will resolve #228.