### PR TITLE
TKSS-324: Backport JDK-8311592: ECKeySizeParameterSpec causes too many exceptions on third party providers

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/KeyUtil.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/KeyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,17 +116,19 @@ public final class KeyUtil {
      */
     public static final int getKeySize(AlgorithmParameters parameters) {
 
-        String algorithm = parameters.getAlgorithm();
-        switch (algorithm) {
+        switch (parameters.getAlgorithm()) {
             case "EC":
-                try {
-                    ECKeySizeParameterSpec ps = parameters.getParameterSpec(
-                            ECKeySizeParameterSpec.class);
-                    if (ps != null) {
-                        return ps.getKeySize();
+                // ECKeySizeParameterSpec is SunEC internal only
+                if (parameters.getProvider().getName().equals("SunEC")) {
+                    try {
+                        ECKeySizeParameterSpec ps = parameters.getParameterSpec(
+                                ECKeySizeParameterSpec.class);
+                        if (ps != null) {
+                            return ps.getKeySize();
+                        }
+                    } catch (InvalidParameterSpecException ipse) {
+                        // ignore
                     }
-                } catch (InvalidParameterSpecException ipse) {
-                    // ignore
                 }
 
                 try {


### PR DESCRIPTION
This is a backport of [JDK-8311592]: ECKeySizeParameterSpec causes too many exceptions on third party providers.

This PR will resolve #324.

[JDK-8311592]:
<https://bugs.openjdk.org/browse/JDK-8311592>