### PR TITLE
TKSS-445: Use JUnit5 Assertions::assertThrows

### DIFF
--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/TestUtils.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/TestUtils.java
@@ -47,45 +47,6 @@ public class TestUtils {
         Security.addProvider(new KonaCryptoProvider());
     }
 
-    public static void checkNPE(Executable executable) {
-        checkThrowable(NullPointerException.class, executable);
-    }
-
-    public static void checkIAE(Executable executable) {
-        checkThrowable(IllegalArgumentException.class, executable);
-    }
-
-    public static void checkISE(Executable executable) {
-        checkThrowable(IllegalStateException.class, executable);
-    }
-
-    public static void checkAIOOBE(Executable executable) {
-        checkThrowable(ArrayIndexOutOfBoundsException.class, executable);
-    }
-
-    public static void checkThrowable(Class<? extends Throwable> throwableClass,
-                                      Executable executable,
-                                      boolean requiredExpectedException) {
-        try {
-            executable.execute();
-            if (requiredExpectedException) {
-                throw new AssertionError("Expected exception did not raise");
-            } else {
-                System.out.println("Expected exception did not raise, " +
-                        "though that's not a matter");
-            }
-        } catch(Throwable e) {
-            if (!throwableClass.isInstance(e)) {
-                throw new AssertionError("Unexpected exception: ", e);
-            }
-        }
-    }
-
-    public static void checkThrowable(Class<? extends Throwable> throwableClass,
-                                      Executable executable) {
-        checkThrowable(throwableClass, executable, true);
-    }
-
     public static void repeatTaskParallelly(Callable<Void> task, int count)
             throws Exception {
         List<Callable<Void>> tasks = new ArrayList<>(count);

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2CipherTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2CipherTest.java
@@ -174,11 +174,11 @@ public class SM2CipherTest {
         testKeyRange(1);
 
         // privateKey = order
-        TestUtils.checkThrowable(InvalidKeyException.class,
+        Assertions.assertThrows(InvalidKeyException.class,
                 () -> testKeyRange(0));
 
         // privateKey = order + 1
-        TestUtils.checkThrowable(InvalidKeyException.class,
+        Assertions.assertThrows(InvalidKeyException.class,
                 () -> testKeyRange(-1));
     }
 
@@ -223,7 +223,7 @@ public class SM2CipherTest {
         }
 
         cipher.init(Cipher.DECRYPT_MODE, priKey);
-        TestUtils.checkThrowable(BadPaddingException.class,
+        Assertions.assertThrows(BadPaddingException.class,
                 () -> cipher.doFinal(ciphertext));
     }
 
@@ -280,7 +280,7 @@ public class SM2CipherTest {
         KeyPair altKeyPair = keyPairGenerator.generateKeyPair();
 
         cipher.init(Cipher.DECRYPT_MODE, altKeyPair.getPrivate());
-        TestUtils.checkThrowable(
+        Assertions.assertThrows(
                 BadPaddingException.class, () -> cipher.doFinal(ciphertext));
     }
 
@@ -298,7 +298,7 @@ public class SM2CipherTest {
         byte[] ciphertext = cipher.doFinal(EMPTY);
 
         cipher.init(Cipher.DECRYPT_MODE, priKey);
-        TestUtils.checkThrowable(BadPaddingException.class,
+        Assertions.assertThrows(BadPaddingException.class,
                 () -> cipher.doFinal(EMPTY));
         byte[] cleartext = cipher.doFinal(ciphertext);
         Assertions.assertArrayEquals(EMPTY, cleartext);
@@ -321,7 +321,7 @@ public class SM2CipherTest {
 
         cipher.init(Cipher.DECRYPT_MODE, priKey);
         ByteBuffer cleartextBuf = ByteBuffer.allocate(150);
-        TestUtils.checkThrowable(BadPaddingException.class,
+        Assertions.assertThrows(BadPaddingException.class,
                 () -> cipher.doFinal(ByteBuffer.allocate(0), cleartextBuf));
         cipher.doFinal(ciphertextBuf, cleartextBuf);
 

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2SignatureTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2SignatureTest.java
@@ -75,10 +75,12 @@ public class SM2SignatureTest {
                 = new SM2SignatureParameterSpec((ECPublicKey) keyPair.getPublic());
         Assertions.assertArrayEquals(Constants.defaultId(), paramSpec.getId());
 
-        TestUtils.checkIAE(()-> new SM2SignatureParameterSpec(
-                TestUtils.dataKB(8), (ECPublicKey) keyPair.getPublic()));
-        TestUtils.checkNPE(()-> new SM2SignatureParameterSpec(
-                TestUtils.dataKB(1), null));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                ()-> new SM2SignatureParameterSpec(
+                        TestUtils.dataKB(8), (ECPublicKey) keyPair.getPublic()));
+        Assertions.assertThrows(NullPointerException.class,
+                ()-> new SM2SignatureParameterSpec(
+                        TestUtils.dataKB(1), null));
     }
 
     @Test
@@ -143,13 +145,13 @@ public class SM2SignatureTest {
         // privateKey = order - 1
         // Per the specification, the private key cannot be (order - 1)
         // on generating the signature.
-        TestUtils.checkThrowable(InvalidKeyException.class, () -> testKeyRange(1));
+        Assertions.assertThrows(InvalidKeyException.class, () -> testKeyRange(1));
 
         // privateKey = order
-        TestUtils.checkThrowable(InvalidKeyException.class, () -> testKeyRange(0));
+        Assertions.assertThrows(InvalidKeyException.class, () -> testKeyRange(0));
 
         // privateKey = order + 1
-        TestUtils.checkThrowable(InvalidKeyException.class, () -> testKeyRange(-1));
+        Assertions.assertThrows(InvalidKeyException.class, () -> testKeyRange(-1));
     }
 
     // orderOffset: the relative offset to the order

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacTest.java
@@ -55,7 +55,7 @@ public class SM3HMacTest {
         KeyGenerator sm3HMacKeyGen
                 = KeyGenerator.getInstance("HmacSM3", PROVIDER);
 
-        TestUtils.checkThrowable(
+        Assertions.assertThrows(
                 InvalidParameterException.class, ()-> sm3HMacKeyGen.init(127));
 
         sm3HMacKeyGen.init(128);

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4Test.java
@@ -644,7 +644,7 @@ public class SM4Test {
         Cipher cipher = Cipher.getInstance("SM4/GCM/NoPadding", PROVIDER);
         cipher.init(Cipher.ENCRYPT_MODE, secretKey, paramSpec);
         // Init encrypter with same key and IV is NOT acceptable.
-        TestUtils.checkThrowable(
+        Assertions.assertThrows(
                 InvalidAlgorithmParameterException.class,
                 () -> cipher.init(Cipher.ENCRYPT_MODE, secretKey, paramSpec));
         cipher.init(Cipher.ENCRYPT_MODE, secretKey, altParamSpec);

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
@@ -340,29 +340,6 @@ public class TestUtils {
         }
     }
 
-    public static void checkThrowable(Class<? extends Throwable> throwableClass,
-                                      Executable executable,
-                                      boolean requiredExpectedException) {
-        try {
-            executable.execute();
-            if (requiredExpectedException) {
-                throw new AssertionError("Expected exception did not raise");
-            } else {
-                System.out.println("Expected exception did not raise, " +
-                        "though that's not a matter");
-            }
-        } catch(Throwable e) {
-            if (!throwableClass.isInstance(e)) {
-                throw new AssertionError("Unexpected exception: ", e);
-            }
-        }
-    }
-
-    public static void checkThrowable(Class<? extends Throwable> throwableClass,
-                                      Executable executable) {
-        checkThrowable(throwableClass, executable, true);
-    }
-
     public static void repeatTaskParallelly(Callable<Void> task, int count)
             throws Exception {
         List<Callable<Void>> tasks = new ArrayList<>(count);

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/TestUtils.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/TestUtils.java
@@ -374,29 +374,6 @@ public class TestUtils {
         }
     }
 
-    public static void checkThrowable(Class<? extends Throwable> throwableClass,
-                                      Executable executable,
-                                      boolean requiredExpectedException) {
-        try {
-            executable.execute();
-            if (requiredExpectedException) {
-                throw new AssertionError("Expected exception did not raise");
-            } else {
-                System.out.println("Expected exception did not raise, " +
-                        "though that's not a matter");
-            }
-        } catch(Throwable e) {
-            if (!throwableClass.isInstance(e)) {
-                throw new AssertionError("Unexpected exception: ", e);
-            }
-        }
-    }
-
-    public static void checkThrowable(Class<? extends Throwable> throwableClass,
-                                      Executable executable) {
-        checkThrowable(throwableClass, executable, true);
-    }
-
     public static void repeatTaskParallelly(Callable<Void> task, int count)
             throws Exception {
         List<Callable<Void>> tasks = new ArrayList<>(count);

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/hybrid/JdkServerJdkClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/hybrid/JdkServerJdkClientTest.java
@@ -36,6 +36,7 @@ import com.tencent.kona.ssl.interop.ServerCaller;
 import com.tencent.kona.ssl.interop.Utilities;
 import com.tencent.kona.ssl.SSLUtils;
 import com.tencent.kona.ssl.TestUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -216,7 +217,7 @@ public class JdkServerJdkClientTest {
                 ClientAuth.NONE);
 
         // No protocol can be negotiated
-        TestUtils.checkThrowable(SSLTestException.class,
+        Assertions.assertThrows(SSLTestException.class,
                 () -> testConnectWithProtocolProps(
                         "TLSv1.3",
                         "TLCPv1.1",

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/JdkServerJdkClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/JdkServerJdkClientTest.java
@@ -107,7 +107,7 @@ public class JdkServerJdkClientTest {
     @Test
     public void testFailedConnect() {
         // No enc cert
-        TestUtils.checkThrowable(SSLException.class,
+        Assertions.assertThrows(SSLException.class,
                 () -> connect(
                         TlcpUtils.CA_CERT,
                         TlcpUtils.SERVER_SIGN_CERT, TlcpUtils.SERVER_SIGN_CERT,
@@ -117,7 +117,7 @@ public class JdkServerJdkClientTest {
                         ClientAuth.NONE));
 
         // No sign cert
-        TestUtils.checkThrowable(SSLException.class,
+        Assertions.assertThrows(SSLException.class,
                 () -> connect(
                         TlcpUtils.CA_CERT,
                         TlcpUtils.SERVER_ENC_CERT, TlcpUtils.SERVER_ENC_CERT,


### PR DESCRIPTION
It should just use JUnit5 `Assertions::assertThrows` instead of custom method `TestUtils::checkThrowable`.

This PR will resolves #445.