### PR TITLE
TKSS-366: Remove BouncyCastle from LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 Copyright (C) 2022 THL A29 Limited, a Tencent company.  All rights reserved.
 
-TencentKonaSMSuite is licensed under the GNU GPL v2.0 license with classpath exception, except for the third-party components listed below.
+TencentKonaSMSuite is licensed under the GNU GPL v2.0 license with classpath exception.
 
 Terms of the GNU GPL v2.0 license with classpath exception:
 --------------------------------------------------------------------
@@ -345,18 +345,3 @@ License instead of this License.
     you modify this library, you may extend this exception to your version of
     the library, but you are not obligated to do so.  If you do not wish to do
     so, delete this exception statement from your version.
-
-
-
-Other dependencies and licenses:
-
-Open Source Software Licensed under the MIT license:
--------------------------------------------------------------------------------------------
-1. bouncycastle
-Copyright (c) 2000 - 2021 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Tencent Kona SM Suite is licensed under GNU GPL v2.0 license with classpath exce
 
 **Q**: How old JDK 8 released can be supported?<br>
 **A**: Different scenarios require different JDK 8 releases.
-- Only need SM algorithms and/or TLCP protocol, at most `8u141` (even older versions) is required.-
-  - If it requires ALPN extension in TLCP protocol, this required oldest version is `8u251`.
+- Only need SM algorithms and/or TLCP protocol, at most `8u141` (even older versions) is required.
+  - If it requires ALPN extension in TLCP protocol, the required oldest version is `8u251`.
 - In order to apply TLS 1.3/RFC 8998, the required oldest version is `8u261`.
 
 In addition, your problems may be already raised by others. Before open a new issue, please look through the existing [questions].


### PR DESCRIPTION
It would remove BouncyCastle from LICENSE.txt due to TencentKonaSMSuite doesn't depend on it any more.

This PR will resolve #366.