### PR TITLE
TKSS-420: SM4Parameters::engineGetParameterSpec throws NullPointerException

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4Parameters.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4Parameters.java
@@ -113,20 +113,24 @@ public final class SM4Parameters extends AlgorithmParametersSpi {
     protected <T extends AlgorithmParameterSpec> T engineGetParameterSpec(
             Class<T> paramSpec) throws InvalidParameterSpecException {
         if (IvParameterSpec.class.isAssignableFrom(paramSpec)) {
-            try {
-                decode();
-            } catch (IOException e) {
-                throw new InvalidParameterSpecException(
-                        "Decode parameters failed: " + e.getMessage());
+            if (iv == null) {
+                try {
+                    decode();
+                } catch (IOException e) {
+                    throw new InvalidParameterSpecException(
+                            "Decode parameters failed: " + e.getMessage());
+                }
             }
 
             return paramSpec.cast(new IvParameterSpec(iv));
         } else if (GCMParameterSpec.class.isAssignableFrom(paramSpec)) {
-            try {
-                gcmDecode();
-            } catch (IOException e) {
-                throw new InvalidParameterSpecException(
-                        "Decode GCM parameters failed: " + e.getMessage());
+            if (iv == null) {
+                try {
+                    gcmDecode();
+                } catch (IOException e) {
+                    throw new InvalidParameterSpecException(
+                            "Decode GCM parameters failed: " + e.getMessage());
+                }
             }
 
             if (tagLen == SM4_GCM_TAG_LEN) {


### PR DESCRIPTION
If `SM4Parameters` instance is initiated via method `engineInit(AlgorithmParameterSpec paramSpec)`, and then `engineGetParameterSpec` will throws `NullPointerException`.

In the above case, the `encoded` is null, so the invocation on method `decode` must fail with `NullPointerException`.
However, it is unnecessary to try to decode the `iv`, since the `iv` is already there.

This PR will resolves #420.