### PR TITLE
TKSS-410: SM3HMacTest::testNoInput misuses Mac instance

### DIFF
--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacTest.java
@@ -182,8 +182,8 @@ public class SM3HMacTest {
 
         Mac sm3HMac2 = Mac.getInstance("HmacSM3", PROVIDER);
         sm3HMac2.init(keySpec);
-        sm3HMac1.update(new byte[0]);
-        byte[] mac2 = sm3HMac1.doFinal();
+        sm3HMac2.update(new byte[0]);
+        byte[] mac2 = sm3HMac2.doFinal();
 
         Assertions.assertArrayEquals(mac1, mac2);
     }


### PR DESCRIPTION
```java
@Test
public void testNoInput() throws Exception {
 ...
    Mac sm3HMac2 = Mac.getInstance("HmacSM3", PROVIDER);
    sm3HMac2.init(keySpec);
    sm3HMac1.update(new byte[0]);
    byte[] mac2 = sm3HMac1.doFinal();
...
}
```

Here `sm3HMac1` must be `sm3HMac2`.

This PR will resolve #410.