### PR TITLE
TKSS-284: KeyTool supports PBEWithHmacSM3AndSM4

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/KonaCryptoProvider.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/KonaCryptoProvider.java
@@ -72,8 +72,10 @@ public class KonaCryptoProvider extends Provider {
         // PBES2 on SM
         provider.put("AlgorithmParameters.PBES2",
                 "com.tencent.kona.crypto.provider.PBES2Parameters$General");
-        provider.put("AlgorithmParameters.PBESWithHmacSM3AndSM4",
+        provider.put("AlgorithmParameters.PBEWithHmacSM3AndSM4",
                 "com.tencent.kona.crypto.provider.PBES2Parameters$HmacSM3AndSM4");
+        provider.put("Alg.Alias.AlgorithmParameters.PBEWithHmacSM3AndSM4_128",
+                "PBEWithHmacSM3AndSM4");
         provider.put("SecretKeyFactory.PBEWithHmacSM3AndSM4",
                 "com.tencent.kona.crypto.provider.PBEKeyFactory$PBEWithHmacSM3AndSM4");
         provider.put("Alg.Alias.SecretKeyFactory.PBEWithHmacSM3AndSM4_128",

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBES2Parameters.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBES2Parameters.java
@@ -174,6 +174,8 @@ abstract class PBES2Parameters extends AlgorithmParametersSpi {
         }
 
         if (cipherAlgo.equals("SM4")) {
+            keysize = 128; // the SM4 key size always be 128
+
             switch (keysize) {
             case 128:
                 cipherAlgo_OID = sm4128CBC_OID;

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
@@ -398,7 +398,7 @@ public class TestUtils {
             List<String> args) throws Throwable {
         List<String> allJVMOptions = new ArrayList<>();
 
-        if (jvmOptions != null) {
+        if (jvmOptions != null && !jvmOptions.isEmpty()) {
             allJVMOptions.addAll(jvmOptions);
         }
 
@@ -418,7 +418,7 @@ public class TestUtils {
         List<String> cmds = new ArrayList<>();
         cmds.add(javaPath.toString());
 
-        if (jvmOptions != null) {
+        if (jvmOptions != null && !jvmOptions.isEmpty()) {
             cmds.addAll(jvmOptions);
         }
 
@@ -426,7 +426,8 @@ public class TestUtils {
         cmds.add(classpath);
 
         cmds.add(clazz.getName());
-        if (arguments != null) {
+
+        if (arguments != null && !arguments.isEmpty()) {
             cmds.addAll(arguments);
         }
 


### PR DESCRIPTION
KeyTool should support PBEWithHmacSM3AndSM4 on encrypting key store and private key.
This change only affects PKCS12 key store, since JKS key store uses non-PBE algorithm.

This PR will resolve #284.