### PR TITLE
TKSS-356: Highlight third-party components in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Tencent Kona SM Suite is a set of Java security providers, which service the Sha
 - [KonaSSL] implements China's Transport Layer Cryptographic Protocol, and also applies ShangMi algorithms to TLS 1.3 based on RFC 8998.
 - [Kona], which wraps all the features in `KonaCrypto`，`KonaPKIX` and `KonaSSL`, so it has to depend on one or more of them. Generally, **this provider is recommended**.
 
-This project provides a Spring Boot module, exactly [kona-demo], as a server-side demo. This module demonstrates the approach on integrating Tencent Kona SM Suite to the 3rd-party web servers, including Jetty and Tomcat. But this module is not one of the artifacts of this project. In addition, [the test set] in `kona-ssl` module provides the demon on integrating with `Netty` and `Apache HttpClient`.
+This project provides a Spring Boot module, exactly [kona-demo], as a server-side demo. This module demonstrates the approach on integrating Tencent Kona SM Suite to the 3rd-party web servers, including `Jetty` and `Tomcat`. But this module is not one of the artifacts of this project. In addition, [the test set] in `kona-ssl` module provides the demon on integrating with `Netty` and `Apache HttpClient`.
 
 ## System requirements
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -13,7 +13,7 @@
 - [KonaSSL]，它实现了中国的传输层密码协议（TLCP），并遵循RFC 8998规范将国密基础算法应用到了TLS 1.3协议中。它需要依赖`KonaCrypto`和`KonaPKIX`。
 - [Kona]，它将`KonaCrypto`，`KonaPKIX`和`KonaSSL`中的特性进行了简单的封装，所以它需要根据实际需求去依赖这些Provider中的一个或多个。一般地，**建议使用这个Provider**。
 
-本项目还提供了一个Spring Boot模块，即[kona-demo]，作为服务端的示例。该模块演示了将腾讯Kona国密套件集成入第三方Web服务器，包括Jetty和Tomcat，的途径。但该模块并不是本项目的制品之一。另外，`kona-ssl`模块的[测试集]还提供了与`Netty`和`Apache HttpClient`进行集成的示例。
+本项目还提供了一个Spring Boot模块，即[kona-demo]，作为服务端的示例。该模块演示了将腾讯Kona国密套件集成入第三方Web服务器，包括`Jetty`和`Tomcat`，的途径。但该模块并不是本项目的制品之一。另外，`kona-ssl`模块的[测试集]还提供了与`Netty`和`Apache HttpClient`进行集成的示例。
 
 ## 系统要求
 

--- a/kona-demo/README.md
+++ b/kona-demo/README.md
@@ -5,7 +5,7 @@ English | **[中文]**
 ## Introduction
 Tencent Kona Demo is a server-side application based on Spring Boot. It is only used for demonstrating the approach on integrating this suite to a Spring Boot project. However, this module is not one of the artifacts of this project.
 
-`kona-demo` supports two embedded web servers, including Jetty and Tomcat. But only Jetty web server `JettyServer` is a `SpringBootApplication`, so it can be launched by Gradle task `bootRun`. However, Tomcat web server `TomcatServer` is a common application.
+`kona-demo` supports two embedded web servers, including `Jetty` and `Tomcat`. But only Jetty web server `JettyServer` is a `SpringBootApplication`, so it can be launched by Gradle task `bootRun`. However, Tomcat web server `TomcatServer` is a common application.
 
 ## Usages
 It can launch the Jetty server via the below command,

--- a/kona-demo/README_cn.md
+++ b/kona-demo/README_cn.md
@@ -5,7 +5,7 @@
 ## 简介
 Tencent Kona Demo是一个基于Spring Boot的服务端应用，它仅用于展示如何将本套组件集成到Spring Boot工程中，它并不是本项目的制品之一。
 
-`kona-demo`支持了两个内嵌的Web服务器，即Jetty和Tomcat。但只有Jetty Web服务器`JettyServer`是`SpringBootApplication`，可以由Gradle的`bootRun`任务启动。而Tomcat Web服务器`TomcatServer`是一个普通的应用程序。
+`kona-demo`支持了两个内嵌的Web服务器，即`Jetty`和`Tomcat`。但只有Jetty Web服务器`JettyServer`是`SpringBootApplication`，可以由Gradle的`bootRun`任务启动。而Tomcat Web服务器`TomcatServer`是一个普通的应用程序。
 
 ## 使用
 启动Jetty服务器，可以使用如下命令，


### PR DESCRIPTION
It would highlight the third-party components, such as `Jetty` and `Tomcat`, in the READMEs.

This PR will resolves #356.