### PR TITLE
TKSS-417: Deprecate SM4KeySpec

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM4KeySpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM4KeySpec.java
@@ -22,6 +22,10 @@ package com.tencent.kona.crypto.spec;
 
 import javax.crypto.spec.SecretKeySpec;
 
+/**
+ * @deprecated Use <code>SecretKeySpec(key, "SM4")</code> instead
+ */
+@Deprecated
 public class SM4KeySpec extends SecretKeySpec {
 
     private static final long serialVersionUID = -621469601839652916L;


### PR DESCRIPTION
It would be better to use SecretKeySpec(key, "SM4") instead of SM4KeySpec.

This PR will resolves #417.