### PR TITLE
TKSS-266: SysPropNamedGroupsTest failed on Windows

### DIFF
--- a/buildSrc/src/main/kotlin/kona-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/kona-common.gradle.kts
@@ -45,9 +45,7 @@ tasks {
 
             // The TLCP and TLS interop tests are not stable on Windows
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                excludeTestsMatching("com.tencent.kona.ssl.hybrid.*")
-                excludeTestsMatching("com.tencent.kona.ssl.tlcp.*")
-                excludeTestsMatching("com.tencent.kona.ssl.tls.*")
+                excludeTestsMatching("com.tencent.kona.ssl.*")
             }
 
             val babasslPathProp = "test.babassl.path"

--- a/buildSrc/src/main/kotlin/kona-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/kona-common.gradle.kts
@@ -45,7 +45,10 @@ tasks {
 
             // The TLCP and TLS interop tests are not stable on Windows
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                excludeTestsMatching("com.tencent.kona.ssl.*")
+                excludeTestsMatching("com.tencent.kona.ssl.hybrid.*")
+                excludeTestsMatching("com.tencent.kona.ssl.tlcp.*")
+                excludeTestsMatching("com.tencent.kona.ssl.tls.*")
+                excludeTestsMatching("com.tencent.kona.ssl.misc.*")
             }
 
             val babasslPathProp = "test.babassl.path"


### PR DESCRIPTION
com.tencent.kona.ssl.misc.SysPropNamedGroupsTest failed on Windows due to the below error,

```
---------- Server log start ----------
Error: Could not find or load main class com.tencent.kona.ssl.interop.JdkProcServer
---------- Server log end  ----------
```

It would ignore this test on Windows.

This PR will resolve #266.