### PR TITLE
TKSS-269: Backport JDK-8310106: sun.security.ssl.SSLHandshake.getHandshakeProducer() incorrectly checks handshakeConsumers

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLHandshake.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLHandshake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -514,7 +514,7 @@ enum SSLHandshake implements SSLConsumer, HandshakeProducer {
 
     private HandshakeProducer getHandshakeProducer(
             ConnectionContext context) {
-        if (handshakeConsumers.length == 0) {
+        if (handshakeProducers.length == 0) {
             return null;
         }
 


### PR DESCRIPTION
This is a backport of [JDK-8310106]: sun.security.ssl.SSLHandshake.getHandshakeProducer() incorrectly checks handshakeConsumers.

This PR will resolve #269.

[JDK-8310106]:
<https://bugs.openjdk.org/browse/JDK-8310106>