### PR TITLE
TKSS-294: Backport JDK-8308398: Move SunEC crypto provider into java.base

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/AlgorithmId.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/AlgorithmId.java
@@ -550,8 +550,8 @@ public class AlgorithmId implements Serializable, DerEncoder {
 //        if (pn != null && mn != null) {
 //            return ((mn.equals("java.base") &&
 //                    (pn.equals("SUN") || pn.equals("SunRsaSign") ||
-//                            pn.equals("SunJCE") || pn.equals("SunJSSE"))) ||
-//                    (mn.equals("jdk.crypto.ec") && pn.equals("SunEC")) ||
+//                    pn.equals("SunJCE") || pn.equals("SunJSSE"))) ||
+//                    pn.equals("SunEC")) ||
 //                    (mn.equals("jdk.crypto.mscapi") && pn.equals("SunMSCAPI")) ||
 //                    (mn.equals("jdk.crypto.cryptoki") &&
 //                            pn.startsWith("SunPKCS11")));


### PR DESCRIPTION
This is a backport of [JDK-8308398]: Move SunEC crypto provider into java.base.
The changes from JDK-8308398 just affects a bit of comments in `com.tencent.kona.sun.security.x509.AlgorithmId`.

This PR will resolve #294.

[JDK-8308398]:
<https://bugs.openjdk.org/browse/JDK-8308398>