### PR TITLE
TKSS-318: Backport JDK-8312578: Redundant javadoc in X400Address

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X400Address.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X400Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -337,12 +337,6 @@ public class X400Address implements GeneralNameInterface {
 
     // Private data members
     DerValue derValue;
-
-    /**
-     * Create the X400Address object from the specified byte array
-     *
-     * @param value value of the name as a byte array
-     */
 
     /**
      * Create the X400Address object from the passed encoded Der value.


### PR DESCRIPTION
This is a backport of [JDK-8312578:] Redundant javadoc in X400Address.

This PR will resolve #318.

[JDK-8312578:]:
<https://bugs.openjdk.org/browse/JDK-8312578>