### PR TITLE
TKSS-430: Backport JDK-8315042: NPE in PKCS7.parseOldSignedData

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS7.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS7.java
@@ -188,6 +188,10 @@ public class PKCS7 {
         ObjectIdentifier contentType = block.contentType;
         DerValue content = block.getContent();
 
+        if (content == null) {
+            throw new ParsingException("content is null");
+        }
+
         if (contentType.equals((Object) ContentInfo.SIGNED_DATA_OID)) {
             parseSignedData(content);
         } else if (contentType.equals((Object) ContentInfo.OLD_SIGNED_DATA_OID)) {


### PR DESCRIPTION
This is a backport of [JDK-8315042]: NPE in PKCS7.parseOldSignedData.

This PR will resolves #430.

[JDK-8315042]:
<https://bugs.openjdk.org/browse/JDK-8315042>