### PR TITLE
TKSS-449: AlgorithmParameterSpecs would not depend on internal Keys

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2KeyAgreementParamSpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2KeyAgreementParamSpec.java
@@ -20,26 +20,23 @@
 
 package com.tencent.kona.crypto.spec;
 
-import com.tencent.kona.crypto.provider.SM2PrivateKey;
-import com.tencent.kona.crypto.provider.SM2PublicKey;
-
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
-
-import static com.tencent.kona.crypto.util.Constants.defaultId;
 
 /**
  * The parameters for SM2 key agreement.
  */
 public class SM2KeyAgreementParamSpec implements AlgorithmParameterSpec {
 
+    private static final byte[] DEFAULT_ID = "1234567812345678".getBytes();
+
     public final byte[] id;
-    public final SM2PrivateKey privateKey;
-    public final SM2PublicKey publicKey;
+    public final ECPrivateKey privateKey;
+    public final ECPublicKey publicKey;
 
     public final byte[] peerId;
-    public final SM2PublicKey peerPublicKey;
+    public final ECPublicKey peerPublicKey;
 
     public final boolean isInitiator;
 
@@ -50,12 +47,12 @@ public class SM2KeyAgreementParamSpec implements AlgorithmParameterSpec {
             byte[] id, ECPrivateKey privateKey, ECPublicKey publicKey,
             byte[] peerId, ECPublicKey peerPublicKey,
             boolean isInitiator, int sharedKeyLength) {
-        this.id = id;
-        this.privateKey = new SM2PrivateKey(privateKey);
-        this.publicKey = new SM2PublicKey(publicKey);
+        this.id = id.clone();
+        this.privateKey = privateKey;
+        this.publicKey = publicKey;
 
         this.peerId = peerId;
-        this.peerPublicKey = new SM2PublicKey(peerPublicKey);
+        this.peerPublicKey = peerPublicKey;
 
         this.isInitiator = isInitiator;
         this.sharedKeyLength = sharedKeyLength;
@@ -65,7 +62,7 @@ public class SM2KeyAgreementParamSpec implements AlgorithmParameterSpec {
             ECPrivateKey privateKey, ECPublicKey publicKey,
             ECPublicKey peerPublicKey,
             boolean isInitiator, int sharedKeyLength) {
-        this(defaultId(), privateKey, publicKey,
-                defaultId(), peerPublicKey, isInitiator, sharedKeyLength);
+        this(DEFAULT_ID, privateKey, publicKey,
+             DEFAULT_ID, peerPublicKey, isInitiator, sharedKeyLength);
     }
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2ParameterSpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2ParameterSpec.java
@@ -26,8 +26,6 @@ import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 import java.security.spec.EllipticCurve;
 
-import static com.tencent.kona.crypto.CryptoUtils.toBigInt;
-
 /**
  * SM2 parameter spec. The EC-related parameters are defined by China's
  * specification GB/T 32918.5-2017.
@@ -60,21 +58,21 @@ public class SM2ParameterSpec extends ECParameterSpec {
 
     private static EllipticCurve curve() {
         return new EllipticCurve(
-                new ECFieldFp(toBigInt(
-                        "FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000FFFFFFFFFFFFFFFF")),
-                toBigInt("FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000FFFFFFFFFFFFFFFC"),
-                toBigInt("28E9FA9E9D9F5E344D5A9E4BCF6509A7F39789F515AB8F92DDBCBD414D940E93"),
+                new ECFieldFp(new BigInteger(
+                        "FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000FFFFFFFFFFFFFFFF", 16)),
+                new BigInteger("FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000FFFFFFFFFFFFFFFC", 16),
+                new BigInteger("28E9FA9E9D9F5E344D5A9E4BCF6509A7F39789F515AB8F92DDBCBD414D940E93", 16),
                 null);
     }
 
     private static ECPoint generator() {
         return new ECPoint(
-                toBigInt("32C4AE2C1F1981195F9904466A39C9948FE30BBFF2660BE1715A4589334C74C7"),
-                toBigInt("BC3736A2F4F6779C59BDCEE36B692153D0A9877CC62A474002DF32E52139F0A0"));
+                new BigInteger("32C4AE2C1F1981195F9904466A39C9948FE30BBFF2660BE1715A4589334C74C7", 16),
+                new BigInteger("BC3736A2F4F6779C59BDCEE36B692153D0A9877CC62A474002DF32E52139F0A0", 16));
     }
 
     private static BigInteger order() {
-        return toBigInt("FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFF7203DF6B21C6052B53BBF40939D54123");
+        return new BigInteger("FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFF7203DF6B21C6052B53BBF40939D54123", 16);
     }
 
     private static BigInteger cofactor() {

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2SignatureParameterSpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2SignatureParameterSpec.java
@@ -20,9 +20,6 @@
 
 package com.tencent.kona.crypto.spec;
 
-import com.tencent.kona.crypto.provider.SM2PublicKey;
-import com.tencent.kona.crypto.CryptoUtils;
-
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Objects;
@@ -32,9 +29,9 @@ import java.util.Objects;
  */
 public class SM2SignatureParameterSpec implements AlgorithmParameterSpec {
 
-    private byte[] id = CryptoUtils.toBytes("31323334353637383132333435363738");
+    private byte[] id = "1234567812345678".getBytes();
 
-    private final SM2PublicKey publicKey;
+    private final ECPublicKey publicKey;
 
     public SM2SignatureParameterSpec(byte[] id, ECPublicKey publicKey) {
         Objects.requireNonNull(publicKey);
@@ -48,7 +45,7 @@ public class SM2SignatureParameterSpec implements AlgorithmParameterSpec {
             this.id = id.clone();
         }
 
-        this.publicKey = new SM2PublicKey(publicKey);
+        this.publicKey = publicKey;
     }
 
     public SM2SignatureParameterSpec(ECPublicKey publicKey) {


### PR DESCRIPTION
`SM2KeyAgreementParamSpec` and `SM2SignatureParameterSpec` are public APIs, so they would not depend on the internal `SM2PrivateKey` and `SM2PublicKey`.

This PR will resolves #449.