### PR TITLE
TKSS-319: KeyStoreUtil::getKeyStore should release resource

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/tools/KeyStoreUtil.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/tools/KeyStoreUtil.java
@@ -30,6 +30,7 @@ import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 
 import java.io.StreamTokenizer;
@@ -294,7 +295,9 @@ public class KeyStoreUtil {
             CertificateException {
         String type = keyStoreType(file);
         KeyStore keyStore = PKIXInsts.getKeyStore(type);
-        keyStore.load(new FileInputStream(file), password);
+        try (InputStream in = new FileInputStream(file)) {
+            keyStore.load(in, password);
+        }
         return keyStore;
     }
 


### PR DESCRIPTION
`KeyStoreUtil::getKeyStore` loads keystore from `InputStream`, but it doesn't release the resource after loading.

This PR will resolve #319.