### PR TITLE
TKSS-340: Backport JDK-8314059: Remove PKCS7.verify()

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS7.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -591,17 +591,6 @@ public class PKCS7 {
             return intResult.toArray(result);
         }
         return null;
-    }
-
-    /**
-     * Returns all signerInfos which self-verify.
-     *
-     * @exception NoSuchAlgorithmException on unrecognized algorithms.
-     * @exception SignatureException on signature handling errors.
-     */
-    public SignerInfo[] verify()
-            throws NoSuchAlgorithmException, SignatureException {
-        return verify(null);
     }
 
     /**


### PR DESCRIPTION
This is a backport of [JDK-8314059]: Remove PKCS7.verify().

This PR will resolve #340.

[JDK-8314059]:
<https://bugs.openjdk.org/browse/JDK-8314059>