### PR TITLE
TKSS-252: Enable useSharedSecrets by default on JDK 8

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/jdk/internal/misc/SharedSecretsUtil.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/jdk/internal/misc/SharedSecretsUtil.java
@@ -24,7 +24,8 @@ import java.security.spec.EncodedKeySpec;
 public class SharedSecretsUtil {
 
     private static final boolean USE_SHARED_SECRETS
-            = privilegedGetBoolProperty("com.tencent.misc.useSharedSecrets", "false");
+            = privilegedGetBoolProperty("com.tencent.misc.useSharedSecrets",
+                    isJdk8() ? "true" : "false");
 
     /* JavaLangAccess */
     private static final Method langNewStringNoRepl;


### PR DESCRIPTION
The system property `useSharedSecrets` could be `true` by default on JDK 8.

This PR will resolve #252.