### PR TITLE
TKSS-322: Backport JDK-6453901: (cal) clean up sun.util.calendar classes

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/AbstractCalendar.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/AbstractCalendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,20 +78,6 @@ public abstract class AbstractCalendar extends CalendarSystem {
             System.arraycopy(eras, 0, e, 0, eras.length);
         }
         return e;
-    }
-
-    public void setEra(CalendarDate date, String eraName) {
-        if (eras == null) {
-            return; // should report an error???
-        }
-        for (int i = 0; i < eras.length; i++) {
-            Era e = eras[i];
-            if (e != null && e.getName().equals(eraName)) {
-                date.setEra(e);
-                return;
-            }
-        }
-        throw new IllegalArgumentException("unknown era name: " + eraName);
     }
 
     protected void setEras(Era[] eras) {
@@ -257,15 +243,6 @@ public abstract class AbstractCalendar extends CalendarSystem {
         return cdate;
     }
 
-    /**
-     * Returns 7 in this default implementation.
-     *
-     * @return 7
-     */
-    public int getWeekLength() {
-        return 7;
-    }
-
     protected abstract boolean isLeapYear(CalendarDate date);
 
     public CalendarDate getNthDayOfWeek(int nth, int dayOfWeek, CalendarDate date) {
@@ -340,7 +317,7 @@ public abstract class AbstractCalendar extends CalendarSystem {
      * method stores the calculated calendar field values in the specified
      * <code>CalendarDate</code>.
      *
-     * @param date a <code>CalendarDate</code> to stored the
+     * @param date a <code>CalendarDate</code> to store the
      * calculated calendar fields.
      * @param fixedDate a fixed date to calculate calendar fields
      * @see AbstractCalendar.html#fixed_date

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/BaseCalendar.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/BaseCalendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -307,10 +307,6 @@ public abstract class BaseCalendar extends AbstractCalendar {
         return isLeapYear(((Date)date).getNormalizedYear()) ? 366 : 365;
     }
 
-    public int getYearLengthInMonths(CalendarDate date) {
-        return 12;
-    }
-
     static final int[] DAYS_IN_MONTH
         //  12   1   2   3   4   5   6   7   8   9  10  11  12
         = { 31, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
@@ -494,7 +490,7 @@ public abstract class BaseCalendar extends AbstractCalendar {
      */
     final int getGregorianYearFromFixedDate(long fixedDate) {
         long d0;
-        int  d1, d2, d3, d4;
+        int  d1, d2, d3;
         int  n400, n100, n4, n1;
         int  year;
 
@@ -507,7 +503,6 @@ public abstract class BaseCalendar extends AbstractCalendar {
             n4 = d2 / 1461;
             d3 = d2 % 1461;
             n1 = d3 / 365;
-            d4 = (d3 % 365) + 1;
         } else {
             d0 = fixedDate - 1;
             n400 = (int)CalendarUtils.floorDivide(d0, 146097L);
@@ -517,7 +512,6 @@ public abstract class BaseCalendar extends AbstractCalendar {
             n4 = CalendarUtils.floorDivide(d2, 1461);
             d3 = CalendarUtils.mod(d2, 1461);
             n1 = CalendarUtils.floorDivide(d3, 365);
-            d4 = CalendarUtils.mod(d3, 365) + 1;
         }
         year = 400 * n400 + 100 * n100 + 4 * n4 + n1;
         if (!(n100 == 4 || n1 == 4)) {
@@ -529,7 +523,7 @@ public abstract class BaseCalendar extends AbstractCalendar {
     /**
      * @return true if the specified year is a Gregorian leap year, or
      * false otherwise.
-     * @see BaseCalendar#isGregorianLeapYear
+     * @see CalendarUtils#isGregorianLeapYear
      */
     protected boolean isLeapYear(CalendarDate date) {
         return isLeapYear(((Date)date).getNormalizedYear());

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/CalendarDate.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/CalendarDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,7 +152,7 @@ public abstract class CalendarDate implements Cloneable {
      * @return <code>true</code> if this <code>CalendarDate</code> is
      * normalized and the year of this <code>CalendarDate</code> is a
      * leap year, or <code>false</code> otherwise.
-     * @see BaseCalendar#isGregorianLeapYear
+     * @see CalendarUtils#isGregorianLeapYear
      */
     public boolean isLeapYear() {
         return leapYear;
@@ -189,14 +189,6 @@ public abstract class CalendarDate implements Cloneable {
     public CalendarDate setDayOfMonth(int date) {
         if (dayOfMonth != date) {
             dayOfMonth = date;
-            normalized = false;
-        }
-        return this;
-    }
-
-    public CalendarDate addDayOfMonth(int n) {
-        if (n != 0) {
-            dayOfMonth += n;
             normalized = false;
         }
         return this;
@@ -247,14 +239,6 @@ public abstract class CalendarDate implements Cloneable {
         return this;
     }
 
-    public CalendarDate addMinutes(int n) {
-        if (n != 0) {
-            minutes += n;
-            normalized = false;
-        }
-        return this;
-    }
-
     public int getSeconds() {
         return seconds;
     }
@@ -267,14 +251,6 @@ public abstract class CalendarDate implements Cloneable {
         return this;
     }
 
-    public CalendarDate addSeconds(int n) {
-        if (n != 0) {
-            seconds += n;
-            normalized = false;
-        }
-        return this;
-    }
-
     public int getMillis() {
         return millis;
     }
@@ -282,14 +258,6 @@ public abstract class CalendarDate implements Cloneable {
     public CalendarDate setMillis(int millis) {
         if (this.millis != millis) {
             this.millis = millis;
-            normalized = false;
-        }
-        return this;
-    }
-
-    public CalendarDate addMillis(int n) {
-        if (n != 0) {
-            millis += n;
             normalized = false;
         }
         return this;
@@ -309,26 +277,11 @@ public abstract class CalendarDate implements Cloneable {
         return this;
     }
 
-    public CalendarDate addDate(int year, int month, int dayOfMonth) {
-        addYear(year);
-        addMonth(month);
-        addDayOfMonth(dayOfMonth);
-        return this;
-    }
-
     public CalendarDate setTimeOfDay(int hours, int minutes, int seconds, int millis) {
         setHours(hours);
         setMinutes(minutes);
         setSeconds(seconds);
         setMillis(millis);
-        return this;
-    }
-
-    public CalendarDate addTimeOfDay(int hours, int minutes, int seconds, int millis) {
-        addHours(hours);
-        addMinutes(minutes);
-        addSeconds(seconds);
-        addMillis(millis);
         return this;
     }
 
@@ -343,10 +296,6 @@ public abstract class CalendarDate implements Cloneable {
 
     public boolean isStandardTime() {
         return forceStandardTime;
-    }
-
-    public void setStandardTime(boolean standardTime) {
-        forceStandardTime = standardTime;
     }
 
     public boolean isDaylightTime() {

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/CalendarSystem.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/CalendarSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -235,14 +235,6 @@ public abstract class CalendarSystem {
     public abstract int getYearLength(CalendarDate date);
 
     /**
-     * Returns the number of months of the specified year. This method
-     * does not perform the normalization with the specified
-     * <code>CalendarDate</code>. The <code>CalendarDate</code> must
-     * be normalized to get a correct value.
-     */
-    public abstract int getYearLengthInMonths(CalendarDate date);
-
-    /**
      * Returns the length in days of the month specified by the calendar
      * date. This method does not perform the normalization with the
      * specified calendar date. The <code>CalendarDate</code> must
@@ -254,13 +246,6 @@ public abstract class CalendarSystem {
      * doesn't have a valid month value in this calendar system.
      */
     public abstract int getMonthLength(CalendarDate date); // no setter
-
-    /**
-     * Returns the length in days of a week in this calendar
-     * system. If this calendar system has multiple radix weeks, this
-     * method returns only one of them.
-     */
-    public abstract int getWeekLength();
 
     /**
      * Returns the <code>Era</code> designated by the era name that
@@ -286,13 +271,6 @@ public abstract class CalendarSystem {
      * system.
      */
     public abstract Era[] getEras();
-
-    /**
-     * @throws IllegalArgumentException if the specified era name is
-     * unknown to this calendar system.
-     * @see Era
-     */
-    public abstract void setEra(CalendarDate date, String eraName);
 
     /**
      * Returns a <code>CalendarDate</code> of the n-th day of week

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/CalendarUtils.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/CalendarUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,29 +103,6 @@ public class CalendarUtils {
         }
         int q = ((n + 1) / d) - 1;
         r[0] = n - (q * d);
-        return q;
-    }
-
-    /**
-     * Divides two integers and returns the floor of the quotient and
-     * the modulus remainder.  For example,
-     * <code>floorDivide(-1,4)</code> returns <code>-1</code> with
-     * <code>3</code> as its remainder, while <code>-1/4</code> is
-     * <code>0</code> and <code>-1%4</code> is <code>-1</code>.
-     *
-     * @param n the numerator
-     * @param d a divisor which must be {@literal > 0}
-     * @param r an array of at least one element in which the value
-     * <code>mod(n, d)</code> is returned.
-     * @return the floor of the quotient.
-     */
-    public static final int floorDivide(long n, int d, int[] r) {
-        if (n >= 0) {
-            r[0] = (int)(n % d);
-            return (int)(n / d);
-        }
-        int q = (int)(((n + 1) / d) - 1);
-        r[0] = (int)(n - (q * d));
         return q;
     }
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/Era.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/Era.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,9 +79,9 @@ public final class Era {
         this.abbr = abbr;
         this.since = since;
         this.localTime = localTime;
-        Gregorian gcal = CalendarSystem.getGregorianCalendar();
-        BaseCalendar.Date d = gcal.newCalendarDate(null);
-        gcal.getCalendarDate(since, d);
+        Gregorian gCal = CalendarSystem.getGregorianCalendar();
+        BaseCalendar.Date d = gCal.newCalendarDate(null);
+        gCal.getCalendarDate(since, d);
         sinceDate = new ImmutableGregorianDate(d);
     }
 
@@ -94,10 +94,6 @@ public final class Era {
     }
 
     public String getAbbreviation() {
-        return abbr;
-    }
-
-    public String getDiaplayAbbreviation(Locale locale) {
         return abbr;
     }
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/ImmutableGregorianDate.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/ImmutableGregorianDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,10 +86,6 @@ class ImmutableGregorianDate extends BaseCalendar.Date {
         unsupported(); return this;
     }
 
-    public CalendarDate addDayOfMonth(int n) {
-        unsupported(); return this;
-    }
-
     public int getDayOfWeek() {
         return date.getDayOfWeek();
     }
@@ -114,19 +110,11 @@ class ImmutableGregorianDate extends BaseCalendar.Date {
         unsupported(); return this;
     }
 
-    public CalendarDate addMinutes(int n) {
-        unsupported(); return this;
-    }
-
     public int getSeconds() {
         return date.getSeconds();
     }
 
     public CalendarDate setSeconds(int seconds) {
-        unsupported(); return this;
-    }
-
-    public CalendarDate addSeconds(int n) {
         unsupported(); return this;
     }
 
@@ -138,10 +126,6 @@ class ImmutableGregorianDate extends BaseCalendar.Date {
         unsupported(); return this;
     }
 
-    public CalendarDate addMillis(int n) {
-        unsupported(); return this;
-    }
-
     public long getTimeOfDay() {
         return date.getTimeOfDay();
     }
@@ -150,15 +134,7 @@ class ImmutableGregorianDate extends BaseCalendar.Date {
         unsupported(); return this;
     }
 
-    public CalendarDate addDate(int year, int month, int dayOfMonth) {
-        unsupported(); return this;
-    }
-
     public CalendarDate setTimeOfDay(int hours, int minutes, int seconds, int millis) {
-        unsupported(); return this;
-    }
-
-    public CalendarDate addTimeOfDay(int hours, int minutes, int seconds, int millis) {
         unsupported(); return this;
     }
 
@@ -172,10 +148,6 @@ class ImmutableGregorianDate extends BaseCalendar.Date {
 
     public boolean isStandardTime() {
         return date.isStandardTime();
-    }
-
-    public void setStandardTime(boolean standardTime) {
-        unsupported();
     }
 
     public boolean isDaylightTime() {

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/LocalGregorianCalendar.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/LocalGregorianCalendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package com.tencent.kona.sun.util.calendar;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import com.tencent.kona.sun.security.action.GetPropertyAction;
 
 /**

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/ZoneInfo.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/ZoneInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,6 @@ public class ZoneInfo extends TimeZone {
     private static final long DST_MASK = 0xf0L;
     private static final int DST_NSHIFT = 4;
     // this bit field is reserved for abbreviation support
-    private static final long ABBR_MASK = 0xf00L;
     private static final int TRANSITION_NSHIFT = 12;
 
     /**
@@ -393,7 +392,7 @@ public class ZoneInfo extends TimeZone {
         }
 
         long dateInMillis = gcal.getTime(date) + milliseconds;
-        dateInMillis -= (long) rawOffset; // make it UTC
+        dateInMillis -= rawOffset; // make it UTC
         return getOffsets(dateInMillis, null, UTC_TIME);
     }
 
@@ -403,7 +402,7 @@ public class ZoneInfo extends TimeZone {
      * historical ones, if applicable.
      *
      * @param offsetMillis the base time zone offset to GMT.
-     * @see getRawOffset
+     * @see #getRawOffset
      */
     public synchronized void setRawOffset(int offsetMillis) {
         if (offsetMillis == rawOffset + rawOffsetDiff) {
@@ -523,21 +522,6 @@ public class ZoneInfo extends TimeZone {
     public int getDSTSavings() {
         return dstSavings;
     }
-
-//    /**
-//     * @return the last year in the transition table or -1 if this
-//     * time zone doesn't observe any daylight saving time.
-//     */
-//    public int getMaxTransitionYear() {
-//      if (transitions == null) {
-//          return -1;
-//      }
-//      long val = transitions[transitions.length - 1];
-//      int offset = this.offsets[(int)(val & OFFSET_MASK)] + rawOffsetDiff;
-//      val = (val >> TRANSITION_NSHIFT) + offset;
-//      CalendarDate lastDate = Gregorian.getCalendarDate(val);
-//      return lastDate.getYear();
-//    }
 
     /**
      * Returns a string representation of this time zone.

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/ZoneInfoFile.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/util/calendar/ZoneInfoFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -297,9 +297,9 @@ public final class ZoneInfoFile {
      * Loads the rules from a DateInputStream
      *
      * @param dis  the DateInputStream to load, not null
-     * @throws Exception if an error occurs
+     * @throws IOException if an error occurs
      */
-    private static void load(DataInputStream dis) throws ClassNotFoundException, IOException {
+    private static void load(DataInputStream dis) throws IOException {
         if (dis.readByte() != 1) {
             throw new StreamCorruptedException("File format not recognised");
         }
@@ -418,7 +418,8 @@ public final class ZoneInfoFile {
     //Current time. Used to determine future GMToffset transitions
     private static final long CURRT = System.currentTimeMillis()/1000;
 
-    /* Get a ZoneInfo instance.
+    /**
+     * Get a ZoneInfo instance.
      *
      * @param standardTransitions  the standard transitions, not null
      * @param standardOffsets  the standard offsets, not null
@@ -582,12 +583,8 @@ public final class ZoneInfoFile {
                     // we can then pass in the dom = -1, dow > 0 into ZoneInfo
                     //
                     // hacking, assume the >=24 is the result of ZRB optimization for
-                    // "last", it works for now. From tzdata2020d this hacking
-                    // will not work for Asia/Gaza and Asia/Hebron which follow
-                    // Palestine DST rules.
-                    if (dom < 0 || dom >= 24 &&
-                                   !(zoneId.equals("Asia/Gaza") ||
-                                     zoneId.equals("Asia/Hebron"))) {
+                    // "last", it works for now.
+                    if (dom < 0 || dom >= 24) {
                         params[1] = -1;
                         params[2] = toCalendarDOW[dow];
                     } else {
@@ -609,7 +606,6 @@ public final class ZoneInfoFile {
                     params[7] = 0;
                 } else {
                     // hacking: see comment above
-                    // No need of hacking for Asia/Gaza and Asia/Hebron from tz2021e
                     if (dom < 0 || dom >= 24) {
                         params[6] = -1;
                         params[7] = toCalendarDOW[dow];
@@ -621,6 +617,17 @@ public final class ZoneInfoFile {
                 params[8] = endRule.secondOfDay * 1000;
                 params[9] = toSTZTime[endRule.timeDefinition];
                 dstSavings = (startRule.offsetAfter - startRule.offsetBefore) * 1000;
+
+                // Note: known mismatching -> Africa/Cairo
+                // ZoneInfo :      startDayOfWeek=5     <= Thursday
+                //                 startTime=86400000   <= 24:00
+                // This:           startDayOfWeek=6     <= Friday
+                //                 startTime=0          <= 0:00
+                if (zoneId.equals("Africa/Cairo") &&
+                        params[7] == Calendar.FRIDAY && params[8] == 0) {
+                    params[7] = Calendar.THURSDAY;
+                    params[8] = SECONDS_PER_DAY * 1000;
+                }
             } else if (nTrans > 0) {  // only do this if there is something in table already
                 if (lastyear < LASTYEAR) {
                     // ZoneInfo has an ending entry for 2037
@@ -716,9 +723,7 @@ public final class ZoneInfoFile {
                 for (i = 0; i < transitions.length; i++) {
                     long val = transitions[i];
                     int dst = (int)((val >>> DST_NSHIFT) & 0xfL);
-                    int saving = (dst == 0) ? 0 : offsets[dst];
                     int index = (int)(val & OFFSET_MASK);
-                    int offset = offsets[index];
                     long second = (val >> TRANSITION_NSHIFT);
                     // javazic uses "index of the offset in offsets",
                     // instead of the real offset value itself to
@@ -785,13 +790,11 @@ public final class ZoneInfoFile {
         int marchDoy0 = (int) doyEst;
         // convert march-based values back to january-based
         int marchMonth0 = (marchDoy0 * 5 + 2) / 153;
-        int month = (marchMonth0 + 2) % 12 + 1;
-        int dom = marchDoy0 - (marchMonth0 * 306 + 5) / 10 + 1;
         yearEst += marchMonth0 / 10;
         return (int)yearEst;
     }
 
-    private static final int toCalendarDOW[] = new int[] {
+    private static final int[] toCalendarDOW = new int[] {
         -1,
         Calendar.MONDAY,
         Calendar.TUESDAY,
@@ -802,7 +805,7 @@ public final class ZoneInfoFile {
         Calendar.SUNDAY
     };
 
-    private static final int toSTZTime[] = new int[] {
+    private static final int[] toSTZTime = new int[] {
         SimpleTimeZone.UTC_TIME,
         SimpleTimeZone.WALL_TIME,
         SimpleTimeZone.STANDARD_TIME,
@@ -826,8 +829,8 @@ public final class ZoneInfoFile {
     }
 
     // return updated nOffsets
-    private static int addTrans(long transitions[], int nTrans,
-                                int offsets[], int nOffsets,
+    private static int addTrans(long[] transitions, int nTrans,
+                                int[] offsets, int nOffsets,
                                 long trans, int offset, int stdOffset) {
         int offsetIndex = indexOf(offsets, 0, nOffsets, offset);
         if (offsetIndex == nOffsets)


### PR DESCRIPTION
This is a backport of [JDK-6453901]: (cal) clean up sun.util.calendar classes.

This. PR will resolve #322.

[JDK-6453901]:
<https://bugs.openjdk.org/browse/JDK-6453901>