### PR TITLE
TKSS-396: kona-ssl uses wrong function for JMH annotation processor

### DIFF
--- a/kona-ssl/build.gradle.kts
+++ b/kona-ssl/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     testRuntimeOnly(libs.junit.platform.launcher)
 
     jmhImplementation(libs.jmh.core)
-    jmhImplementation(libs.jmh.generator.annprocess)
+    jmhAnnotationProcessor(libs.jmh.generator.annprocess)
     jmhImplementation(sourceSets["test"].runtimeClasspath)
 }
 


### PR DESCRIPTION
`jmhImplementation` --> `jmhAnnotationProcessor`.