### PR TITLE
TKSS-335: Backport JDK-8311170: Simplify and modernize equals and hashCode in security area

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBEKey.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBEKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,11 +106,8 @@ final class PBEKey implements SecretKey {
      * Objects that are equal will also have the same hashcode.
      */
     public int hashCode() {
-        int retval = 0;
-        for (int i = 1; i < this.key.length; i++) {
-            retval += this.key[i] * i;
-        }
-        return(retval ^= getAlgorithm().toLowerCase(Locale.ENGLISH).hashCode());
+        return Arrays.hashCode(this.key)
+                ^ getAlgorithm().toLowerCase(Locale.ENGLISH).hashCode();
     }
 
     public boolean equals(Object obj) {

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBKDF2KeyImpl.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBKDF2KeyImpl.java
@@ -167,7 +167,7 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
                 @Override
                 public boolean equals(Object obj) {
                     if (this == obj) return true;
-                    if (this.getClass() != obj.getClass()) return false;
+                    if (obj == null || this.getClass() != obj.getClass()) return false;
                     SecretKey sk = (SecretKey)obj;
                     return prf.getAlgorithm().equalsIgnoreCase(
                         sk.getAlgorithm()) &&
@@ -251,18 +251,15 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
      */
     public int hashCode() {
         try {
-            int retval = 0;
-            for (int i = 1; i < this.key.length; i++) {
-                retval += this.key[i] * i;
-            }
-            return (retval ^= getAlgorithm().toLowerCase
-                    (Locale.ENGLISH).hashCode());
+            return Arrays.hashCode(this.key)
+                    ^ getAlgorithm().toLowerCase(Locale.ENGLISH).hashCode();
         } finally {
             // prevent this from being cleaned for the above block
 //            Reference.reachabilityFence(this);
         }
     }
 
+    @Override
     public boolean equals(Object obj) {
         try {
             if (obj == this) {

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS8Key.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS8Key.java
@@ -261,6 +261,7 @@ public class PKCS8Key implements PrivateKey, InternalPrivateKey {
      * @return {@code true} if this key has the same encoding as the
      *          object argument; {@code false} otherwise.
      */
+    @Override
     public boolean equals(Object object) {
         if (this == object) {
             return true;
@@ -290,6 +291,7 @@ public class PKCS8Key implements PrivateKey, InternalPrivateKey {
      * Calculates a hash code value for this object. Objects
      * which are equal will also have the same hashcode.
      */
+    @Override
     public int hashCode() {
         return Arrays.hashCode(getEncodedInternal());
     }

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/BitArray.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/BitArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package com.tencent.kona.sun.security.util;
 import com.tencent.kona.jdk.internal.util.Preconditions;
 
 import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
 
 /**
  * A packed array of booleans.
@@ -68,7 +69,7 @@ public class BitArray {
      * Creates a BitArray of the specified size, initialized from the
      * specified byte array. The most significant bit of {@code a[0]} gets
      * index zero in the BitArray. The array must be large enough to specify
-     * a value for every bit of the BitArray. i.e. {@code 8*a.length <= length}.
+     * a value for every bit of the BitArray, i.e. {@code 8*a.length >= length}.
      */
     public BitArray(int length, byte[] a) throws IllegalArgumentException {
         this(length, a, 0);
@@ -79,7 +80,7 @@ public class BitArray {
      * specified byte array starting at the specified offset.  The most
      * significant bit of {@code a[ofs]} gets index zero in the BitArray.
      * The array must be large enough to specify a value for every bit of
-     * the BitArray, i.e. {@code 8*(a.length - ofs) <= length}.
+     * the BitArray, i.e. {@code 8*(a.length - ofs) >= length}.
      */
     public BitArray(int length, byte[] a, int ofs)
             throws IllegalArgumentException {
@@ -177,18 +178,16 @@ public class BitArray {
         return repn.clone();
     }
 
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
-        if (!(obj instanceof BitArray)) return false;
 
-        BitArray ba = (BitArray) obj;
-
-        if (ba.length != length) return false;
-
-        for (int i = 0; i < repn.length; i += 1) {
-            if (repn[i] != ba.repn[i]) return false;
+        if (!(obj instanceof BitArray)) {
+            return false;
         }
-        return true;
+
+        return length == ((BitArray) obj).length
+                && Arrays.equals(repn, ((BitArray) obj).repn);
     }
 
     /**
@@ -204,17 +203,11 @@ public class BitArray {
     }
 
     /**
-     * Returns a hash code value for this bit array.
-     *
-     * @return  a hash code value for this bit array.
+     * {@return a hash code value for this bit array}
      */
+    @Override
     public int hashCode() {
-        int hashCode = 0;
-
-        for (int i = 0; i < repn.length; i++)
-            hashCode = 31*hashCode + repn[i];
-
-        return hashCode ^ length;
+        return Arrays.hashCode(repn) ^ length;
     }
 
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerValue.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerValue.java
@@ -1315,9 +1315,7 @@ public class DerValue {
     }
 
     /**
-     * Returns a hashcode for this DerValue.
-     *
-     * @return a hashcode for this DerValue.
+     * {@return a hashcode for this DerValue}
      */
     @Override
     public int hashCode() {

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/AlgorithmId.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/AlgorithmId.java
@@ -345,9 +345,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
     }
 
     /**
-     * Returns a hashcode for this AlgorithmId.
-     *
-     * @return a hashcode for this AlgorithmId.
+     * {@return a hashcode for this AlgorithmId}
      */
     @Override
     public int hashCode() {

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/X509Key.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/x509/X509Key.java
@@ -36,6 +36,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Objects;
 
 import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.sun.security.util.BitArray;
@@ -399,6 +400,7 @@ public class X509Key implements PublicKey, DerEncoder {
         }
     }
 
+    @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/EncryptedPrivateKeyInfo.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/EncryptedPrivateKeyInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package com.tencent.kona.sun.security.pkcs;
 
 import java.io.*;
+import java.util.Arrays;
 
 import com.tencent.kona.sun.security.util.DerOutputStream;
 import com.tencent.kona.sun.security.x509.AlgorithmId;
@@ -135,33 +136,23 @@ public class EncryptedPrivateKeyInfo {
         return this.encoded.clone();
     }
 
-    public boolean equals(Object other) {
-        if (this == other)
+    public boolean equals(Object obj) {
+        if (this == obj) {
             return true;
-        if (!(other instanceof EncryptedPrivateKeyInfo))
+        }
+        if (!(obj instanceof EncryptedPrivateKeyInfo)) {
             return false;
-        byte[] thisEncrInfo = this.getEncoded();
-        byte[] otherEncrInfo
-                = ((EncryptedPrivateKeyInfo) other).getEncoded();
+        }
 
-        if (thisEncrInfo.length != otherEncrInfo.length)
-            return false;
-        for (int i = 0; i < thisEncrInfo.length; i++)
-            if (thisEncrInfo[i] != otherEncrInfo[i])
-                return false;
-        return true;
+        return Arrays.equals(this.getEncoded(),
+                ((EncryptedPrivateKeyInfo) obj).getEncoded());
     }
 
     /**
-     * Returns a hashcode for this EncryptedPrivateKeyInfo.
-     *
-     * @return a hashcode for this EncryptedPrivateKeyInfo.
+     * {@return a hashcode for this EncryptedPrivateKeyInfo}
      */
+    @Override
     public int hashCode() {
-        int retval = 0;
-
-        for (int i = 0; i < this.encryptedData.length; i++)
-            retval += this.encryptedData[i] * i;
-        return retval;
+        return Arrays.hashCode(encryptedData);
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs10/PKCS10.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs10/PKCS10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.math.BigInteger;
 
 import java.security.*;
 
+import java.util.Arrays;
 import java.util.Base64;
 
 import com.tencent.kona.crypto.CryptoInsts;
@@ -326,41 +327,36 @@ public class PKCS10 {
 
     /**
      * Compares this object for equality with the specified
-     * object. If the <code>other</code> object is an
+     * object. If the <code>obj</code> object is an
      * <code>instanceof</code> <code>PKCS10</code>, then
      * its encoded form is retrieved and compared with the
      * encoded form of this certificate request.
      *
-     * @param other the object to test for equality with this object.
+     * @param obj the object to test for equality with this object.
      * @return true iff the encoded forms of the two certificate
      * requests match, false otherwise.
      */
-    public boolean equals(Object other) {
-        if (this == other)
+    public boolean equals(Object obj) {
+        if (this == obj)
             return true;
-        if (!(other instanceof PKCS10))
+        if (!(obj instanceof PKCS10))
             return false;
         if (encoded == null) // not signed yet
             return false;
-        byte[] otherEncoded = ((PKCS10)other).getEncoded();
+        byte[] otherEncoded = ((PKCS10)obj).getEncoded();
         if (otherEncoded == null)
             return false;
 
-        return java.util.Arrays.equals(encoded, otherEncoded);
+        return Arrays.equals(encoded, otherEncoded);
     }
 
     /**
-     * Returns a hashcode value for this certificate request from its
-     * encoded form.
-     *
-     * @return the hashcode value.
+     * {@return the hashcode value for this certificate request from its
+     * encoded form}
      */
+    @Override
     public int hashCode() {
-        int     retval = 0;
-        if (encoded != null)
-            for (int i = 1; i < encoded.length; i++)
-             retval += encoded[i] * i;
-        return(retval);
+        return Arrays.hashCode(encoded);
     }
 
     private X500Name                subject;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs10/PKCS10Attributes.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs10/PKCS10Attributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,7 +158,6 @@ public class PKCS10Attributes implements DerEncoder {
             return true;
         if (!(other instanceof PKCS10Attributes))
             return false;
-
         Collection<PKCS10Attribute> othersAttribs =
                 ((PKCS10Attributes)other).getAttributes();
         PKCS10Attribute[] attrs =
@@ -166,26 +165,24 @@ public class PKCS10Attributes implements DerEncoder {
         int len = attrs.length;
         if (len != map.size())
             return false;
-        PKCS10Attribute thisAttr, otherAttr;
+        PKCS10Attribute thisAttr;
         String key;
-        for (int i=0; i < len; i++) {
-            otherAttr = attrs[i];
+        for (PKCS10Attribute otherAttr : attrs) {
             key = otherAttr.getAttributeId().toString();
 
             thisAttr = map.get(key);
             if (thisAttr == null)
                 return false;
-            if (! thisAttr.equals(otherAttr))
+            if (!thisAttr.equals(otherAttr))
                 return false;
         }
         return true;
     }
 
     /**
-     * Returns a hashcode value for this PKCS10Attributes.
-     *
-     * @return the hashcode value.
+     * {@return the hashcode value for this PKCS10Attributes}
      */
+    @Override
     public int hashCode() {
         return map.hashCode();
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/CertId.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/CertId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -178,19 +178,13 @@ public class CertId implements DerEncoder {
     }
 
     /**
-     * Returns a hashcode value for this CertId.
-     *
-     * @return the hashcode value.
+     * {@return a hashcode value for this CertId}
      */
     @Override public int hashCode() {
         if (myhash == -1) {
             myhash = hashAlgId.hashCode();
-            for (int i = 0; i < issuerNameHash.length; i++) {
-                myhash += issuerNameHash[i] * i;
-            }
-            for (int i = 0; i < issuerKeyHash.length; i++) {
-                myhash += issuerKeyHash[i] * i;
-            }
+            myhash += Arrays.hashCode(issuerNameHash);
+            myhash += Arrays.hashCode(issuerKeyHash);
             myhash += certSerialNumber.getNumber().hashCode();
         }
         return myhash;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/ResponderId.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/ResponderId.java
@@ -234,18 +234,15 @@ public final class ResponderId {
             return true;
         }
 
-        if (obj instanceof ResponderId) {
-            ResponderId respObj = (ResponderId)obj;
-            return Arrays.equals(encodedRid, respObj.getEncoded());
+        if (!(obj instanceof ResponderId)) {
+            return false;
         }
 
-        return false;
+        return Arrays.equals(encodedRid, ((ResponderId) obj).getEncoded());
     }
 
     /**
-     * Returns the hash code value for this {@code ResponderId}
-     *
-     * @return the hash code value for this {@code ResponderId}
+     * {@return the hash code value for this {@code ResponderId}}
      */
     @Override
     public int hashCode() {

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/tools/keytool/Main.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/tools/keytool/Main.java
@@ -5355,11 +5355,15 @@ class Pair<A, B> {
         return "Pair[" + fst + "," + snd + "]";
     }
 
-    public boolean equals(Object other) {
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Pair<?, ?>)) {
+            return false;
+        }
+
         return
-            other instanceof Pair &&
-            Objects.equals(fst, ((Pair)other).fst) &&
-            Objects.equals(snd, ((Pair)other).snd);
+            Objects.equals(fst, ((Pair<?, ?>) obj).fst) &&
+            Objects.equals(snd, ((Pair<?, ?>) obj).snd);
     }
 
     public int hashCode() {

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AVA.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AVA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -609,6 +609,7 @@ public class AVA implements DerEncoder {
         this(in.getDerValue());
     }
 
+    @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
@@ -622,10 +623,9 @@ public class AVA implements DerEncoder {
     }
 
     /**
-     * Returns a hashcode for this AVA.
-     *
-     * @return a hashcode for this AVA.
+     * {@return a hashcode for this AVA}
      */
+    @Override
     public int hashCode() {
         return toRFC2253CanonicalString().hashCode();
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLExtensions.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CRLExtensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.security.cert.CRLException;
@@ -221,6 +220,7 @@ public class CRLExtensions {
      * @return true iff all the entries match that of the Other,
      * false otherwise.
      */
+    @Override
     public boolean equals(Object other) {
         if (this == other)
             return true;
@@ -246,10 +246,9 @@ public class CRLExtensions {
     }
 
     /**
-     * Returns a hashcode value for this CRLExtensions.
-     *
-     * @return the hashcode value.
+     * {@return a hashcode value for this CRLExtensions}
      */
+    @Override
     public int hashCode() {
         return map.hashCode();
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateExtensions.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificateExtensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,6 +248,7 @@ public class CertificateExtensions implements DerEncoder {
      * @return true iff all the entries match that of the Other,
      * false otherwise.
      */
+    @Override
     public boolean equals(Object other) {
         if (this == other)
             return true;
@@ -274,12 +275,11 @@ public class CertificateExtensions implements DerEncoder {
     }
 
     /**
-     * Returns a hashcode value for this CertificateExtensions.
-     *
-     * @return the hashcode value.
+     * {@return a hashcode value for this CertificateExtensions}
      */
+    @Override
     public int hashCode() {
-        return map.hashCode() + getUnparseableExtensions().hashCode();
+        return Objects.hash(map, getUnparseableExtensions());
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePolicyId.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/CertificatePolicyId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,19 +93,20 @@ public class CertificatePolicyId implements DerEncoder {
      *
      * @return true iff the ids are identical.
      */
-    public boolean equals(Object other) {
-        if (other instanceof CertificatePolicyId)
-            return id.equals((Object) ((CertificatePolicyId) other).getIdentifier());
-        else
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof CertificatePolicyId)) {
             return false;
+        }
+
+        return id.equals(((CertificatePolicyId) obj).getIdentifier());
     }
 
     /**
-     * Returns a hash code value for this object.
-     *
-     * @return a hash code value
+     * {@return a hash code value for this object}
      */
+    @Override
     public int hashCode() {
-        return id.hashCode();
+      return id.hashCode();
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DNSName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DNSName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,6 +170,7 @@ public class DNSName implements GeneralNameInterface {
      * @return true iff the names are equivalent
      * according to RFC5280.
      */
+    @Override
     public boolean equals(Object obj) {
         if (this == obj)
             return true;
@@ -185,10 +186,9 @@ public class DNSName implements GeneralNameInterface {
     }
 
     /**
-     * Returns the hash code value for this object.
-     *
-     * @return a hash code value for this object.
+     * {@return the hash code value for this object}
      */
+    @Override
     public int hashCode() {
         return name.toUpperCase(Locale.ENGLISH).hashCode();
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DistributionPoint.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DistributionPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -324,6 +324,7 @@ public class DistributionPoint implements DerEncoder {
      * @param obj Object to be compared to this
      * @return true if objects match; false otherwise
      */
+    @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
@@ -339,26 +340,14 @@ public class DistributionPoint implements DerEncoder {
                 && Arrays.equals(this.reasonFlags, other.reasonFlags);
     }
 
+    @Override
     public int hashCode() {
         int hash = hashCode;
         if (hash == 0) {
-            hash = 1;
-            if (fullName != null) {
-                hash += fullName.hashCode();
-            }
-            if (relativeName != null) {
-                hash += relativeName.hashCode();
-            }
-            if (crlIssuer != null) {
-                hash += crlIssuer.hashCode();
-            }
-            if (reasonFlags != null) {
-                for (int i = 0; i < reasonFlags.length; i++) {
-                    if (reasonFlags[i]) {
-                        hash += i;
-                    }
-                }
-            }
+            hash = 1 + Objects.hashCode(fullName)
+                    + Objects.hashCode(relativeName)
+                    + Objects.hash(crlIssuer)
+                    + Arrays.hashCode(reasonFlags);
             hashCode = hash;
         }
         return hash;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DistributionPointName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DistributionPointName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -191,6 +191,7 @@ public class DistributionPointName implements DerEncoder {
      * @param obj Object to be compared to this
      * @return true if objects match; false otherwise
      */
+    @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
@@ -205,10 +206,9 @@ public class DistributionPointName implements DerEncoder {
     }
 
     /**
-     * Returns the hash code for this distribution point name.
-     *
-     * @return the hash code.
+     * {@return the hash code for this distribution point name}
      */
+    @Override
     public int hashCode() {
         int hash = hashCode;
         if (hash == 0) {

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/EDIPartyName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/EDIPartyName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -165,37 +165,23 @@ public class EDIPartyName implements GeneralNameInterface {
         return party;
     }
 
-    /**
-     * Compare this EDIPartyName with another.  Does a byte-string
-     * comparison without regard to type of the partyName and
-     * the assignerName.
-     *
-     * @return true if the two names match
-     */
-    public boolean equals(Object other) {
-        if (!(other instanceof EDIPartyName))
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+
+        if (!(obj instanceof EDIPartyName)) {
             return false;
-        String otherAssigner = ((EDIPartyName)other).assigner;
-        if (this.assigner == null) {
-            if (otherAssigner != null)
-                return false;
-        } else {
-            if (!(this.assigner.equals(otherAssigner)))
-                return false;
         }
-        String otherParty = ((EDIPartyName)other).party;
-        if (this.party == null) {
-            return otherParty == null;
-        } else {
-            return this.party.equals(otherParty);
-        }
+
+        return Objects.equals(this.assigner, ((EDIPartyName) obj).assigner)
+                && Objects.equals(this.party, ((EDIPartyName) obj).party);
     }
 
     /**
-     * Returns the hash code value for this EDIPartyName.
-     *
-     * @return a hash code value.
+     * {@return the hash code value for this EDIPartyName}
      */
+    @Override
     public int hashCode() {
         if (myhash == -1) {
             myhash = 37 + (party == null ? 1 : party.hashCode());

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/Extension.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/Extension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -246,20 +246,13 @@ public class Extension implements java.security.cert.Extension, DerEncoder {
     private static final int hashMagic = 31;
 
     /**
-     * Returns a hashcode value for this Extension.
-     *
-     * @return the hashcode value.
+     * {@return a hashcode value for this Extension}
      */
+    @Override
     public int hashCode() {
-        int h = 0;
-        if (extensionValue != null) {
-            byte[] val = extensionValue;
-            int len = val.length;
-            while (len > 0)
-                h += len * val[--len];
-        }
+        int h = Arrays.hashCode(extensionValue);
         h = h * hashMagic + extensionId.hashCode();
-        h = h * hashMagic + (critical?1231:1237);
+        h = h * hashMagic + Boolean.hashCode(critical);
         return h;
     }
 
@@ -275,6 +268,7 @@ public class Extension implements java.security.cert.Extension, DerEncoder {
      * criticality flag, object identifier and encoded extension value of
      * the two Extensions match, false otherwise.
      */
+    @Override
     public boolean equals(Object other) {
         if (this == other)
             return true;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,28 +203,28 @@ public class GeneralName implements DerEncoder {
     /**
      * Compare this GeneralName with another
      *
-     * @param other GeneralName to compare to this
+     * @param obj GeneralName to compare to this
      * @return true if match
      */
-    public boolean equals(Object other) {
-        if (this == other) {
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
             return true;
         }
-        if (!(other instanceof GeneralName))
+        if (!(obj instanceof GeneralName))
             return false;
-        GeneralNameInterface otherGNI = ((GeneralName)other).name;
         try {
-            return name.constrains(otherGNI) == GeneralNameInterface.NAME_MATCH;
+            return name.constrains(((GeneralName) obj).name)
+                    == GeneralNameInterface.NAME_MATCH;
         } catch (UnsupportedOperationException ioe) {
             return false;
         }
     }
 
     /**
-     * Returns the hash code for this GeneralName.
-     *
-     * @return a hash code value.
+     * {@return the hash code for this GeneralName}
      */
+    @Override
     public int hashCode() {
         return name.hashCode();
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralSubtree.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/GeneralSubtree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,31 +151,27 @@ public class GeneralSubtree implements DerEncoder {
     /**
      * Compare this GeneralSubtree with another
      *
-     * @param other GeneralSubtree to compare to this
+     * @param obj GeneralSubtree to compare to this
      * @return true if match
      */
-    public boolean equals(Object other) {
-        if (!(other instanceof GeneralSubtree))
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+
+        if (!(obj instanceof GeneralSubtree)) {
             return false;
-        GeneralSubtree otherGS = (GeneralSubtree)other;
-        if (this.name == null) {
-            if (otherGS.name != null) {
-                return false;
-            }
-        } else {
-            if (!((this.name).equals(otherGS.name)))
-                return false;
         }
-        if (this.minimum != otherGS.minimum)
-            return false;
-        return this.maximum == otherGS.maximum;
+
+        return Objects.equals(this.name, ((GeneralSubtree) obj).name)
+                && this.minimum == ((GeneralSubtree) obj).minimum
+                && this.maximum == ((GeneralSubtree) obj).maximum;
     }
 
     /**
-     * Returns the hash code for this GeneralSubtree.
-     *
-     * @return a hash code value.
+     * {@return the hash code for this GeneralSubtree}
      */
+    @Override
     public int hashCode() {
         if (myhash == -1) {
             myhash = 17;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IPAddressName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/IPAddressName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -310,6 +310,7 @@ public class IPAddressName implements GeneralNameInterface {
      *
      * @return true iff the names are identical.
      */
+    @Override
     public boolean equals(Object obj) {
         if (this == obj)
             return true;
@@ -347,17 +348,11 @@ public class IPAddressName implements GeneralNameInterface {
     }
 
     /**
-     * Returns the hash code value for this object.
-     *
-     * @return a hash code value for this object.
+     * {@return the hash code value for this object}
      */
+    @Override
     public int hashCode() {
-        int retval = 0;
-
-        for (int i=0; i<address.length; i++)
-            retval += address[i] * i;
-
-        return retval;
+        return Arrays.hashCode(address);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/KeyIdentifier.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/KeyIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.security.PublicKey;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 
 import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -134,22 +135,23 @@ public class KeyIdentifier {
      * Returns a hash code value for this object.
      * Objects that are equal will also have the same hashcode.
      */
+    @Override
     public int hashCode () {
-        int retval = 0;
-        for (int i = 0; i < octetString.length; i++)
-            retval += octetString[i] * i;
-        return retval;
+        return Arrays.hashCode(octetString);
     }
 
     /**
      * Indicates whether some other object is "equal to" this one.
      */
-    public boolean equals(Object other) {
-        if (this == other)
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
             return true;
-        if (!(other instanceof KeyIdentifier))
+
+        if (!(obj instanceof KeyIdentifier)) {
             return false;
-        byte[] otherString = ((KeyIdentifier)other).octetString;
-        return java.util.Arrays.equals(octetString, otherString);
+        }
+
+        return Arrays.equals(octetString, ((KeyIdentifier) obj).octetString);
     }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/OIDName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/OIDName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,23 +114,22 @@ public class OIDName implements GeneralNameInterface {
      *
      * @return true iff the names are identical
      */
+    @Override
     public boolean equals(Object obj) {
         if (this == obj)
             return true;
 
-        if (!(obj instanceof OIDName))
+        if (!(obj instanceof OIDName)) {
             return false;
+        }
 
-        OIDName other = (OIDName)obj;
-
-        return oid.equals((Object) other.oid);
+        return oid.equals(((OIDName)obj).oid);
     }
 
     /**
-     * Returns the hash code value for this object.
-     *
-     * @return a hash code value for this object.
+     * {@return the hash code value for this object}
      */
+    @Override
     public int hashCode() {
         return oid.hashCode();
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/OtherName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/OtherName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,6 +173,7 @@ public class OtherName implements GeneralNameInterface {
      *
      * @return true iff the names are identical.
      */
+    @Override
     public boolean equals(Object other) {
         if (this == other) {
             return true;
@@ -206,10 +207,9 @@ public class OtherName implements GeneralNameInterface {
     }
 
     /**
-     * Returns the hash code for this OtherName.
-     *
-     * @return a hash code value.
+     * {@return the hash code for this OtherName}
      */
+    @Override
     public int hashCode() {
         if (myhash == -1) {
             myhash = 37 + oid.hashCode();

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyInformation.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/PolicyInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,29 +123,25 @@ public class PolicyInformation implements DerEncoder {
     /**
      * Compare this PolicyInformation with another object for equality
      *
-     * @param other object to be compared with this
+     * @param obj object to be compared with this
      * @return true iff the PolicyInformation objects match
      */
-    public boolean equals(Object other) {
-        if (!(other instanceof PolicyInformation))
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof PolicyInformation)) {
             return false;
-        PolicyInformation piOther = (PolicyInformation)other;
+        }
 
-        if (!policyIdentifier.equals(piOther.getPolicyIdentifier()))
-            return false;
-
-        return policyQualifiers.equals(piOther.getPolicyQualifiers());
+        return policyIdentifier.equals(((PolicyInformation) obj).getPolicyIdentifier())
+                && policyQualifiers.equals(((PolicyInformation) obj).getPolicyQualifiers());
     }
 
     /**
-     * Returns the hash code for this PolicyInformation.
-     *
-     * @return a hash code value.
+     * {@return the hash code for this PolicyInformation}
      */
+    @Override
     public int hashCode() {
-        int myhash = 37 + policyIdentifier.hashCode();
-        myhash = 37 * myhash + policyQualifiers.hashCode();
-        return myhash;
+        return Objects.hash(policyIdentifier, policyQualifiers);
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/RFC822Name.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/RFC822Name.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,6 +133,7 @@ public class RFC822Name implements GeneralNameInterface
      * @return true iff the names are equivalent
      * according to RFC 5280.
      */
+    @Override
     public boolean equals(Object obj) {
         if (this == obj)
             return true;
@@ -148,10 +149,9 @@ public class RFC822Name implements GeneralNameInterface
     }
 
     /**
-     * Returns the hash code value for this object.
-     *
-     * @return a hash code value for this object.
+     * {@return the hash code value for this object}
      */
+    @Override
     public int hashCode() {
         return name.toUpperCase(Locale.ENGLISH).hashCode();
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/URIName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/URIName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -215,6 +215,7 @@ public class URIName implements GeneralNameInterface {
      *
      * @return true iff the names are equivalent according to RFC 5280.
      */
+    @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
@@ -277,10 +278,9 @@ public class URIName implements GeneralNameInterface {
     }
 
     /**
-     * Returns the hash code value for this object.
-     *
-     * @return a hash code value for this object.
+     * {@return the hash code value for this object}
      */
+    @Override
     public int hashCode() {
         return uri.hashCode();
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X500Name.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X500Name.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -398,6 +398,7 @@ public class X500Name implements GeneralNameInterface, Principal {
      * Calculates a hash code value for the object.  Objects
      * which are equal will also have the same hashcode.
      */
+    @Override
     public int hashCode() {
         return getRFC2253CanonicalName().hashCode();
     }
@@ -407,6 +408,7 @@ public class X500Name implements GeneralNameInterface, Principal {
      *
      * @return true iff the names are identical.
      */
+    @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLImpl.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CRLImpl.java
@@ -1297,6 +1297,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
          * @param o the other object to compare with
          * @return true if equal, false otherwise
          */
+        @Override
         public boolean equals(Object o) {
             if (o == this) {
                 return true;
@@ -1312,16 +1313,13 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
         }
 
         /**
-         * Returns a hash code value for this X509IssuerSerial.
-         *
-         * @return the hash code value
+         * {@return a hash code value for this X509IssuerSerial}
          */
+        @Override
         public int hashCode() {
             int h = hashcode;
             if (h == 0) {
-                h = 17;
-                h = 37*h + issuer.hashCode();
-                h = 37*h + serial.hashCode();
+                h = Objects.hash(issuer, serial);
                 if (h != 0) {
                     hashcode = h;
                 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertInfo.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,15 +188,22 @@ public class X509CertInfo {
      * certificates are not both X.509 certs, otherwise it
      * compares them as binary data.
      *
-     * @param other the object being compared with this one
+     * @param obj the object being compared with this one
      * @return true iff the certificates are equivalent
      */
-    public boolean equals(Object other) {
-        if (other instanceof X509CertInfo) {
-            return equals((X509CertInfo) other);
-        } else {
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof X509CertInfo)) {
             return false;
         }
+
+        return rawCertInfo != null
+                && ((X509CertInfo) obj).rawCertInfo != null
+                && Arrays.equals(rawCertInfo, ((X509CertInfo) obj).rawCertInfo);
     }
 
     /**
@@ -222,17 +229,9 @@ public class X509CertInfo {
         return true;
     }
 
-    /**
-     * Calculates a hash code value for the object.  Objects
-     * which are equal will also have the same hashcode.
-     */
+    @Override
     public int hashCode() {
-        int retval = 0;
-
-        for (int i = 1; i < rawCertInfo.length; i++) {
-            retval += rawCertInfo[i] * i;
-        }
-        return retval;
+        return Arrays.hashCode(rawCertInfo);
     }
 
     /**

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLSessionImpl.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLSessionImpl.java
@@ -988,7 +988,7 @@ final class SSLSessionImpl extends ExtendedSSLSession {
     }
 
     /**
-     * Returns the hashcode for this session
+     * {@return the hashcode for this session}
      */
     @Override
     public int hashCode() {
@@ -1000,18 +1000,16 @@ final class SSLSessionImpl extends ExtendedSSLSession {
      */
     @Override
     public boolean equals(Object obj) {
-
         if (obj == this) {
             return true;
         }
 
-        if (obj instanceof SSLSessionImpl) {
-            SSLSessionImpl sess = (SSLSessionImpl) obj;
-            return (sessionId != null) && (sessionId.equals(
-                        sess.getSessionId()));
+        if (!(obj instanceof SSLSessionImpl)) {
+            return false;
         }
 
-        return false;
+        return  sessionId != null
+                && sessionId.equals(((SSLSessionImpl) obj).getSessionId());
     }
 
 


### PR DESCRIPTION
This is a backport of [JDK-8311170]: Simplify and modernize equals and hashCode in security area.

This PR will resolve #335.

[JDK-8311170]:
<https://bugs.openjdk.org/browse/JDK-8311170>