### PR TITLE
TKSS-447: Declare SM3withSM2 as an alias of SM2 signature

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/KonaCryptoProvider.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/KonaCryptoProvider.java
@@ -86,7 +86,7 @@ public class KonaCryptoProvider extends Provider {
         provider.put("KeyFactory.SM2", "com.tencent.kona.crypto.provider.SM2KeyFactory");
         provider.put("Cipher.SM2", "com.tencent.kona.crypto.provider.SM2Cipher");
         provider.put("Signature.SM2", "com.tencent.kona.crypto.provider.SM2Signature");
-        provider.put("Signature.SM3withSM2", "com.tencent.kona.crypto.provider.SM2Signature");
+        provider.put("Alg.Alias.Signature.SM3withSM2", "SM2");
         provider.put("KeyAgreement.SM2", "com.tencent.kona.crypto.provider.SM2KeyAgreement");
 
         // PBES2 on SM

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2SignatureTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2SignatureTest.java
@@ -85,6 +85,11 @@ public class SM2SignatureTest {
 
     @Test
     public void testSignature() throws Exception {
+        testSignature("SM2");
+        testSignature("SM3withSM2");
+    }
+
+    private void testSignature(String name) throws Exception {
         KeyFactory keyFactory = KeyFactory.getInstance("SM2", PROVIDER);
         SM2PublicKeySpec publicKeySpec = new SM2PublicKeySpec(toBytes(PUB_KEY));
         PublicKey pubKey = keyFactory.generatePublic(publicKeySpec);
@@ -94,14 +99,14 @@ public class SM2SignatureTest {
         SM2SignatureParameterSpec paramSpec
                 = new SM2SignatureParameterSpec(ID, (ECPublicKey) pubKey);
 
-        Signature signer = Signature.getInstance("SM2", PROVIDER);
+        Signature signer = Signature.getInstance(name, PROVIDER);
         signer.setParameter(paramSpec);
         signer.initSign(priKey);
 
         signer.update(MESSAGE);
         byte[] signature = signer.sign();
 
-        Signature verifier = Signature.getInstance("SM2", PROVIDER);
+        Signature verifier = Signature.getInstance(name, PROVIDER);
         verifier.setParameter(paramSpec);
         verifier.initVerify(pubKey);
         verifier.update(MESSAGE);


### PR DESCRIPTION
It would not declare SM3withSM2 signature directly, instead, declare it as an alias of SM2 signature.

This PR will resolves #447.