### PR TITLE
TKSS-234: Cannot select the signing certificate

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPAuthentication.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPAuthentication.java
@@ -219,14 +219,19 @@ final class TLCPAuthentication implements SSLAuthentication {
             for (String clientAlias : clientAliases) {
                 PossessionEntry bufPossEntry = clientPossEntry(
                         chc, keyType, km, clientAlias);
-                if (bufPossEntry != null) {
-                    if (signPossEntry == null
-                            && PKIXUtils.isSignCert(bufPossEntry.popCert)) {
-                        signPossEntry = bufPossEntry;
-                    } else if (PKIXUtils.isEncCert(bufPossEntry.popCert)) {
-                        encPossEntry = bufPossEntry;
-                        break;
-                    }
+                if (bufPossEntry == null) {
+                    continue;
+                }
+
+                if (signPossEntry == null
+                        && PKIXUtils.isSignCert(bufPossEntry.popCert)) {
+                    signPossEntry = bufPossEntry;
+                } else if (PKIXUtils.isEncCert(bufPossEntry.popCert)) {
+                    encPossEntry = bufPossEntry;
+                }
+
+                if (signPossEntry != null && encPossEntry != null) {
+                    break;
                 }
             }
 
@@ -320,6 +325,9 @@ final class TLCPAuthentication implements SSLAuthentication {
                     signPossEntry = bufPossEntry;
                 } else if (PKIXUtils.isEncCert(bufPossEntry.popCert)) {
                     encPossEntry = bufPossEntry;
+                }
+
+                if (signPossEntry != null && encPossEntry != null) {
                     break;
                 }
             }


### PR DESCRIPTION
If the encrypting certificate is selected at first, the signing certificate may not be selected.
It should not depend on the order of the certificates in the alias array.

This PR will resolve #234.