### PR TITLE
TKSS-408: Add SM3 test cases with empty and null inputs

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/com/sun/crypto/provider/HmacCore.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/com/sun/crypto/provider/HmacCore.java
@@ -35,7 +35,6 @@ import java.security.*;
 import java.security.spec.*;
 
 import com.tencent.kona.crypto.CryptoInsts;
-import sun.security.x509.AlgorithmId;
 
 /**
  * This class constitutes the core of HMAC-<MD> algorithms, where

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacTest.java
@@ -116,6 +116,23 @@ public class SM3HMacTest {
     }
 
     @Test
+    public void testNullBytes() throws Exception {
+        SecretKeySpec keySpec = new SecretKeySpec(KEY, "HmacSM3");
+
+        Mac sm3HMac1 = Mac.getInstance("HmacSM3", PROVIDER);
+        sm3HMac1.init(keySpec);
+        sm3HMac1.update((byte[]) null);
+        byte[] mac1 = sm3HMac1.doFinal();
+
+        Mac sm3HMac2 = Mac.getInstance("HmacSM3", PROVIDER);
+        sm3HMac2.init(keySpec);
+        sm3HMac2.update(new byte[0]);
+        byte[] mac2 = sm3HMac2.doFinal();
+
+        Assertions.assertArrayEquals(mac1, mac2);
+    }
+
+    @Test
     public void testByteBuffer() throws Exception {
         Mac sm3HMac = Mac.getInstance("HmacSM3", PROVIDER);
         SecretKeySpec keySpec = new SecretKeySpec(KEY, "HmacSM3");
@@ -124,6 +141,51 @@ public class SM3HMacTest {
         sm3HMac.update(buffer);
         byte[] mac = sm3HMac.doFinal();
         Assertions.assertEquals(SM3_HMAC_LEN, mac.length);
+    }
+
+    @Test
+    public void testNullByteBuffer() throws Exception {
+        Mac sm3HMac = Mac.getInstance("HmacSM3", PROVIDER);
+        SecretKeySpec keySpec = new SecretKeySpec(KEY, "HmacSM3");
+        sm3HMac.init(keySpec);
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    sm3HMac.update((ByteBuffer) null);
+                });
+    }
+
+    @Test
+    public void testEmptyInput() throws Exception {
+        SecretKeySpec keySpec = new SecretKeySpec(KEY, "HmacSM3");
+
+        Mac sm3HMac1 = Mac.getInstance("HmacSM3", PROVIDER);
+        sm3HMac1.init(keySpec);
+        sm3HMac1.update(new byte[0]);
+        byte[] mac1 = sm3HMac1.doFinal();
+
+        Mac sm3HMac2 = Mac.getInstance("HmacSM3", PROVIDER);
+        sm3HMac2.init(keySpec);
+        sm3HMac2.update(ByteBuffer.wrap(new byte[0]));
+        byte[] mac2 = sm3HMac2.doFinal();
+
+        Assertions.assertArrayEquals(mac1, mac2);
+    }
+
+    @Test
+    public void testNoInput() throws Exception {
+        SecretKeySpec keySpec = new SecretKeySpec(KEY, "HmacSM3");
+
+        Mac sm3HMac1 = Mac.getInstance("HmacSM3", PROVIDER);
+        sm3HMac1.init(keySpec);
+        byte[] mac1 = sm3HMac1.doFinal();
+
+        Mac sm3HMac2 = Mac.getInstance("HmacSM3", PROVIDER);
+        sm3HMac2.init(keySpec);
+        sm3HMac1.update(new byte[0]);
+        byte[] mac2 = sm3HMac1.doFinal();
+
+        Assertions.assertArrayEquals(mac1, mac2);
     }
 
     @Test

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3Test.java
@@ -96,11 +96,52 @@ public class SM3Test {
     }
 
     @Test
+    public void testNullBytes() throws Exception {
+        MessageDigest md = MessageDigest.getInstance("SM3", PROVIDER);
+        Assertions.assertThrows(
+                NullPointerException.class,
+                () -> md.update((byte[]) null));
+    }
+
+    @Test
     public void testByteBuffer() throws Exception {
         MessageDigest md = MessageDigest.getInstance("SM3", PROVIDER);
         md.update(ByteBuffer.wrap(MESSAGE_SHORT));
         byte[] digest = md.digest();
         Assertions.assertArrayEquals(DIGEST_SHORT, digest);
+    }
+
+    @Test
+    public void testNullByteBuffer() throws Exception {
+        MessageDigest md = MessageDigest.getInstance("SM3", PROVIDER);
+        Assertions.assertThrows(
+                NullPointerException.class,
+                () -> md.update((ByteBuffer) null));
+    }
+
+    @Test
+    public void testEmptyInput() throws Exception {
+        MessageDigest md1 = MessageDigest.getInstance("SM3", PROVIDER);
+        md1.update(new byte[0]);
+        byte[] digest1 = md1.digest();
+
+        MessageDigest md2 = MessageDigest.getInstance("SM3", PROVIDER);
+        md2.update(ByteBuffer.wrap(new byte[0]));
+        byte[] digest2 = md2.digest();
+
+        Assertions.assertArrayEquals(digest1, digest2);
+    }
+
+    @Test
+    public void testNoInput() throws Exception {
+        MessageDigest md1 = MessageDigest.getInstance("SM3", PROVIDER);
+        byte[] digest1 = md1.digest();
+
+        MessageDigest md2 = MessageDigest.getInstance("SM3", PROVIDER);
+        md2.update(new byte[0]);
+        byte[] digest2 = md2.digest();
+
+        Assertions.assertArrayEquals(digest1, digest2);
     }
 
     @Test


### PR DESCRIPTION
It would be better to add some SM3 test cases with empty and null inputs.

This PR will resolves #408.