### PR TITLE
TKSS-242: Backport JDK-8308010: X509Key and PKCS8Key allows garbage bytes at the end

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS8Key.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS8Key.java
@@ -97,13 +97,15 @@ public class PKCS8Key implements PrivateKey, InternalPrivateKey {
      * This method is also used by {@link #parseKey} to create a raw key.
      */
     protected PKCS8Key(byte[] input) throws InvalidKeyException {
-        decode(new ByteArrayInputStream(input));
+        try {
+            decode(new DerValue(input));
+        } catch (IOException e) {
+            throw new InvalidKeyException("Unable to decode key", e);
+        }
     }
 
-    private void decode(InputStream is) throws InvalidKeyException {
-        DerValue val = null;
+    private void decode(DerValue val) throws InvalidKeyException {
         try {
-            val = new DerValue(is);
             if (val.tag != DerValue.tag_Sequence) {
                 throw new InvalidKeyException("invalid key format");
             }
@@ -137,7 +139,7 @@ public class PKCS8Key implements PrivateKey, InternalPrivateKey {
             }
             throw new InvalidKeyException("Extra bytes");
         } catch (IOException e) {
-            throw new InvalidKeyException("IOException : " + e.getMessage());
+            throw new InvalidKeyException("Unable to decode key", e);
         } finally {
             if (val != null) {
                 val.clear();
@@ -243,10 +245,9 @@ public class PKCS8Key implements PrivateKey, InternalPrivateKey {
      */
     private void readObject(ObjectInputStream stream) throws IOException {
         try {
-            decode(stream);
+            decode(new DerValue(stream));
         } catch (InvalidKeyException e) {
-            throw new IOException("deserialized key is invalid: " +
-                    e.getMessage());
+            throw new IOException("deserialized key is invalid", e);
         }
     }
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/X509Key.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/X509Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -336,8 +336,7 @@ public class X509Key implements PublicKey, DerEncoder {
     }
 
     /**
-     * Initialize an X509Key object from an input stream.  The data on that
-     * input stream must be encoded using DER, obeying the X.509
+     * Initialize an X509Key object from a DerValue, obeying the X.509
      * <code>SubjectPublicKeyInfo</code> format.  That is, the data is a
      * sequence consisting of an algorithm ID and a bit string which holds
      * the key.  (That bit string is often used to encapsulate another DER
@@ -352,17 +351,12 @@ public class X509Key implements PublicKey, DerEncoder {
      * private keys may override this method, <code>encode</code>, and
      * of course <code>getFormat</code>.
      *
-     * @param in an input stream with a DER-encoded X.509
-     *          SubjectPublicKeyInfo value
+     * @param val a DER-encoded X.509 SubjectPublicKeyInfo value
      * @exception InvalidKeyException on parsing errors.
      */
-    public void decode(InputStream in)
-            throws InvalidKeyException
-    {
-        DerValue        val;
+    void decode(DerValue val) throws InvalidKeyException {
 
         try {
-            val = new DerValue(in);
             if (val.tag != DerValue.tag_Sequence)
                 throw new InvalidKeyException("invalid key format");
 
@@ -373,13 +367,16 @@ public class X509Key implements PublicKey, DerEncoder {
                 throw new InvalidKeyException ("excess key data");
 
         } catch (IOException e) {
-            throw new InvalidKeyException("IOException: " +
-                    e.getMessage());
+            throw new InvalidKeyException("Unable to decode key", e);
         }
     }
 
     public void decode(byte[] encodedKey) throws InvalidKeyException {
-        decode(new ByteArrayInputStream(encodedKey));
+        try {
+            decode(new DerValue(encodedKey));
+        } catch (IOException e) {
+            throw new InvalidKeyException("Unable to decode key", e);
+        }
     }
 
     /**
@@ -396,11 +393,9 @@ public class X509Key implements PublicKey, DerEncoder {
      */
     private void readObject(ObjectInputStream stream) throws IOException {
         try {
-            decode(stream);
+            decode(new DerValue(stream));
         } catch (InvalidKeyException e) {
-            e.printStackTrace();
-            throw new IOException("deserialized key is invalid: " +
-                    e.getMessage());
+            throw new IOException("deserialized key is invalid", e);
         }
     }
 


### PR DESCRIPTION
This is a backport of [JDK-8308010]: X509Key and PKCS8Key allows garbage bytes at the end.

This PR will resolve #242.

[JDK-8308010]:
<https://bugs.openjdk.org/browse/JDK-8308010>