### PR TITLE
TKSS-402: SM3MessageDigest must check the input bounds

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM3MessageDigest.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM3MessageDigest.java
@@ -20,6 +20,8 @@
 
 package com.tencent.kona.crypto.provider;
 
+import com.tencent.kona.jdk.internal.util.Preconditions;
+
 import java.security.DigestException;
 import java.security.MessageDigest;
 
@@ -45,6 +47,12 @@ public final class SM3MessageDigest extends MessageDigest implements Cloneable {
 
     @Override
     protected void engineUpdate(byte[] input, int offset, int length) {
+        if (length == 0) {
+            return;
+        }
+        Preconditions.checkFromIndexSize(
+                offset, length, input.length, Preconditions.AIOOBE_FORMATTER);
+
         engine.update(input, offset, length);
     }
 

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3Test.java
@@ -136,11 +136,12 @@ public class SM3Test {
         outOfBounds(16, 0, 32);
         outOfBounds(7, 0, 32);
         outOfBounds(16, -8, 16);
-//        outOfBounds(16, 8, -8);
+        outOfBounds(16, 8, -8);
         outOfBounds(16, Integer.MAX_VALUE, 8);
     }
 
-    private static void outOfBounds(int arrayLen, int ofs, int len) throws Exception {
+    private static void outOfBounds(int arrayLen, int ofs, int len)
+            throws Exception {
         MessageDigest md = MessageDigest.getInstance("SM3", PROVIDER);
 
         try {


### PR DESCRIPTION
SM3MessageDigest must check the input to make sure it can get the valid byte array from the input.

This PR will resolve #402.