### PR TITLE
TKSS-333: Backport JDK-8313226: Redundant condition test in X509CRLImpl

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLImpl.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -241,8 +241,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
 
             // revokedCertificates (optional)
             nextByte = (byte)derStrm.peekByte();
-            if ((nextByte == DerValue.tag_SequenceOf)
-                    && (! ((nextByte & 0x0c0) == 0x080))) {
+            if ((nextByte == DerValue.tag_SequenceOf)) {
                 DerValue[] badCerts = derStrm.getSequence(4);
 
                 X500Principal crlIssuer = getIssuerX500Principal();


### PR DESCRIPTION
This is a backport of [JDK-8313226]: Redundant condition test in X509CRLImpl.

This PR will resolve #333.

[JDK-8313226]:
<https://bugs.openjdk.org/browse/JDK-8313226>