### PR TITLE
TKSS-358: TomcatServer would not use custom Connector

### DIFF
--- a/kona-demo/build.gradle
+++ b/kona-demo/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
 
     implementation("org.springframework.boot:spring-boot-starter-tomcat")
-    testImplementation("org.apache.tomcat.embed:tomcat-embed-core:9.0.78")
+    implementation("org.apache.tomcat.embed:tomcat-embed-core:9.0.78")
 
     implementation("org.springframework.boot:spring-boot-starter-jetty")
 


### PR DESCRIPTION
It is unnecessary to use the custom `Connector` for applying the custom `SSLImplementation`.
Instead, using `Connector` property `sslImplementationName` to apply that `SSLImplementation`.

This PR will resolves #358.