### PR TITLE
TKSS-414: SM4Test should not depend on SM2

### DIFF
--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4Test.java
@@ -843,7 +843,7 @@ public class SM4Test {
     @Test
     public void testSealedObject() throws Exception {
         KeyPairGenerator keyPairGen
-                = KeyPairGenerator.getInstance("SM2", PROVIDER);
+                = KeyPairGenerator.getInstance("EC", PROVIDER);
         keyPairGen.initialize(256);
         KeyPair keyPair = keyPairGen.generateKeyPair();
 
@@ -855,7 +855,7 @@ public class SM4Test {
         Cipher cipher = Cipher.getInstance("SM4/CBC/PKCS7Padding", PROVIDER);
         cipher.init(Cipher.ENCRYPT_MODE, secretKey);
 
-        // Seal the SM2 private key
+        // Seal the private key
         SealedObject sealed = new SealedObject(keyPair.getPrivate(), cipher);
 
         // Serialize


### PR DESCRIPTION
As an algorithm independent of SM2, the test for SM4 should not rely on SM2.

This PR will resolves #414.