### PR TITLE
TKSS-305: Backport JDK-8309867: redundant class field RSAPadding.md

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAPadding.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/rsa/RSAPadding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,9 +103,6 @@ public final class RSAPadding {
     // maximum size of the data
     private final int maxDataSize;
 
-    // OAEP: main message digest
-    private MessageDigest md;
-
     // OAEP: MGF1
     private MGF1 mgf;
 
@@ -152,6 +149,8 @@ public final class RSAPadding {
             // sanity check, already verified in RSASignature/RSACipher
             throw new InvalidKeyException("Padded size must be at least 64");
         }
+        // OAEP: main message digest
+        MessageDigest md;
         switch (type) {
         case PAD_BLOCKTYPE_1:
         case PAD_BLOCKTYPE_2:


### PR DESCRIPTION
This is backport of [JDK-8309867]: redundant class field RSAPadding.md.

This PR will resolve #305.

[JDK-8309867]:
<https://bugs.openjdk.org/browse/JDK-8309867>