### PR TITLE
TKSS-310: JDK peers should support different providers

### DIFF
--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkClient.java
@@ -79,7 +79,7 @@ public class JdkClient extends AbstractClient {
 
     protected SSLContext getContext(Builder builder) throws Exception {
         return builder.getContext() == null
-                ? Utilities.createSSLContext(
+                ? Utilities.createSSLContext(builder.getProvider(),
                         builder.getContextProtocol(), builder.getCertTuple())
                 : builder.getContext();
     }
@@ -111,8 +111,19 @@ public class JdkClient extends AbstractClient {
 
     public static class Builder extends AbstractClient.Builder {
 
+        private Provider provider = Provider.KONA;
+
         private ConnectionInterceptor interceptor;
         private SSLContext context;
+
+        public Provider getProvider() {
+            return provider;
+        }
+
+        public AbstractPeer.Builder setProvider(Provider provider) {
+            this.provider = provider;
+            return this;
+        }
 
         public ConnectionInterceptor getInterceptor() {
             return interceptor;

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkHttpsClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkHttpsClient.java
@@ -48,7 +48,7 @@ public class JdkHttpsClient extends AbstractClient {
 
     protected SSLContext getContext(Builder builder) throws Exception {
         return builder.getContext() == null
-                ? Utilities.createSSLContext(
+                ? Utilities.createSSLContext(builder.getProvider(),
                         builder.getContextProtocol(), builder.getCertTuple())
                 : builder.getContext();
     }
@@ -56,6 +56,8 @@ public class JdkHttpsClient extends AbstractClient {
     public static class Builder extends AbstractClient.Builder {
 
         private String path = "";
+
+        private Provider provider = Provider.KONA;
 
         private SSLContext context;
 
@@ -65,6 +67,15 @@ public class JdkHttpsClient extends AbstractClient {
 
         public Builder setPath(String path) {
             this.path = path;
+            return this;
+        }
+
+        public Provider getProvider() {
+            return provider;
+        }
+
+        public AbstractPeer.Builder setProvider(Provider provider) {
+            this.provider = provider;
             return this;
         }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcClient.java
@@ -102,6 +102,7 @@ public class JdkProcClient extends AbstractClient {
 
         if (Utilities.DEBUG) {
             props.put("com.tencent.kona.ssl.debug", "all");
+            props.put("javax.net.debug", "all");
         }
 
         props.putAll(builder.getAllProps());
@@ -110,6 +111,8 @@ public class JdkProcClient extends AbstractClient {
     public static class Builder extends AbstractClient.Builder {
 
         private Jdk jdk = Jdk.DEFAULT;
+
+        private Provider provider = Provider.KONA;
 
         private Path secPropsFile;
 
@@ -130,6 +133,16 @@ public class JdkProcClient extends AbstractClient {
             this.secPropsFile = secPropsFile;
             return this;
         }
+
+        public Provider getProvider() {
+            return provider;
+        }
+
+        public AbstractPeer.Builder setProvider(Provider provider) {
+            this.provider = provider;
+            return this;
+        }
+
 
         @Override
         public JdkProcClient build() {
@@ -167,7 +180,11 @@ public class JdkProcClient extends AbstractClient {
     }
 
     public static void main(String[] args) throws Exception {
-        TestUtils.addProviders();
+        String providerStr = System.getProperty(
+                JdkProcUtils.PROP_PROVIDER, Provider.KONA.name);
+        if (Provider.KONA.name.equals(providerStr)) {
+            TestUtils.addProviders();
+        }
 
         String trustedCertsStr = System.getProperty(JdkProcUtils.PROP_TRUSTED_CERTS);
         String eeCertsStr = System.getProperty(JdkProcUtils.PROP_EE_CERTS);
@@ -186,6 +203,7 @@ public class JdkProcClient extends AbstractClient {
         String readResponseStr = System.getProperty(JdkProcUtils.PROP_READ_RESPONSE);
 
         JdkClient.Builder builder = new JdkClient.Builder();
+        builder.setProvider(Provider.provider(providerStr));
         builder.setCertTuple(JdkProcUtils.createCertTuple(
                 trustedCertsStr, eeCertsStr));
         builder.setContextProtocol(

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcServer.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcServer.java
@@ -53,6 +53,8 @@ public class JdkProcServer extends AbstractServer {
                     builder.getSecPropsFile().toString());
         }
 
+        props.put(JdkProcUtils.PROP_PROVIDER, builder.getProvider().name);
+
         if (builder.getCertTuple() != null) {
             props.put(JdkProcUtils.PROP_TRUSTED_CERTS,
                     JdkProcUtils.certsToStr(builder.getCertTuple().trustedCerts));
@@ -104,6 +106,7 @@ public class JdkProcServer extends AbstractServer {
 
         if (Utilities.DEBUG) {
             props.put("com.tencent.kona.ssl.debug", "all");
+            props.put("javax.net.debug", "all");
         }
 
         props.putAll(builder.getAllProps());
@@ -114,6 +117,8 @@ public class JdkProcServer extends AbstractServer {
         private Jdk jdk = Jdk.DEFAULT;
 
         private Path secPropsFile;
+
+        private Provider provider = Provider.KONA;
 
         public Jdk getJdk() {
             return jdk;
@@ -130,6 +135,15 @@ public class JdkProcServer extends AbstractServer {
 
         public Builder setSecPropsFile(Path secPropsFile) {
             this.secPropsFile = secPropsFile;
+            return this;
+        }
+
+        public Provider getProvider() {
+            return provider;
+        }
+
+        public AbstractPeer.Builder setProvider(Provider provider) {
+            this.provider = provider;
             return this;
         }
 
@@ -205,7 +219,11 @@ public class JdkProcServer extends AbstractServer {
     }
 
     public static void main(String[] args) throws Exception {
-        TestUtils.addProviders();
+        String providerStr = System.getProperty(
+                JdkProcUtils.PROP_PROVIDER, Provider.KONA.name);
+        if (Provider.KONA.name.equals(providerStr)) {
+            TestUtils.addProviders();
+        }
 
         String trustedCertsStr = System.getProperty(JdkProcUtils.PROP_TRUSTED_CERTS);
         String eeCertsStr = System.getProperty(JdkProcUtils.PROP_EE_CERTS);
@@ -224,6 +242,7 @@ public class JdkProcServer extends AbstractServer {
         String messageStr = System.getProperty(JdkProcUtils.PROP_MESSAGE);
 
         JdkServer.Builder builder = new JdkServer.Builder();
+        builder.setProvider(Provider.provider(providerStr));
         builder.setCertTuple(JdkProcUtils.createCertTuple(
                 trustedCertsStr, eeCertsStr));
         builder.setContextProtocol(

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcUtils.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcUtils.java
@@ -41,6 +41,7 @@ public class JdkProcUtils {
     public static final String PROP_PORT = "test.port";
 
     public static final String PROP_SEC_PROPS_FILE = "java.security.properties";
+    public static final String PROP_PROVIDER = "test.provider";
     public static final String PROP_CTX_PROTOCOL = "test.context.protocol";
     public static final String PROP_PROTOCOLS = "test.protocols";
     public static final String PROP_CIPHER_SUITES = "test.cipher.suites";

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkServer.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkServer.java
@@ -68,7 +68,7 @@ public class JdkServer extends AbstractServer {
 
         response = builder.getMessage();
 
-        context = Utilities.createSSLContext(
+        context = Utilities.createSSLContext(builder.getProvider(),
                 builder.getContextProtocol(), builder.getCertTuple());
         SSLServerSocketFactory serverFactory = context.getServerSocketFactory();
         serverSocket
@@ -114,6 +114,17 @@ public class JdkServer extends AbstractServer {
     }
 
     public static class Builder extends AbstractServer.Builder {
+
+        private Provider provider = Provider.KONA;
+
+        public Provider getProvider() {
+            return provider;
+        }
+
+        public AbstractPeer.Builder setProvider(Provider provider) {
+            this.provider = provider;
+            return this;
+        }
 
         @Override
         public JdkServer build() throws Exception {

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/Provider.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/Provider.java
@@ -1,0 +1,22 @@
+package com.tencent.kona.ssl.interop;
+
+public enum Provider {
+
+    JDK("JDK"), KONA("Kona");
+
+    public final String name;
+
+    private Provider(String name) {
+        this.name = name;
+    }
+
+    public static Provider provider(String name) {
+        for (Provider provider : values()) {
+            if (provider.name.equals(name)) {
+                return provider;
+            }
+        }
+
+        return null;
+    }
+}

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/Utilities.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/Utilities.java
@@ -113,10 +113,10 @@ public class Utilities {
         return cipherSuites;
     }
 
-    public static SSLContext createSSLContext(String provider,
-            String contextProtocol, CertTuple certTuple) throws Exception {
-        String sslProvider = provider.equalsIgnoreCase("JDK") ? "SunJSSE" : "KonaSSL";
-        String pkixProvider = provider.equalsIgnoreCase("JDK") ? "SUN" : "KonaPKIX";
+    public static SSLContext createSSLContext(Provider provider,
+            ContextProtocol contextProtocol, CertTuple certTuple) throws Exception {
+        String sslProvider = provider == Provider.JDK ? "SunJSSE" : "KonaSSL";
+        String pkixProvider = provider == Provider.JDK ? "SUN" : "KonaPKIX";
 
         KeyStore trustStore = createTrustStore(pkixProvider, certTuple.trustedCerts);
         TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX", sslProvider);
@@ -126,18 +126,9 @@ public class Utilities {
         KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509", sslProvider);
         kmf.init(keyStore, null);
 
-        SSLContext context = SSLContext.getInstance(contextProtocol, sslProvider);
+        SSLContext context = SSLContext.getInstance(contextProtocol.name, sslProvider);
         context.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
         return context;
-    }
-
-    /*
-     * Creates SSL context with the specified certificates.
-     */
-    public static SSLContext createSSLContext(
-            ContextProtocol contextProtocol, CertTuple certTuple)
-            throws Exception {
-        return createSSLContext(PROVIDER, contextProtocol.name, certTuple);
     }
 
     /*


### PR DESCRIPTION
Currently, JDK peers support Kona-family providers only.
However, it should also support the OpenJDK-family providers, say SunJSSE.

This PR will resolve #310.