### PR TITLE
TKSS-316: TLS JMH tests meet compilation error

### DIFF
--- a/kona-ssl/src/jmh/java/com/tencent/kona/ssl/perf/KonaSSLTlcpHandshakePerfTest.java
+++ b/kona-ssl/src/jmh/java/com/tencent/kona/ssl/perf/KonaSSLTlcpHandshakePerfTest.java
@@ -24,6 +24,7 @@
 package com.tencent.kona.ssl.perf;
 
 import com.tencent.kona.ssl.interop.ContextProtocol;
+import com.tencent.kona.ssl.interop.Provider;
 import com.tencent.kona.ssl.interop.SmCertTuple;
 import com.tencent.kona.ssl.interop.Utilities;
 import com.tencent.kona.ssl.TestUtils;
@@ -91,9 +92,9 @@ public class KonaSSLTlcpHandshakePerfTest {
 
     @Setup(Level.Trial)
     public void init() throws Exception {
-        serverContext = Utilities.createSSLContext(
+        serverContext = Utilities.createSSLContext(Provider.KONA,
                 ContextProtocol.TLCP11, SERVER_CERT_TUPLE);
-        clientContext = Utilities.createSSLContext(
+        clientContext = Utilities.createSSLContext(Provider.KONA,
                 ContextProtocol.TLCP11, CLIENT_CERT_TUPLE);
     }
 

--- a/kona-ssl/src/jmh/java/com/tencent/kona/ssl/perf/KonaSSLTlsHandshakePerfTest.java
+++ b/kona-ssl/src/jmh/java/com/tencent/kona/ssl/perf/KonaSSLTlsHandshakePerfTest.java
@@ -29,6 +29,7 @@ import com.tencent.kona.ssl.interop.ContextProtocol;
 import com.tencent.kona.ssl.interop.FileCert;
 import com.tencent.kona.ssl.interop.HashAlgorithm;
 import com.tencent.kona.ssl.interop.KeyAlgorithm;
+import com.tencent.kona.ssl.interop.Provider;
 import com.tencent.kona.ssl.interop.SignatureAlgorithm;
 import com.tencent.kona.ssl.interop.Utilities;
 import com.tencent.kona.ssl.TestUtils;
@@ -104,9 +105,9 @@ public class KonaSSLTlsHandshakePerfTest {
 
     @Setup(Level.Trial)
     public void init() throws Exception {
-        serverContext = Utilities.createSSLContext(
+        serverContext = Utilities.createSSLContext(Provider.KONA,
                 ContextProtocol.TLS, CERT_TUPLE);
-        clientContext = Utilities.createSSLContext(
+        clientContext = Utilities.createSSLContext(Provider.KONA,
                 ContextProtocol.TLS, CERT_TUPLE);
     }
 

--- a/kona-ssl/src/jmh/java/com/tencent/kona/ssl/perf/SunJSSETlsHandshakePerfTest.java
+++ b/kona-ssl/src/jmh/java/com/tencent/kona/ssl/perf/SunJSSETlsHandshakePerfTest.java
@@ -30,6 +30,7 @@ import com.tencent.kona.ssl.interop.FileCert;
 import com.tencent.kona.ssl.interop.HashAlgorithm;
 import com.tencent.kona.ssl.interop.KeyAlgorithm;
 import com.tencent.kona.ssl.interop.Protocol;
+import com.tencent.kona.ssl.interop.Provider;
 import com.tencent.kona.ssl.interop.SignatureAlgorithm;
 import com.tencent.kona.ssl.interop.Utilities;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -97,10 +98,10 @@ public class SunJSSETlsHandshakePerfTest {
 
     @Setup(Level.Trial)
     public void init() throws Exception {
-        serverContext = Utilities.createSSLContext(
-                "JDK", ContextProtocol.TLS.name, CERT_TUPLE);
-        clientContext = Utilities.createSSLContext(
-                "JDK", ContextProtocol.TLS.name, CERT_TUPLE);
+        serverContext = Utilities.createSSLContext(Provider.JDK,
+                ContextProtocol.TLS, CERT_TUPLE);
+        clientContext = Utilities.createSSLContext(Provider.JDK,
+                ContextProtocol.TLS, CERT_TUPLE);
     }
 
     /**


### PR DESCRIPTION
Issue #310 (PR #311) refactored [java/com/tencent/kona/ssl/interop/Utilities.java], but the TLS JMH tests didn't modified accordingly.

This PR will resolve #316.

[java/com/tencent/kona/ssl/interop/Utilities.java]:
<https://github.com/Tencent/TencentKonaSMSuite/blob/5a5da3efa9045a0da887aeccc2bd1621a7aa08c6/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/Utilities.java>