### PR TITLE
TKSS-424: Backport JDK-8301686: TLS 1.3 handshake fails if server_name doesn't match resuming session

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ServerNameExtension.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ServerNameExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -339,6 +339,10 @@ final class ServerNameExtension {
                         sni, shc.resumingSession.serverNameIndication)) {
                     shc.isResumption = false;
                     shc.resumingSession = null;
+                    // this server is disallowing this session resumption,
+                    // so don't include the pre-shared key in the
+                    // ServerHello handshake message
+                    shc.handshakeExtensions.remove(SSLExtension.SH_PRE_SHARED_KEY);
                     if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
                         SSLLogger.fine(
                                 "abort session resumption, " +


### PR DESCRIPTION
This is a backport of [JDK-8301686]: TLS 1.3 handshake fails if server_name doesn't match resuming session.

This PR will resolve #424.

[JDK-8301686]:
<https://bugs.openjdk.org/browse/JDK-8301686>