### PR TITLE
TKSS-288: Backport JDK-8295068: SSLEngine throws NPE parsing CertificateRequests

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateRequest.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateRequest.java
@@ -133,7 +133,7 @@ final class CertificateRequest {
             ArrayList<String> keyTypes = new ArrayList<>(3);
             for (byte id : ids) {
                 ClientCertificateType cct = ClientCertificateType.valueOf(id);
-                if (cct.isAvailable) {
+                if (cct != null && cct.isAvailable) {
                     cct.keyAlgorithm.forEach(key -> {
                         if (!keyTypes.contains(key)) {
                             keyTypes.add(key);


### PR DESCRIPTION
This is a backport of [JDK-8295068]: SSLEngine throws NPE parsing CertificateRequests.

This PR will resolve #288.

[JDK-8295068]:
<https://bugs.openjdk.org/browse/JDK-8295068>