### PR TITLE
TKSS-400: Use HmacSM3 as the standard name for SM3 HMAC algorithm

### DIFF
--- a/kona-crypto/README.md
+++ b/kona-crypto/README.md
@@ -220,8 +220,8 @@ byte[] digest = md.digest();
 
 For detailed information about MessageDigest APIs, please refer to the official [MessageDigest] docs.
 
-### SM3HMac
-Using SM3 HMAC algorithm is the same as using other existing MAC algorithm, like HmacSHA256. It only invokes JDK APIs to generate the message authentication code.
+### HmacSM3
+Using HmacSM3 algorithm is the same as using other existing MAC algorithm, like HmacSHA256. It only invokes JDK APIs to generate the message authentication code.
 
 Prepare a 16-bytes key.
 
@@ -233,7 +233,7 @@ SecretKey secretKey = new SecretKeySpec(key, "SM4");
 Create Mac instance.
 
 ```
-Mac hmac = Mac.getInstance("SM3HMac");
+Mac hmac = Mac.getInstance("HmacSM3");
 ```
 
 Initialize the Mac instance with the key.

--- a/kona-crypto/README_cn.md
+++ b/kona-crypto/README_cn.md
@@ -220,8 +220,8 @@ byte[] digest = md.digest();
 
 关于消息摘要算法API的更详细用法，请参考[MessageDigest]的官方文档。
 
-### SM3HMac
-使用SM3HMac算法与使用JDK自带的其它消息验证码算法（如HmacSHA256）的方式是完全相同的，仅需要调用JDK API就可以生成消息验证码。
+### HmacSM3
+使用HmacSM3算法与使用JDK自带的其它消息验证码算法（如HmacSHA256）的方式是完全相同的，仅需要调用JDK API就可以生成消息验证码。
 
 准备密钥，其长度为16字节。
 
@@ -233,7 +233,7 @@ SecretKey secretKey = new SecretKeySpec(key, "SM4");
 创建Mac实例。
 
 ```
-Mac hmac = Mac.getInstance("SM3HMac");
+Mac hmac = Mac.getInstance("HmacSM3");
 ```
 
 使用密钥对Mac进行初始化。

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM3HMacPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM3HMacPerfTest.java
@@ -71,7 +71,7 @@ public class SM3HMacPerfTest {
 
         @Setup(Level.Trial)
         public void setup() throws Exception {
-            mac = Mac.getInstance("SM3HMac", PROVIDER);
+            mac = Mac.getInstance("HmacSM3", PROVIDER);
             mac.init(SECRET_KEY);
         }
     }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/KonaCryptoProvider.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/KonaCryptoProvider.java
@@ -72,12 +72,12 @@ public class KonaCryptoProvider extends Provider {
         provider.put("Alg.Alias.MessageDigest.OID.1.2.156.10197.1.401", "SM3");
         provider.put("MessageDigest.SM3",
                 "com.tencent.kona.crypto.provider.SM3MessageDigest");
-        provider.put("Mac.SM3HMac",
-                "com.tencent.kona.crypto.provider.SM3HMac");
         provider.put("Mac.HmacSM3",
                 "com.tencent.kona.crypto.provider.SM3HMac");
-        provider.put("KeyGenerator.SM3HMac",
+        provider.put("Alg.Alias.Mac.SM3HMac", "HmacSM3");
+        provider.put("KeyGenerator.HmacSM3",
                 "com.tencent.kona.crypto.provider.SM3HMacKeyGenerator");
+        provider.put("Alg.Alias.KeyGenerator.SM3HMac", "HmacSM3");
 
         provider.put("Alg.Alias.Cipher.OID.1.2.156.10197.1.301", "SM2");
         provider.put("Alg.Alias.Signature.OID.1.2.156.10197.1.501", "SM3withSM2");

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacTest.java
@@ -52,7 +52,7 @@ public class SM3HMacTest {
     @Test
     public void testSM3HMacKeyGen() throws Exception {
         KeyGenerator sm3HMacKeyGen
-                = KeyGenerator.getInstance("SM3HMac", PROVIDER);
+                = KeyGenerator.getInstance("HmacSM3", PROVIDER);
 
         TestUtils.checkThrowable(
                 InvalidParameterException.class, ()-> sm3HMacKeyGen.init(127));
@@ -84,7 +84,7 @@ public class SM3HMacTest {
 
     @Test
     public void testSM3HMac() throws Exception {
-        Mac sm3HMac = Mac.getInstance("SM3HMac", PROVIDER);
+        Mac sm3HMac = Mac.getInstance("HmacSM3", PROVIDER);
         SecretKeySpec keySpec = new SecretKeySpec(KEY, "SM4");
         sm3HMac.init(keySpec);
         byte[] mac = sm3HMac.doFinal(toBytes("616263"));
@@ -93,7 +93,7 @@ public class SM3HMacTest {
 
     @Test
     public void testUpdateByte() throws Exception {
-        Mac sm3HMac = Mac.getInstance("SM3HMac", PROVIDER);
+        Mac sm3HMac = Mac.getInstance("HmacSM3", PROVIDER);
         SecretKeySpec keySpec = new SecretKeySpec(KEY, "SM4");
         sm3HMac.init(keySpec);
         for (byte b : MESSAGE) {
@@ -105,7 +105,7 @@ public class SM3HMacTest {
 
     @Test
     public void testUpdateBytes() throws Exception {
-        Mac sm3HMac = Mac.getInstance("SM3HMac", PROVIDER);
+        Mac sm3HMac = Mac.getInstance("HmacSM3", PROVIDER);
         SecretKeySpec keySpec = new SecretKeySpec(KEY, "SM4");
         sm3HMac.init(keySpec);
         sm3HMac.update(MESSAGE, 0, MESSAGE.length / 2);
@@ -116,7 +116,7 @@ public class SM3HMacTest {
 
     @Test
     public void testBigData() throws Exception {
-        Mac sm3HMac = Mac.getInstance("SM3HMac", PROVIDER);
+        Mac sm3HMac = Mac.getInstance("HmacSM3", PROVIDER);
         SecretKeySpec keySpec = new SecretKeySpec(KEY, "SM4");
         sm3HMac.init(keySpec);
         byte[] mac = sm3HMac.doFinal(TestUtils.dataMB(10));

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacWithBCTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacWithBCTest.java
@@ -48,7 +48,7 @@ public class SM3HMacWithBCTest {
     public void testSM3HMac() throws Exception {
         byte[] message = toBytes("616263");
 
-        Mac sm3HMac = Mac.getInstance("SM3HMac", PROVIDER);
+        Mac sm3HMac = Mac.getInstance("HmacSM3", PROVIDER);
         Mac sm3HMacBC = Mac.getInstance("HMACSM3", "BC");
 
         SecretKey secretKey = new SecretKeySpec(


### PR DESCRIPTION
According to OpenJDK naming convention, it would be better to use `HmacSM3` as the standard name for SM3 HMAC.
And `SM3HMac` is an alias for this algorithm name.