### PR TITLE
TKSS-268: Backport JDK-8294985: SSLEngine throws IAE during parsing of X500Principal

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateAuthoritiesExtension.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateAuthoritiesExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,8 +119,11 @@ final class CertificateAuthoritiesExtension {
             return authorities;
         }
 
+        // This method will throw IllegalArgumentException if the
+        // X500Principal cannot be parsed.
         X500Principal[] getAuthorities() {
             X500Principal[] principals = new X500Principal[authorities.size()];
+
             int i = 0;
             for (byte[] encoded : authorities) {
                 principals[i++] = new X500Principal(encoded);
@@ -135,8 +138,12 @@ final class CertificateAuthoritiesExtension {
                 "\"certificate authorities\": '['\n{0}']'", Locale.ENGLISH);
             StringBuilder builder = new StringBuilder(512);
             for (byte[] encoded : authorities) {
-                X500Principal principal = new X500Principal(encoded);
-                builder.append(principal.toString());
+                try {
+                    X500Principal principal = new X500Principal(encoded);
+                    builder.append(principal.toString());
+                } catch (IllegalArgumentException iae) {
+                    builder.append("unparseable distinguished name: " + iae);
+                }
                 builder.append("\n");
             }
             Object[] messageFields = {
@@ -274,7 +281,13 @@ final class CertificateAuthoritiesExtension {
                     new CertificateAuthoritiesSpec(shc, buffer);
 
             // Update the context.
-            shc.peerSupportedAuthorities = spec.getAuthorities();
+            try {
+                shc.peerSupportedAuthorities = spec.getAuthorities();
+            } catch (IllegalArgumentException iae) {
+                shc.conContext.fatal(Alert.DECODE_ERROR, "The distinguished " +
+                        "names of the peer's certificate authorities could " +
+                        "not be parsed", iae);
+            }
             shc.handshakeExtensions.put(
                     SSLExtension.CH_CERTIFICATE_AUTHORITIES, spec);
 
@@ -395,7 +408,13 @@ final class CertificateAuthoritiesExtension {
                     new CertificateAuthoritiesSpec(chc, buffer);
 
             // Update the context.
-            chc.peerSupportedAuthorities = spec.getAuthorities();
+            try {
+                chc.peerSupportedAuthorities = spec.getAuthorities();
+            } catch (IllegalArgumentException iae) {
+                chc.conContext.fatal(Alert.DECODE_ERROR, "The distinguished " +
+                        "names of the peer's certificate authorities could " +
+                        "not be parsed", iae);
+            }
             chc.handshakeExtensions.put(
                     SSLExtension.CR_CERTIFICATE_AUTHORITIES, spec);
 


### PR DESCRIPTION
This is a backport of [JDK-8294985]: SSLEngine throws IAE during parsing of X500Principal.

This PR will resolve #268.

[JDK-8294985]:
<https://bugs.openjdk.org/browse/JDK-8294985>