### PR TITLE
TKSS-286: Update READMEs on KeyTool supports PBEWithHmacSM3AndSM4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Tencent Kona SM Suite is a set of Java security providers, which service the Sha
 
 - [KonaCrypto]，which implements SM2, SM3 and SM4 algorithms based on Java Cryptography Architecture.
 - [KonaPKIX]，which supports ShangMi algorithms on loading certificate and certificate chain verification. It also can load and write key store files containing ShangMi certificates. Additionally, this component provides two utility classes: 
-  - KeyTool, which is the same as `keytool` in JDK, can generate private keys and certificates.
-  - KeyStoreTool, which can import the existing [PEM]-encoded private keys and certificates to key store files.
+  - KeyTool, which is the same as `keytool` in JDK, can generate private keys, and create certificates and key store files. It can use `PBEWithHmacSM3AndSM4` to encrypt private keys and keystore files.
+  - KeyStoreTool, which can import the existing [PEM]-encoded private keys and certificates to keystore files.
 - [KonaSSL] implements China's Transport Layer Cryptographic Protocol, and also applies ShangMi algorithms to TLS 1.3 based on RFC 8998.
 - [Kona], which wraps all the features in `KonaCrypto`，`KonaPKIX` and `KonaSSL`, so it has to depend on one or more of them. Generally, **this provider is recommended**.
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -8,7 +8,7 @@
 
 - [KonaCrypto]，它遵循标准的[JCA]框架实现了国密基础算法SM2，SM3和SM4。
 - [KonaPKIX]，它实现了国密证书的解析与验证，并可加载和创建包含国密证书的密钥库文件。它需要依赖`KonaCrypto`。另外，该组件还提供了两个工具类：
-  - KeyTool，它的功能与JDK中的`keytool`相同，可以创建私钥和证书。
+  - KeyTool，它的功能与JDK中的`keytool`相同，可以生成密钥对，创建证书以及密钥库文件。它支持使用`PBEWithHmacSM3AndSM4`算法对私钥和密钥库文件进行加密。
   - KeyStoreTool，它可以将已有的[PEM]格式的私钥和证书导入密钥库文件。
 - [KonaSSL]，它实现了中国的传输层密码协议（TLCP），并遵循RFC 8998规范将国密基础算法应用到了TLS 1.3协议中。它需要依赖`KonaCrypto`和`KonaPKIX`。
 - [Kona]，它将`KonaCrypto`，`KonaPKIX`和`KonaSSL`中的特性进行了简单的封装，所以它需要根据实际需求去依赖这些Provider中的一个或多个。一般地，**建议使用这个Provider**。

--- a/kona-pkix/README.md
+++ b/kona-pkix/README.md
@@ -191,6 +191,11 @@ java -cp <...> KeyTool \
   -infile ee.csr -outfile ee.crt
 ```
 
+When the type of the keystore file is `PKCS12`, KeyTool can also use `PBEWithHmacSM3AndSM4` to encrypt the private keys and keystore files. Since the `KeyStoreSpi` of JDK does not provide relevant interfaces for setting these encryption algorithms, the following two system properties are provided:
+
+- `com.tencent.kona.keystore.pkcs12.certPbeAlgorithm`, setting the PBE algorithm for encrypting keystore files.
+- `com.tencent.kona.keystore.pkcs12.keyPbeAlgorithm`, setting the PBE algorithm for encrypting private keys.
+
 #### KeyStoreTool
 To facilitate users in importing the existing private keys and certificates using ShangMi algorithms to a keystore, another tool `com.tencent.kona.pkix.tool.KeyStoreTool` is provided. The usage of this tool is as follows:
 

--- a/kona-pkix/README_cn.md
+++ b/kona-pkix/README_cn.md
@@ -190,6 +190,11 @@ java -cp <...> KeyTool \
   -infile ee.csr -outfile ee.crt
 ```
 
+当密钥库文件的类型为`PKCS12`时，KeyTool还可以使用`PBEWithHmacSM3AndSM4`对私钥和密钥库文件进行加密。由于JDK的`KeyStoreSpi`并没有为设置该加密算法提供相关的接口，所以提供了如下两个系统属性：
+
+- `com.tencent.kona.keystore.pkcs12.certPbeAlgorithm`，设置加密密钥库的PBE算法。
+- `com.tencent.kona.keystore.pkcs12.keyPbeAlgorithm`，设置加密私钥的PBE算法。
+
 #### KeyStoreTool
 为了方便用户将已有的国密私钥和证书导入密钥库文件中，提供了另一个工具，即`com.tencent.kona.pkix.tool.KeyStoreTool`。该工具的用法如下，
 


### PR DESCRIPTION
The READMEs should introduce that KeyTool supports PBEWithHmacSM3AndSM4 for encrypting private keys and store files.

This PR will resolve #286.