### PR TITLE
TKSS-452: Tests should not depend on provider-internal classes

### DIFF
--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/TestUtils.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/TestUtils.java
@@ -19,11 +19,16 @@
 
 package com.tencent.kona.crypto;
 
-import com.tencent.kona.crypto.provider.SM2PrivateKey;
-import com.tencent.kona.crypto.provider.SM2PublicKey;
+import com.tencent.kona.crypto.spec.SM2PrivateKeySpec;
+import com.tencent.kona.crypto.spec.SM2PublicKeySpec;
 
+import java.security.KeyFactory;
 import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.Security;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -111,10 +116,29 @@ public class TestUtils {
     }
 
     public static KeyPair keyPair(String publicKeyHex, String privateKeyHex) {
-        SM2PublicKey publicKeySpec = new SM2PublicKey(toBytes(publicKeyHex));
-        SM2PrivateKey privateKeySpec = new SM2PrivateKey(toBytes(privateKeyHex));
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance("SM2");
 
-        return new KeyPair(publicKeySpec, privateKeySpec);
+            PrivateKey privateKey = keyFactory.generatePrivate(
+                    new SM2PrivateKeySpec(toBytes(privateKeyHex)));
+            PublicKey publicKey = keyFactory.generatePublic(
+                    new SM2PublicKeySpec(toBytes(publicKeyHex)));
+            return new KeyPair(publicKey, privateKey);
+        } catch (Exception e) {
+            throw new RuntimeException("Create key pair failed", e);
+        }
+    }
+
+    public static ECPrivateKey privateKey(String hex) throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance("SM2");
+        return (ECPrivateKey) keyFactory.generatePrivate(
+                new SM2PrivateKeySpec(toBytes(hex)));
+    }
+
+    public static ECPublicKey publicKey(String hex) throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance("SM2");
+        return (ECPublicKey) keyFactory.generatePublic(
+                new SM2PublicKeySpec(toBytes(hex)));
     }
 
     @FunctionalInterface

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2CipherTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2CipherTest.java
@@ -183,12 +183,16 @@ public class SM2CipherTest {
     }
 
     private void testKeyRange(int orderOffset) throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance("SM2");
+
         BigInteger privateKeyS = ECOperator.SM2.getOrder().subtract(
                 BigInteger.valueOf(orderOffset));
-        ECPrivateKey privateKey = new SM2PrivateKey(privateKeyS);
+        ECPrivateKey privateKey = (ECPrivateKey) keyFactory.generatePrivate(
+                new SM2PrivateKeySpec(privateKeyS.toByteArray()));
 
         ECPoint publicPoint = ECOperator.SM2.multiply(privateKeyS);
