### PR TITLE
TKSS-371: No need to counter chosen-plaintext issue on TLCP

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLEngineOutputRecord.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLEngineOutputRecord.java
@@ -597,8 +597,8 @@ final class SSLEngineOutputRecord extends OutputRecord implements SSLRecord {
      * the peer must have similar protections.
      */
     boolean needToSplitPayload() {
-        return (!protocolVersion.useTLS11PlusSpec()) &&
-                writeCipher.isCBCMode() && !isFirstAppOutputRecord &&
-                enableCBCProtection;
+        return !protocolVersion.useTLS11PlusSpec() && !protocolVersion.isTLCP11()
+                && writeCipher.isCBCMode() && !isFirstAppOutputRecord
+                && enableCBCProtection;
     }
 }

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLSocketOutputRecord.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLSocketOutputRecord.java
@@ -398,9 +398,9 @@ final class SSLSocketOutputRecord extends OutputRecord implements SSLRecord {
      * the peer must have similar protections.
      */
     private boolean needToSplitPayload() {
-        return (!protocolVersion.useTLS11PlusSpec()) &&
-                writeCipher.isCBCMode() && !isFirstAppOutputRecord &&
-                enableCBCProtection;
+        return !protocolVersion.useTLS11PlusSpec() && !protocolVersion.isTLCP11()
+                && writeCipher.isCBCMode() && !isFirstAppOutputRecord
+                && enableCBCProtection;
     }
 
     private int getFragLimit() {


### PR DESCRIPTION
TLCP is based on TLS 1.1 and TLS 1.2, so it has no chosen-plaintext issue on CBC mode ciphers.

This PR will resolves #371.