### PR TITLE
TKSS-291: SM3MessageDigest should be cloneable

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM3Engine.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM3Engine.java
@@ -7,7 +7,7 @@ import static com.tencent.kona.crypto.util.Constants.SM3_DIGEST_LEN;
 /**
  * SM3 engine in compliance with China's GB/T 32905-2016.
  */
-public final class SM3Engine {
+public final class SM3Engine implements Cloneable {
 
     // The initial value
     private static final int[] IV = {
@@ -57,14 +57,14 @@ public final class SM3Engine {
     private int[] v;
 
     // W0..W67
-    private final int[] w = new int[68];
+    private int[] w = new int[68];
 
     // A word is 4-bytes or 1-integer.
-    private final byte[] word = new byte[4];
+    private byte[] word = new byte[4];
     private int wordOffset;
 
     // A message block is 512-bits or 16-integers.
-    private final int[] block = new int[SM3_BLOCK_INT_SIZE];
+    private int[] block = new int[SM3_BLOCK_INT_SIZE];
     private int blockOffset;
 
     private long countOfBytes;
@@ -257,6 +257,15 @@ public final class SM3Engine {
         v[5] ^= f;
         v[6] ^= g;
         v[7] ^= h;
+    }
+
+    public SM3Engine clone() throws CloneNotSupportedException {
+        SM3Engine clone = (SM3Engine) super.clone();
+        clone.v = v.clone();
+        clone.w = w.clone();
+        clone.word = word.clone();
+        clone.block = block.clone();
+        return clone;
     }
 
     /* ***** Boolean functions ***** */

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM3MessageDigest.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM3MessageDigest.java
@@ -5,9 +5,9 @@ import java.security.MessageDigest;
 
 import static com.tencent.kona.crypto.util.Constants.SM3_DIGEST_LEN;
 
-public final class SM3MessageDigest extends MessageDigest {
+public final class SM3MessageDigest extends MessageDigest implements Cloneable {
 
-    private final SM3Engine engine = new SM3Engine();
+    private SM3Engine engine = new SM3Engine();
 
     public SM3MessageDigest() {
         super("SM3");
@@ -49,5 +49,11 @@ public final class SM3MessageDigest extends MessageDigest {
     @Override
     protected void engineReset() {
         engine.reset();
+    }
+
+    public Object clone() throws CloneNotSupportedException {
+        SM3MessageDigest clone = (SM3MessageDigest) super.clone();
+        clone.engine = engine.clone();
+        return clone;
     }
 }

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3Test.java
@@ -163,4 +163,19 @@ public class SM3Test {
             }
         }
     }
+
+    @Test
+    public void testClone() throws Exception {
+        MessageDigest md = MessageDigest.getInstance("SM3", PROVIDER);
+        md.update(MESSAGE_LONG, 0, MESSAGE_LONG.length / 3);
+        md.update(MESSAGE_LONG[MESSAGE_LONG.length / 3]);
+
+        MessageDigest clone = (MessageDigest) md.clone();
+        clone.update(MESSAGE_LONG, MESSAGE_LONG.length / 3 + 1,
+                MESSAGE_LONG.length - MESSAGE_LONG.length / 3 - 2);
+        clone.update(MESSAGE_LONG[MESSAGE_LONG.length - 1]);
+        byte[] digest = clone.digest();
+
+        Assertions.assertArrayEquals(DIGEST_LONG, digest);
+    }
 }


### PR DESCRIPTION
The JDK MessageDigest implementations (see `sun.security.provider.DigestBase`) implement `Cloneable`.
So, `SM3MessageDigest` would also follow this routine.

This PR will resolve #291.