### PR TITLE
TKSS-416: Backport JDK-8293176: SSLEngine handshaker does not send an alert after a bad parameters

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLEngineImpl.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLEngineImpl.java
@@ -1273,7 +1273,12 @@ final class SSLEngineImpl extends SSLEngine implements SSLTransport {
                     Map.Entry<Byte, ByteBuffer> me =
                             context.delegatedActions.poll();
                     if (me != null) {
-                        context.dispatch(me.getKey(), me.getValue());
+                        try {
+                            context.dispatch(me.getKey(), me.getValue());
+                        } catch (Exception e) {
+                            throw context.conContext.fatal(Alert.INTERNAL_ERROR,
+                                    "Unhandled exception", e);
+                        }
                     }
                 }
                 return null;


### PR DESCRIPTION
This is a backport of [JDK-8293176]: SSLEngine handshaker does not send an alert after a bad parameters.

This PR will resolves #416.

[JDK-8293176]:
<https://bugs.openjdk.org/browse/JDK-8293176>