### PR TITLE
TKSS-406: Add SM3 test cases with ByteBuffer

### DIFF
--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacTest.java
@@ -29,6 +29,7 @@ import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
+import java.nio.ByteBuffer;
 import java.security.InvalidParameterException;
 import java.security.SecureRandom;
 
@@ -115,12 +116,41 @@ public class SM3HMacTest {
     }
 
     @Test
+    public void testByteBuffer() throws Exception {
+        Mac sm3HMac = Mac.getInstance("HmacSM3", PROVIDER);
+        SecretKeySpec keySpec = new SecretKeySpec(KEY, "HmacSM3");
+        sm3HMac.init(keySpec);
+        ByteBuffer buffer = ByteBuffer.wrap(toBytes("616263"));
+        sm3HMac.update(buffer);
+        byte[] mac = sm3HMac.doFinal();
+        Assertions.assertEquals(SM3_HMAC_LEN, mac.length);
+    }
+
+    @Test
     public void testBigData() throws Exception {
         Mac sm3HMac = Mac.getInstance("HmacSM3", PROVIDER);
         SecretKeySpec keySpec = new SecretKeySpec(KEY, "HmacSM3");
         sm3HMac.init(keySpec);
         byte[] mac = sm3HMac.doFinal(TestUtils.dataMB(10));
         Assertions.assertEquals(SM3_HMAC_LEN, mac.length);
+    }
+
+    @Test
+    public void testBigByteBuffer() throws Exception {
+        byte[] data = TestUtils.dataMB(10);
+        SecretKeySpec keySpec = new SecretKeySpec(KEY, "HmacSM3");
+
+        Mac sm3HMac = Mac.getInstance("HmacSM3", PROVIDER);
+        sm3HMac.init(keySpec);
+        byte[] mac = sm3HMac.doFinal(data);
+
+        Mac sm3HMacBuffer = Mac.getInstance("HmacSM3", PROVIDER);
+        sm3HMacBuffer.init(keySpec);
+        ByteBuffer buffer = ByteBuffer.wrap(data);
+        sm3HMacBuffer.update(buffer);
+        byte[] macBuffer = sm3HMacBuffer.doFinal();
+
+        Assertions.assertArrayEquals(mac, macBuffer);
     }
 
     @Test

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3Test.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.util.Random;
 
@@ -95,10 +96,32 @@ public class SM3Test {
     }
 
     @Test
+    public void testByteBuffer() throws Exception {
+        MessageDigest md = MessageDigest.getInstance("SM3", PROVIDER);
+        md.update(ByteBuffer.wrap(MESSAGE_SHORT));
+        byte[] digest = md.digest();
+        Assertions.assertArrayEquals(DIGEST_SHORT, digest);
+    }
+
+    @Test
     public void testBigData() throws Exception {
         MessageDigest md = MessageDigest.getInstance("SM3", PROVIDER);
         byte[] digest = md.digest(TestUtils.dataMB(10));
         Assertions.assertEquals(Constants.SM3_DIGEST_LEN, digest.length);
+    }
+
+    @Test
+    public void testBigByteBuffer() throws Exception {
+        byte[] data = TestUtils.dataMB(10);
+
+        MessageDigest md = MessageDigest.getInstance("SM3", PROVIDER);
+        byte[] digest = md.digest(data);
+
+        MessageDigest mdBuffer = MessageDigest.getInstance("SM3", PROVIDER);
+        mdBuffer.update(ByteBuffer.wrap(data));
+        byte[] digestBuffer = mdBuffer.digest();
+
+        Assertions.assertArrayEquals(digest, digestBuffer);
     }
 
     @Test


### PR DESCRIPTION
It should add test cases to `SM3Test` and `SM3HMacTest` for covering the APIs on ByteBuffer.

This PR will resolves #406.