### PR TITLE
TKSS-339: Backport JDK-8314045: ArithmeticException in GaloisCounterMode

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GaloisCounterMode.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GaloisCounterMode.java
@@ -1619,6 +1619,13 @@ abstract class GaloisCounterMode extends CipherSpi {
                 len += buffer.remaining();
             }
 
+            // Check that input data is long enough to fit the expected tag.
+            if (len < 0) {
+                throw new AEADBadTagException("Input data too short to " +
+                    "contain an expected tag length of " + tagLenBytes +
+                    "bytes");
+            }
+
             checkDataLength(len);
 
             // Verify dst is large enough


### PR DESCRIPTION
This is a backport of [JDK-8314045]: ArithmeticException in GaloisCounterMode.

This PR will resolve #339.

[JDK-8314045]:
<https://bugs.openjdk.org/browse/JDK-8314045>