### PR TITLE
TKSS-431: Display testing JDK

### DIFF
--- a/buildSrc/src/main/kotlin/kona-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/kona-common.gradle.kts
@@ -50,15 +50,23 @@ tasks {
 
     val testOnCurrent = register("testOnCurrent", CommonTest::class) {
         systemProperty("test.classpath", classpath.joinToString(separator = ":"))
+
+        doFirst {
+            println("Testing JDK: " + javaLauncher.get().metadata.installationPath)
+        }
     }
 
     register("testOnAdop8", CommonTest::class) {
         systemProperty("test.classpath", classpath.joinToString(separator = ":"))
 
         javaLauncher.set(javaToolchains.launcherFor {
-            languageVersion.set(JavaLanguageVersion.of(17))
+            languageVersion.set(JavaLanguageVersion.of(8))
             vendor.set(JvmVendorSpec.ADOPTIUM)
         })
+
+        doFirst {
+            println("Testing JDK: " + javaLauncher.get().metadata.installationPath)
+        }
     }
 
     register("testOnAdop11", CommonTest::class) {
@@ -68,6 +76,10 @@ tasks {
             languageVersion.set(JavaLanguageVersion.of(11))
             vendor.set(JvmVendorSpec.ADOPTIUM)
         })
+
+        doFirst {
+            println("Testing JDK: " + javaLauncher.get().metadata.installationPath)
+        }
     }
 
     register("testOnAdop17", CommonTest::class) {
@@ -77,6 +89,10 @@ tasks {
             languageVersion.set(JavaLanguageVersion.of(17))
             vendor.set(JvmVendorSpec.ADOPTIUM)
         })
+
+        doFirst {
+            println("Testing JDK: " + javaLauncher.get().metadata.installationPath)
+        }
     }
 
     test {


### PR DESCRIPTION
After using Gradle toolchain, It would be better to print the JDK used by the test task.

This PR will resolves #431.