### PR TITLE
TKSS-270: Backport JDK-8279254: PKCS9Attribute SigningTime always encoded in UTFTime

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerInputStream.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -187,6 +187,10 @@ public class DerInputStream {
 
     public String getGeneralString() throws IOException {
         return getDerValue().getGeneralString();
+    }
+
+    public Date getTime() throws IOException {
+        return getDerValue().getTime();
     }
 
     public Date getUTCTime() throws IOException {

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerOutputStream.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -483,6 +483,23 @@ public final class DerOutputStream
         putLength(data.length);
         write(data, 0, data.length);
         return this;
+    }
+
+    /**
+     * 1/1/1950 is the lowest date that RFC 2630 serializes to UTC time
+     */
+    private static final Date utcLow = new Date(-631152000000L); // Dates before 1/1/1950
+
+    /**
+     * 12/31/2049 is the highest date that RFC 2630 serializes to UTC time
+     */
+    private static final Date utcHigh = new Date(2524607999000L);
+
+    /**
+     * Takes a Date and chooses UTC or GeneralizedTime as per RFC 2630
+     */
+    public DerOutputStream putTime(Date d) {
+        return (d.before(utcLow) || d.after(utcHigh)) ? putGeneralizedTime(d) : putUTCTime(d);
     }
 
     /**

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerValue.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1096,6 +1096,14 @@ public class DerValue {
             throw new IOException("Parse " + type + " time, invalid format");
         }
         return b - '0';
+    }
+
+    /**
+     * Determines whether Date was encoded as UTC or Generalized time and
+     * calls getUTCTime or getGeneralizedTime accordingly
+     */
+    public Date getTime() throws IOException {
+        return (tag == tag_UtcTime) ? getUTCTime() : getGeneralizedTime();
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS9Attribute.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS9Attribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -471,8 +471,7 @@ public class PKCS9Attribute implements DerEncoder {
             case 5:     // signing time
                 byte elemTag = elems[0].getTag();
                 DerInputStream dis = new DerInputStream(elems[0].toByteArray());
-                value = (elemTag == DerValue.tag_GeneralizedTime) ?
-                        dis.getGeneralizedTime() : dis.getUTCTime();
+                value = dis.getTime();
                 break;
 
             case 6:     // countersignature
@@ -579,7 +578,7 @@ public class PKCS9Attribute implements DerEncoder {
             case 5:     // signing time
             {
                 DerOutputStream temp2 = new DerOutputStream();
-                temp2.putUTCTime((Date) value);
+                temp2.putTime((Date) value);
                 temp.write(DerValue.tag_Set, temp2.toByteArray());
             }
             break;


### PR DESCRIPTION
This is a backport of [JDK-8279254]: PKCS9Attribute SigningTime always encoded in UTFTime.

This PR will resolve #270.

[JDK-8279254]:
<https://bugs.openjdk.org/browse/JDK-8279254>