### PR TITLE
TKSS-377: Declare junit-platform-launcher as runtime dependency explicitly

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ jetty = "9.4.52.v20230823"
 apache-httpclient = "4.5.14"
 okhttp = "4.11.0"
 junit = "5.10.0"
+junit-platform-launcher = "1.10.0"
 jmh = "1.37"
 
 springboot = "2.7.15"
@@ -31,6 +32,7 @@ spring-boot-starter-jetty = { module = "org.springframework.boot:spring-boot-sta
 
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit"}
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit"}
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit.platform.launcher"}
 
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh"}
 jmh-generator-annprocess = { module = "org.openjdk.jmh:jmh-generator-annprocess", version.ref = "jmh"}

--- a/kona-crypto/build.gradle.kts
+++ b/kona-crypto/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
 
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
 
     jmhImplementation(libs.jmh.core)
     jmhAnnotationProcessor(libs.jmh.generator.annprocess)

--- a/kona-pkix/build.gradle.kts
+++ b/kona-pkix/build.gradle.kts
@@ -7,4 +7,5 @@ dependencies {
 
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }

--- a/kona-provider/build.gradle.kts
+++ b/kona-provider/build.gradle.kts
@@ -15,4 +15,5 @@ dependencies {
 
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }

--- a/kona-ssl/build.gradle.kts
+++ b/kona-ssl/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
 
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
 
     jmhImplementation(libs.jmh.core)
     jmhImplementation(libs.jmh.generator.annprocess)


### PR DESCRIPTION
Gradle 8.3 complains that Gradle 9.0 will not load test framework implementation dependencies automatically.
So, it should declare junit-platform-launcher as runtime dependency explicitly.

This PR will resolve #377.