### PR TITLE
TKSS-298: Backport JDK-8301553: Support Password-Based Cryptography in SunPKCS11

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBES2Core.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBES2Core.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package com.tencent.kona.crypto.provider;
 
-import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.crypto.util.Constants;
 
 import java.security.*;
@@ -33,6 +32,9 @@ import java.security.spec.*;
 import java.util.Arrays;
 import javax.crypto.*;
 import javax.crypto.spec.*;
+
+import com.tencent.kona.jdk.internal.misc.SharedSecretsUtil;
+import com.tencent.kona.sun.security.util.PBEUtil;
 
 /**
  * This class represents password-based encryption as defined by the PKCS #5
@@ -47,9 +49,6 @@ import javax.crypto.spec.*;
  */
 abstract class PBES2Core extends CipherSpi {
 
-    private static final int DEFAULT_SALT_LENGTH = 20;
-    private static final int DEFAULT_COUNT = 4096;
-
     // the encapsulated cipher
     private final CipherCore cipher;
     private final int keyLength; // in bits
@@ -57,9 +56,7 @@ abstract class PBES2Core extends CipherSpi {
     private final PBKDF2Core kdf;
     private final String pbeAlgo;
     private final String cipherAlgo;
-    private int iCount = DEFAULT_COUNT;
-    private byte[] salt = null;
-    private IvParameterSpec ivSpec = null;
+    private final PBEUtil.PBES2Params pbes2Params = new PBEUtil.PBES2Params();
 
     /**
      * Creates an instance of PBE Scheme 2 according to the selected
@@ -124,35 +121,8 @@ abstract class PBES2Core extends CipherSpi {
     }
 
     protected AlgorithmParameters engineGetParameters() {
-        AlgorithmParameters params = null;
-        if (salt == null) {
-            // generate random salt and use default iteration count
-            salt = new byte[DEFAULT_SALT_LENGTH];
-//            SunJCE.getRandom().nextBytes(salt);
-            SecureRandomHolder.getRandom().nextBytes(salt);
-            iCount = DEFAULT_COUNT;
-        }
-        if (ivSpec == null) {
-            // generate random IV
-            byte[] ivBytes = new byte[blkSize];
-//            SunJCE.getRandom().nextBytes(ivBytes);
-            SecureRandomHolder.getRandom().nextBytes(ivBytes);
-            ivSpec = new IvParameterSpec(ivBytes);
-        }
-        PBEParameterSpec pbeSpec = new PBEParameterSpec(salt, iCount, ivSpec);
-        try {
-//            params = AlgorithmParameters.getInstance(pbeAlgo,
-//                SunJCE.getInstance());
-            params = CryptoInsts.getAlgorithmParameters(pbeAlgo);
-            params.init(pbeSpec);
-        } catch (NoSuchAlgorithmException nsae) {
-            // should never happen
-            throw new RuntimeException("SunJCE called, but not configured");
-        } catch (InvalidParameterSpecException ipse) {
-            // should never happen
-            throw new RuntimeException("PBEParameterSpec not supported");
-        }
-        return params;
+        return pbes2Params.getAlgorithmParameters(
+                blkSize, pbeAlgo, SecureRandomHolder.getRandom());
     }
 
     protected void engineInit(int opmode, Key key, SecureRandom random)
@@ -164,136 +134,45 @@ abstract class PBES2Core extends CipherSpi {
         }
     }
 
-    private static byte[] check(byte[] salt)
-        throws InvalidAlgorithmParameterException {
-        if (salt != null && salt.length < 8) {
-            throw new InvalidAlgorithmParameterException(
-                    "Salt must be at least 8 bytes long");
-        }
-        return salt;
-    }
-
-    private static int check(int iCount)
-        throws InvalidAlgorithmParameterException {
-        if (iCount < 0) {
-            throw new InvalidAlgorithmParameterException(
-                    "Iteration count must be a positive number");
-        }
-        return iCount == 0 ? DEFAULT_COUNT : iCount;
-    }
-
     protected void engineInit(int opmode, Key key,
                               AlgorithmParameterSpec params,
                               SecureRandom random)
         throws InvalidKeyException, InvalidAlgorithmParameterException {
 
-        if (key == null) {
-            throw new InvalidKeyException("Null key");
-        }
-
-        byte[] passwdBytes = key.getEncoded();
-        char[] passwdChars = null;
-        salt = null;
-        iCount = 0;
-        ivSpec = null;
-
-        PBEKeySpec pbeSpec;
-        try {
-            if ((passwdBytes == null) ||
-                    !(key.getAlgorithm().regionMatches(true, 0, "PBE", 0, 3))) {
-                throw new InvalidKeyException("Missing password");
-            }
-
-            boolean doEncrypt = ((opmode == Cipher.ENCRYPT_MODE) ||
-                        (opmode == Cipher.WRAP_MODE));
-
-            // Extract from the supplied PBE params, if present
-            if (params instanceof PBEParameterSpec) {
-                PBEParameterSpec pbeParams = (PBEParameterSpec) params;
-                // salt should be non-null per PBEParameterSpec
-                salt = check(pbeParams.getSalt());
-                iCount = check(pbeParams.getIterationCount());
-                AlgorithmParameterSpec ivParams = pbeParams.getParameterSpec();
-                if (ivParams instanceof IvParameterSpec) {
-                    IvParameterSpec iv = (IvParameterSpec) ivParams;
-                    ivSpec = iv;
-                } else if (ivParams == null && doEncrypt) {
-                    // generate random IV
-                    byte[] ivBytes = new byte[blkSize];
-                    random.nextBytes(ivBytes);
-                    ivSpec = new IvParameterSpec(ivBytes);
-                } else {
-                    throw new InvalidAlgorithmParameterException(
-                            "Wrong parameter type: IV expected");
-                }
-            } else if (params == null && doEncrypt) {
-                // Try extracting from the key if present. If unspecified,
-                // PBEKey returns null and 0 respectively.
-                if (key instanceof javax.crypto.interfaces.PBEKey) {
-                    javax.crypto.interfaces.PBEKey pbeKey
-                            = (javax.crypto.interfaces.PBEKey) key;
-                    salt = check(pbeKey.getSalt());
-                    iCount = check(pbeKey.getIterationCount());
-                }
-                if (salt == null) {
-                    // generate random salt
-                    salt = new byte[DEFAULT_SALT_LENGTH];
-                    random.nextBytes(salt);
-                }
-                if (iCount == 0) {
-                    // use default iteration count
-                    iCount = DEFAULT_COUNT;
-                }
-                // generate random IV
-                byte[] ivBytes = new byte[blkSize];
-                random.nextBytes(ivBytes);
-                ivSpec = new IvParameterSpec(ivBytes);
-            } else {
-                throw new InvalidAlgorithmParameterException
-                        ("Wrong parameter type: PBE expected");
-            }
-            passwdChars = new char[passwdBytes.length];
-            for (int i = 0; i < passwdChars.length; i++)
-                passwdChars[i] = (char) (passwdBytes[i] & 0x7f);
-
-            pbeSpec = new PBEKeySpec(passwdChars, salt, iCount, keyLength);
-        } finally {
-            // password char[] was cloned in PBEKeySpec constructor,
-            // so we can zero it out here
-            if (passwdChars != null) Arrays.fill(passwdChars, '\0');
-            if (passwdBytes != null) Arrays.fill(passwdBytes, (byte)0x00);
-        }
-
-        PBKDF2KeyImpl s;
+        PBEKeySpec pbeSpec = pbes2Params.getPBEKeySpec(blkSize, keyLength,
+                opmode, key, params, random);
+        PBKDF2KeyImpl s = null;
+        byte[] derivedKey;
 
         try {
             s = (PBKDF2KeyImpl)kdf.engineGenerateSecret(pbeSpec);
+            derivedKey = s.getEncoded();
         } catch (InvalidKeySpecException ikse) {
             throw new InvalidKeyException("Cannot construct PBE key", ikse);
         } finally {
+            if (s != null) {
+                s.clear();
+            }
             pbeSpec.clearPassword();
         }
-        byte[] derivedKey = s.getEncoded();
-        s.clearPassword();
-        SecretKeySpec cipherKey = new SecretKeySpec(derivedKey, cipherAlgo);
-
-        // initialize the underlying cipher
-        cipher.init(opmode, cipherKey, ivSpec, random);
+        SecretKeySpec cipherKey = null;
+        try {
+            cipherKey = new SecretKeySpec(derivedKey, cipherAlgo);
+            // initialize the underlying cipher
+            cipher.init(opmode, cipherKey, pbes2Params.getIvSpec(), random);
+        } finally {
+            if (cipherKey != null) {
+                SharedSecretsUtil.cryptoSpecClearSecretKeySpec(cipherKey);
+            }
+            Arrays.fill(derivedKey, (byte) 0);
+        }
     }
 
     protected void engineInit(int opmode, Key key, AlgorithmParameters params,
                               SecureRandom random)
         throws InvalidKeyException, InvalidAlgorithmParameterException {
-        AlgorithmParameterSpec pbeSpec = null;
-        if (params != null) {
-            try {
-                pbeSpec = params.getParameterSpec(PBEParameterSpec.class);
-            } catch (InvalidParameterSpecException ipse) {
-                throw new InvalidAlgorithmParameterException(
-                    "Wrong parameter type: PBE expected");
-            }
-        }
-        engineInit(opmode, key, pbeSpec, random);
+        engineInit(opmode, key, PBEUtil.PBES2Params.getParameterSpec(params),
+                random);
     }
 
     protected byte[] engineUpdate(byte[] input, int inputOffset, int inputLen) {

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/util/Sweeper.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/util/Sweeper.java
@@ -1,0 +1,108 @@
+package com.tencent.kona.crypto.util;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * A worker used to clean resources, say native memory.
+ */
+public class Sweeper {
+
+    private static class InstanceHolder {
+        private static final Sweeper INSTANCE = new Sweeper();
+    }
+
+    /**
+     * Get the default Sweeper instance.
+     * Generally, it just uses this sweeper only.
+     */
+    public static Sweeper instance() {
+        return InstanceHolder.INSTANCE;
+    }
+
+    private final Collection<ResourceHolderRef> resourceHolderRefs
+            = new ConcurrentLinkedQueue<>();
+
+    private final ReferenceQueue<Object> resourceHolderRefQueue
+            = new ReferenceQueue<>();
+
+    private class ResourceHolderRef extends PhantomReference<Object> {
+
+        private final Runnable sweep;
+
+        private ResourceHolderRef(Object resourceHolder,
+                ReferenceQueue<Object> resourceHolderRefQueue,
+                Runnable sweep) {
+            super(resourceHolder, resourceHolderRefQueue);
+            this.sweep = sweep;
+        }
+
+        @Override
+        public void clear() {
+            sweep.run();
+            resourceHolderRefs.remove(this);
+            super.clear();
+        }
+    }
+
+    private final Thread sweeperThread;
+    private boolean started = false;
+
+    public Sweeper(boolean startImmediately) {
+        sweeperThread = new Thread(() -> {
+            while (true) {
+                try {
+                    resourceHolderRefQueue.remove().clear();
+                } catch (Throwable t) {
+                    // just ignore it
+                }
+            }
+        });
+        sweeperThread.setDaemon(true);
+
+        if (startImmediately) {
+            start();
+        }
+    }
+
+    public Sweeper() {
+        this(true);
+    }
+
+    /**
+     * Start to sweep with a single thread.
+     */
+    public synchronized void start() {
+        if (!started) {
+            sweeperThread.start();
+            started = true;
+        }
+    }
+
+    /**
+     * Registers a resource holder and a sweeping action to run when the
+     * resource holder becomes phantom reachable.
+     */
+    public void register(Object resourceHolder, Runnable sweep) {
+        Objects.requireNonNull(resourceHolder);
+        Objects.requireNonNull(sweep);
+
+        resourceHolderRefs.add(new ResourceHolderRef(
+                resourceHolder, resourceHolderRefQueue, sweep));
+    }
+
+    public void clean() {
+        // Do nothing
+    }
+
+    public int size() {
+        return resourceHolderRefs.size();
+    }
+
+    public boolean isEmpty() {
+        return resourceHolderRefs.isEmpty();
+    }
+}

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/PBEUtil.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/PBEUtil.java
@@ -25,6 +25,8 @@
 
 package com.tencent.kona.sun.security.util;
 
+import com.tencent.kona.crypto.CryptoInsts;
+
 import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -128,15 +130,14 @@ public final class PBEUtil {
          * P11PBECipher (SunPKCS11).
          */
         public AlgorithmParameters getAlgorithmParameters(int blkSize,
-                String pbeAlgo, Provider algParamsProv, SecureRandom random) {
+                String pbeAlgo, SecureRandom random) {
             AlgorithmParameters params;
             try {
                 if (iCount == 0 && salt == null && ivSpec == null) {
                     initialize(blkSize, Cipher.ENCRYPT_MODE, 0, null, null,
                             random);
                 }
-                params = AlgorithmParameters.getInstance(pbeAlgo,
-                        algParamsProv);
+                params = CryptoInsts.getAlgorithmParameters(pbeAlgo);
                 params.init(new PBEParameterSpec(salt, iCount, ivSpec));
             } catch (NoSuchAlgorithmException nsae) {
                 // should never happen


### PR DESCRIPTION
This is a backport of [JDK-8301553]: Support Password-Based Cryptography in SunPKCS11.

This PR will resolve #298.

[JDK-8301553]:
<https://bugs.openjdk.org/browse/JDK-8301553>