-        ECPublicKey publicKey = new SM2PublicKey(publicPoint);
+        ECPublicKey publicKey = (ECPublicKey) keyFactory.generatePublic(
+                new SM2PublicKeySpec(publicPoint));
 
         Cipher cipher = Cipher.getInstance("SM2", PROVIDER);
 

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2KeyAgreementTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2KeyAgreementTest.java
@@ -52,8 +52,8 @@ public class SM2KeyAgreementTest {
 
     @Test
     public void testKeyAgreementInit() throws Exception {
-        ECPrivateKey priKey = new SM2PrivateKey(toBytes(PRI_KEY));
-        ECPublicKey pubKey = new SM2PublicKey(toBytes(PUB_KEY));
+        ECPrivateKey priKey = TestUtils.privateKey(PRI_KEY);
+        ECPublicKey pubKey = TestUtils.publicKey(PUB_KEY);
 
         SM2KeyAgreementParamSpec paramSpec = new SM2KeyAgreementParamSpec(
                 ID,
@@ -70,7 +70,7 @@ public class SM2KeyAgreementTest {
 
     @Test
     public void testKeyAgreementInitWithoutParams() throws Exception {
-        ECPrivateKey priKey = new SM2PrivateKey(toBytes(PRI_KEY));
+        ECPrivateKey priKey = TestUtils.privateKey(PRI_KEY);
         KeyAgreement keyAgreement = KeyAgreement.getInstance("SM2", PROVIDER);
         Assertions.assertThrows(
                 UnsupportedOperationException.class,
@@ -79,8 +79,8 @@ public class SM2KeyAgreementTest {
 
     @Test
     public void testKeyAgreementDoPhase() throws Exception {
-        ECPrivateKey priKey = new SM2PrivateKey(toBytes(PRI_KEY));
-        ECPublicKey pubKey = new SM2PublicKey(toBytes(PUB_KEY));
+        ECPrivateKey priKey = TestUtils.privateKey(PRI_KEY);
+        ECPublicKey pubKey = TestUtils.publicKey(PUB_KEY);
 
         SM2KeyAgreementParamSpec paramSpec = new SM2KeyAgreementParamSpec(
                 ID,
@@ -153,15 +153,15 @@ public class SM2KeyAgreementTest {
         // Generate shared secret by the local endpoint
         SM2KeyAgreementParamSpec paramSpec = new SM2KeyAgreementParamSpec(
                 toBytes(idHex),
-                new SM2PrivateKey(toBytes(priKeyHex)),
-                new SM2PublicKey(toBytes(pubKeyHex)),
+                TestUtils.privateKey(priKeyHex),
+                TestUtils.publicKey(pubKeyHex),
                 toBytes(peerIdHex),
-                new SM2PublicKey(toBytes(peerPubKeyHex)),
+                TestUtils.publicKey(peerPubKeyHex),
                 true,
                 keySize);
         KeyAgreement keyAgreement = KeyAgreement.getInstance("SM2", PROVIDER);
-        keyAgreement.init(new SM2PrivateKey(toBytes(tmpPriKeyHex)), paramSpec);
-        keyAgreement.doPhase(new SM2PublicKey(toBytes(peerTmpPubKeyHex)), true);
+        keyAgreement.init(TestUtils.privateKey(tmpPriKeyHex), paramSpec);
+        keyAgreement.doPhase(TestUtils.publicKey(peerTmpPubKeyHex), true);
         SecretKey sharedKey = keyAgreement.generateSecret("SM2SharedSecret");
 
         Assertions.assertEquals(keySize, sharedKey.getEncoded().length);
@@ -172,15 +172,15 @@ public class SM2KeyAgreementTest {
         // Generate shared secret by the remote endpoint
         SM2KeyAgreementParamSpec peerParamSpec = new SM2KeyAgreementParamSpec(
                 toBytes(peerIdHex),
-                new SM2PrivateKey(toBytes(peerPriKeyHex)),
-                new SM2PublicKey(toBytes(peerPubKeyHex)),
+                TestUtils.privateKey(peerPriKeyHex),
+                TestUtils.publicKey(peerPubKeyHex),
                 toBytes(idHex),
-                new SM2PublicKey(toBytes(pubKeyHex)),
+                TestUtils.publicKey(pubKeyHex),
                 false,
                 keySize);
         KeyAgreement peerKeyAgreement = KeyAgreement.getInstance("SM2", PROVIDER);
-        peerKeyAgreement.init(new SM2PrivateKey(toBytes(peerTmpPriKeyHex)), peerParamSpec);
-        peerKeyAgreement.doPhase(new SM2PublicKey(toBytes(tmpPubKeyHex)), true);
+        peerKeyAgreement.init(TestUtils.privateKey(peerTmpPriKeyHex), peerParamSpec);
+        peerKeyAgreement.doPhase(TestUtils.publicKey(tmpPubKeyHex), true);
         SecretKey peerSharedKey = peerKeyAgreement.generateSecret("SM2SharedSecret");
 
         Assertions.assertArrayEquals(sharedKey.getEncoded(), peerSharedKey.getEncoded());

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2SignatureTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2SignatureTest.java
@@ -161,12 +161,16 @@ public class SM2SignatureTest {
 
     // orderOffset: the relative offset to the order
     private void testKeyRange(int orderOffset) throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance("SM2");
+
         BigInteger privateKeyS = ECOperator.SM2.getOrder().subtract(
                 BigInteger.valueOf(orderOffset));
-        ECPrivateKey privateKey = new SM2PrivateKey(privateKeyS);
+        ECPrivateKey privateKey = (ECPrivateKey) keyFactory.generatePrivate(
+                new SM2PrivateKeySpec(privateKeyS.toByteArray()));
 
         ECPoint publicPoint = ECOperator.SM2.multiply(privateKeyS);
-        ECPublicKey publicKey = new SM2PublicKey(publicPoint);
+        ECPublicKey publicKey = (ECPublicKey) keyFactory.generatePublic(
+                new SM2PublicKeySpec(publicPoint));
 
         Signature signer = Signature.getInstance("SM2", PROVIDER);
         signer.initSign(privateKey);

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4ParametersTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4ParametersTest.java
@@ -29,12 +29,10 @@ import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import java.nio.charset.StandardCharsets;
 import java.security.AlgorithmParameters;
 import java.security.spec.InvalidParameterSpecException;
 
 import static com.tencent.kona.crypto.CryptoUtils.toBytes;
-import static com.tencent.kona.crypto.CryptoUtils.toHex;
 
 /**
  * The test for the AlgorithmParameters on SM4.
@@ -42,8 +40,8 @@ import static com.tencent.kona.crypto.CryptoUtils.toHex;
 public class SM4ParametersTest {
 
     private static final byte[] KEY = toBytes("0123456789abcdef0123456789abcdef");
-    private static final byte[] IV = "0123456789abcdef".getBytes(StandardCharsets.UTF_8);
-    private static final byte[] GCM_IV = "0123456789ab".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] IV = toBytes("30313233343536373839616263646566");
+    private static final byte[] GCM_IV = toBytes("303132333435363738396162");
     private static final byte[] ENCODED_PARAMS = toBytes("041030313233343536373839616263646566");
     private static final byte[] GCM_ENCODED_PARAMS = toBytes("3011040c303132333435363738396162020110");
 


### PR DESCRIPTION
Generally, the applications, including tests, should not use provider-internal classes, say `SM2PrivateKey` and `SM2PublicKey`.
Instead, they should use only JDK public APIs, say `SM2PrivateKeySpec` and `SM2PublicKeySpec`.

This PR will resolves #452.