### PR TITLE
TKSS-258: Use system property name com.tencent.kona.ssl.namedGroups rather than jdk.tls.namedGroups

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/NamedGroup.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/NamedGroup.java
@@ -740,12 +740,12 @@ enum NamedGroup {
             // The value of the System Property defines a list of enabled named
             // groups in preference order, separated with comma.  For example:
             //
-            //      jdk.tls.namedGroups="secp521r1, secp256r1, ffdhe2048"
+            //      com.tencent.kona.ssl.namedGroups="secp521r1, secp256r1, ffdhe2048"
             //
             // If the System Property is not defined or the value is empty, the
             // default groups and preferences will be used.
             String property = GetPropertyAction
-                    .privilegedGetProperty("jdk.tls.namedGroups");
+                    .privilegedGetProperty("com.tencent.kona.ssl.namedGroups");
             if (property != null && !property.isEmpty()) {
                 // remove double quote marks from beginning/end of the property
                 if (property.length() > 1 && property.charAt(0) == '"' &&
@@ -772,7 +772,7 @@ enum NamedGroup {
 
                 if (groupList.isEmpty()) {
                     throw new IllegalArgumentException(
-                            "System property jdk.tls.namedGroups(" +
+                            "System property com.tencent.kona.ssl.namedGroups(" +
                             property + ") contains no supported named groups");
                 }
             } else {        // default groups


### PR DESCRIPTION
The [patch] for `TKSS-110: Backport JDK-8281236: (D)TLS key exchange named groups` changes the system property `com.tencent.kona.ssl.namedGroups` to `jdk.tls.namedGroups` accidentally.

This PR will resolve #258.

[patch]:
<https://github.com/Tencent/TencentKonaSMSuite/commit/dd1cfec74d7053da5c1d327f8ff19d7901ad84a1>