### PR TITLE
TKSS-368: SM2Ciphertext should check uncompressed flag

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/util/SM2Ciphertext.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/util/SM2Ciphertext.java
@@ -124,8 +124,7 @@ public class SM2Ciphertext {
     private final byte[] digest;
     private final byte[] ciphertext;
 
-    public SM2Ciphertext(Builder builder)
-            throws IOException {
+    public SM2Ciphertext(Builder builder) throws IOException {
         if (builder.format == Format.DER_C1C3C2
                 || builder.format == Format.DER_C1C2C3) {
             DerInputStream derIn = new DerInputStream(builder.encodedCiphertext);
@@ -151,6 +150,13 @@ public class SM2Ciphertext {
         } else if (builder.format == Format.RAW_C1C3C2
                 || builder.format == Format.RAW_C1C2C3) {
             byte[] encodedCiphertext = builder.encodedCiphertext;
+
+            // The public point key must start with 0x04
+            // indicating the format is uncompressed.
+            if (encodedCiphertext[0] != 0x04) {
+                throw new IOException("For RAW_C1C3C2 and RAW_C1C2C3 formats, "
+                        + "the ciphertext must start with 04");
+            }
 
             builder.coordX(copy(encodedCiphertext, 1, 32));
             builder.coordY(copy(encodedCiphertext, 1 + 32, 32));

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/util/SM2CiphertextTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/util/SM2CiphertextTest.java
@@ -23,6 +23,12 @@ public class SM2CiphertextTest {
             + "0401"
             + "06";
 
+    private static final String C1_WITHOUT_04
+            = "8A2A155B9C644A45D118BCC3213325EECDD970307406F1AB90CB1EC0A0445A6E"
+            + "054797A7ABB739E783CFACE5B1184458685148F40D4C0680DA2AEB4538307555"
+            + "16A9E16A16E440A245DD744E7966A32AC49D22152E9F560F7506E9FAFF293D73"
+            + "06";
+
     private static SM2Ciphertext sm2Ciphertext;
     private static SM2Ciphertext sm2CiphertextNone;
 
@@ -40,6 +46,22 @@ public class SM2CiphertextTest {
                 .digest(CryptoUtils.toBytes("16A9E16A16E440A245DD744E7966A32AC49D22152E9F560F7506E9FAFF293D73"))
                 .ciphertext(CryptoUtils.toBytes("06"))
                 .build();
+    }
+
+    @Test
+    public void testCheckRawC1C3C2() {
+        Assertions.assertThrows(IOException.class, () -> SM2Ciphertext.builder()
+                .format(SM2Ciphertext.Format.RAW_C1C3C2)
+                .encodedCiphertext(CryptoUtils.toBytes(C1_WITHOUT_04))
+                .build());
+    }
+
+    @Test
+    public void testCheckRawC1C2C3() {
+        Assertions.assertThrows(IOException.class, () -> SM2Ciphertext.builder()
+                .format(SM2Ciphertext.Format.RAW_C1C2C3)
+                .encodedCiphertext(CryptoUtils.toBytes(C1_WITHOUT_04))
+                .build());
     }
 
     @Test


### PR DESCRIPTION
The SM2 ciphertext formats could be plain `C1||C3||C2` or `C1||C2||C3`.
And the format of `C1` part, exactly public key point, should be `04||x||y`.
`04` means the point format is uncompressed, and `x` and `y` are the point coordinate.

Some implementations may miss the leading `04` for the above formats.
SM2Ciphertext should check this case for alerting the ciphertext is illegal.

This PR will resolves #368.