### PR TITLE
TKSS-306: Backport JDK-8312443: sun.security should use toLowerCase(Locale.ROOT)

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/action/GetPropertyAction.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/action/GetPropertyAction.java
@@ -27,6 +27,7 @@ package com.tencent.kona.sun.security.action;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Locale;
 import java.util.Properties;
 import com.tencent.kona.sun.security.util.Debug;
 
@@ -194,10 +195,10 @@ public class GetPropertyAction implements PrivilegedAction<String> {
         // the original value in rawPropVal for debug messages.
         boolean isMillis = false;
         String propVal = rawPropVal;
-        if (rawPropVal.toLowerCase().endsWith("ms")) {
+        if (rawPropVal.toLowerCase(Locale.ROOT).endsWith("ms")) {
             propVal = rawPropVal.substring(0, rawPropVal.length() - 2);
             isMillis = true;
-        } else if (rawPropVal.toLowerCase().endsWith("s")) {
+        } else if (rawPropVal.toLowerCase(Locale.ROOT).endsWith("s")) {
             propVal = rawPropVal.substring(0, rawPropVal.length() - 1);
         }
 


### PR DESCRIPTION
This is a backport [JDK-8312443]: sun.security should use toLowerCase(Locale.ROOT).

This PR will resolve #306.

[JDK-8312443]:
<https://bugs.openjdk.org/browse/JDK-8312443>