### PR TITLE
TKSS-457: SM2 KeySpecs should not copy a part of a byte array as keys

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2PrivateKeySpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2PrivateKeySpec.java
@@ -20,23 +20,19 @@
 
 package com.tencent.kona.crypto.spec;
 
-import com.tencent.kona.crypto.CryptoUtils;
-
 import java.math.BigInteger;
 import java.security.spec.ECPrivateKeySpec;
 
+/**
+ * A SM2 private key with the specified value.
+ */
 public class SM2PrivateKeySpec extends ECPrivateKeySpec {
 
-    public SM2PrivateKeySpec(byte[] key, int offset, int length) {
-        super(new BigInteger(CryptoUtils.copy(key, offset, length)),
-                SM2ParameterSpec.instance());
+    public SM2PrivateKeySpec(BigInteger s) {
+        super(s, SM2ParameterSpec.instance());
     }
 
-    public SM2PrivateKeySpec(byte[] key) {
-        this(key, 0, key.length);
-    }
-
-    public SM2PrivateKeySpec(byte[] key, int offset) {
-        this(key, offset, key.length - offset);
+    public SM2PrivateKeySpec(byte[] sKey) {
+        this(new BigInteger(1, sKey));
     }
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2PublicKeySpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2PublicKeySpec.java
@@ -22,20 +22,19 @@ package com.tencent.kona.crypto.spec;
 
 import com.tencent.kona.crypto.CryptoUtils;
 
+import java.security.spec.ECPoint;
 import java.security.spec.ECPublicKeySpec;
 
+/**
+ * A SM2 public key with the specified value.
+ */
 public class SM2PublicKeySpec extends ECPublicKeySpec {
 
-    public SM2PublicKeySpec(byte[] key, int offset, int length) {
-        super(CryptoUtils.pubKeyPoint(CryptoUtils.copy(key, offset, length)),
-                SM2ParameterSpec.instance());
+    public SM2PublicKeySpec(ECPoint pubPoint) {
+        super(pubPoint, SM2ParameterSpec.instance());
     }
 
-    public SM2PublicKeySpec(byte[] key) {
-        this(key, 0, key.length);
-    }
-
-    public SM2PublicKeySpec(byte[] key, int offset) {
-        this(key, offset, key.length - offset);
+    public SM2PublicKeySpec(byte[] encodedKey) {
+        this(CryptoUtils.pubKeyPoint(encodedKey));
     }
 }


### PR DESCRIPTION
`SM2PublicKeySpec` and `SM2PrivateKeySpec` do not need to copy a sub-array from a byte array as the keys.
It would be better to just accept the whole array.

This PR will resolves #457.