### PR TITLE
TKSS-453: Add Javadocs for new public APIs

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/RFC5915EncodedKeySpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/RFC5915EncodedKeySpec.java
@@ -25,19 +25,33 @@ import java.security.spec.EncodedKeySpec;
 /**
  * An encoded EC private key in compliant with RFC 5915.
  *
+ * <pre>
  * ECPrivateKey ::= SEQUENCE {
  *   version        INTEGER { ecPrivkeyVer1(1) } (ecPrivkeyVer1),
  *   privateKey     OCTET STRING,
  *   parameters [0] ECParameters {{ NamedCurve }} OPTIONAL,
  *   publicKey  [1] BIT STRING OPTIONAL
  * }
+ * </pre>
  */
 public class RFC5915EncodedKeySpec extends EncodedKeySpec {
 
+    /**
+     * Creates a new {@code RFC5915EncodedKeySpec} with the given encoded key.
+     *
+     * @param encodedKey the encoded key in compliant with RFC 5915.
+     *
+     * @exception NullPointerException if {@code encodedKey} is null.
+     */
     public RFC5915EncodedKeySpec(byte[] encodedKey) {
         super(encodedKey);
     }
 
+    /**
+     * Returns {@code RFC5915} as the format.
+     *
+     * @return the format name.
+     */
     @Override
     public String getFormat() {
         return "RFC5915";

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2KeyAgreementParamSpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2KeyAgreementParamSpec.java
@@ -23,13 +23,17 @@ package com.tencent.kona.crypto.spec;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
+import java.util.Objects;
 
 /**
- * The parameters for SM2 key agreement.
+ * The parameters used by SM2 key agreement.
  */
 public class SM2KeyAgreementParamSpec implements AlgorithmParameterSpec {
 
-    private static final byte[] DEFAULT_ID = "1234567812345678".getBytes();
+    // The default ID 1234567812345678
+    private static final byte[] DEFAULT_ID = new byte[] {
+            49, 50, 51, 52, 53, 54, 55, 56,
+            49, 50, 51, 52, 53, 54, 55, 56};
 
     private final byte[] id;
     private final ECPrivateKey privateKey;
@@ -43,10 +47,30 @@ public class SM2KeyAgreementParamSpec implements AlgorithmParameterSpec {
     // The length in bytes.
     private final int sharedKeyLength;
 
+    /**
+     * Create a new {@code SM2KeyAgreementParamSpec}.
+     *
+     * @param id the ID.
+     * @param privateKey the private key.
+     * @param publicKey the public key.
+     * @param peerId the peer's ID.
+     * @param peerPublicKey the peer's public key.
+     * @param isInitiator true indicates it initiates the key exchanging;
+     *                    false indicates peer initiates the key exchange.
+     * @param sharedKeyLength the length of the shared key.
+     *
+     * @exception NullPointerException any parameter is null.
+     */
     public SM2KeyAgreementParamSpec(
             byte[] id, ECPrivateKey privateKey, ECPublicKey publicKey,
             byte[] peerId, ECPublicKey peerPublicKey,
             boolean isInitiator, int sharedKeyLength) {
+        Objects.requireNonNull(id, "id must not null");
+        Objects.requireNonNull(privateKey, "privateKey must not null");
+        Objects.requireNonNull(publicKey, "publicKey must not null");
+        Objects.requireNonNull(peerId, "peerId must not null");
+        Objects.requireNonNull(peerPublicKey, "peerPublicKey must not null");
+
         this.id = id.clone();
         this.privateKey = privateKey;
         this.publicKey = publicKey;
@@ -58,6 +82,19 @@ public class SM2KeyAgreementParamSpec implements AlgorithmParameterSpec {
         this.sharedKeyLength = sharedKeyLength;
     }
 
+    /**
+     * Create a new {@code SM2KeyAgreementParamSpec}.
+     * It just uses the default ID, exactly {@code 1234567812345678}.
+     *
+     * @param privateKey the private key.
+     * @param publicKey the public key.
+     * @param peerPublicKey the peer's public key.
+     * @param isInitiator true indicates it initiates the key exchanging;
+     *                    false indicates peer initiates the key exchange.
+     * @param sharedKeyLength the length of the shared key.
+     *
+     * @exception NullPointerException any parameter is null.
+     */
     public SM2KeyAgreementParamSpec(
             ECPrivateKey privateKey, ECPublicKey publicKey,
             ECPublicKey peerPublicKey,

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2ParameterSpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2ParameterSpec.java
@@ -27,8 +27,8 @@ import java.security.spec.ECPoint;
 import java.security.spec.EllipticCurve;
 
 /**
- * SM2 parameter spec. The EC-related parameters are defined by China's
- * specification GB/T 32918.5-2017.
+ * The EC domain parameters used by SM2.
+ * The parameters are defined by China's specification GB/T 32918.5-2017.
  */
 public class SM2ParameterSpec extends ECParameterSpec {
 

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2PrivateKeySpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2PrivateKeySpec.java
@@ -28,10 +28,20 @@ import java.security.spec.ECPrivateKeySpec;
  */
 public class SM2PrivateKeySpec extends ECPrivateKeySpec {
 
+    /**
+     * Create a new {code SM2PrivateKeySpec}.
+     *
+     * @param s the private key value.
+     */
     public SM2PrivateKeySpec(BigInteger s) {
         super(s, SM2ParameterSpec.instance());
     }
 
+    /**
+     * Create a new {code SM2PrivateKeySpec}.
+     *
+     * @param sKey the private key value represented by a byte array.
+     */
     public SM2PrivateKeySpec(byte[] sKey) {
         this(new BigInteger(1, sKey));
     }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2PublicKeySpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2PublicKeySpec.java
@@ -30,11 +30,22 @@ import java.security.spec.ECPublicKeySpec;
  */
 public class SM2PublicKeySpec extends ECPublicKeySpec {
 
+    /**
+     * Create a new {@code SM2PublicKeySpec}.
+     *
+     * @param pubPoint the public point.
+     */
     public SM2PublicKeySpec(ECPoint pubPoint) {
         super(pubPoint, SM2ParameterSpec.instance());
     }
 
-    public SM2PublicKeySpec(byte[] encodedKey) {
-        this(CryptoUtils.pubKeyPoint(encodedKey));
+    /**
+     * Create a new {@code SM2PublicKeySpec}.
+     *
+     * @param encodedPubPoint the public point encoded in the format {@code 0x04|x|y}.
+     *                        Here, {@code x} and {@code y} are the point coordinates.
+     */
+    public SM2PublicKeySpec(byte[] encodedPubPoint) {
+        this(CryptoUtils.pubKeyPoint(encodedPubPoint));
     }
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2SignatureParameterSpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2SignatureParameterSpec.java
@@ -25,14 +25,22 @@ import java.security.spec.AlgorithmParameterSpec;
 import java.util.Objects;
 
 /**
- * The SM2 signature parameter specification.
+ * The parameters used by SM2 signature.
  */
 public class SM2SignatureParameterSpec implements AlgorithmParameterSpec {
 
-    private byte[] id = "1234567812345678".getBytes();
+    private final byte[] id;
 
     private final ECPublicKey publicKey;
 
+    /**
+     * Create a new {@code SM2SignatureParameterSpec}.
+     *
+     * @param id the ID. it must not longer than 8192-bytes.
+     * @param publicKey the SM2 public key.
+     *
+     * @throws NullPointerException if {@code publicKey} is null.
+     */
     public SM2SignatureParameterSpec(byte[] id, ECPublicKey publicKey) {
         Objects.requireNonNull(publicKey);
 
@@ -43,11 +51,23 @@ public class SM2SignatureParameterSpec implements AlgorithmParameterSpec {
             }
 
             this.id = id.clone();
+        } else {
+            // The default ID 1234567812345678
+            this.id = new byte[] {49, 50, 51, 52, 53, 54, 55, 56,
+                                  49, 50, 51, 52, 53, 54, 55, 56};
         }
 
         this.publicKey = publicKey;
     }
 
+    /**
+     * Create a new {@code SM2SignatureParameterSpec}.
+     * It just uses the default ID, exactly {@code 1234567812345678}.
+     *
+     * @param publicKey the SM2 public key.
+     *
+     * @throws NullPointerException if {@code publicKey} is null.
+     */
     public SM2SignatureParameterSpec(ECPublicKey publicKey) {
         this(null, publicKey);
     }


### PR DESCRIPTION
kona-crypto introduced a set of public APIs, like `SM2PublicKeySpec`, it would be better to add formal Javadocs for them.

This PR will resolves #453.