### PR TITLE
TKSS-326: Backport JDK-8313087: DerValue::toString should output a hex view of the values in byte array

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerValue.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerValue.java
@@ -25,6 +25,7 @@
 
 package com.tencent.kona.sun.security.util;
 
+import com.tencent.kona.java.util.HexFormat;
 import com.tencent.kona.sun.util.calendar.CalendarDate;
 import com.tencent.kona.sun.util.calendar.CalendarSystem;
 
@@ -1186,7 +1187,8 @@ public class DerValue {
     @Override
     public String toString() {
         return String.format("DerValue(%02x, %s, %d, %d)",
-                0xff & tag, buffer, start, end);
+                0xff & tag, HexFormat.of().withUpperCase().formatHex(buffer),
+                start, end);
     }
 
     /**


### PR DESCRIPTION
This is a backport of [JDK-8313087]: DerValue::toString should output a hex view of the values in byte array.

This PR will resolve #326.

[JDK-8313087]:
<https://bugs.openjdk.org/browse/JDK-8313087>