### PR TITLE
TKSS-474: Backport JDK-8315974: Make fields final in 'com.sun.crypto.provider' package

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/CipherBlockChaining.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/CipherBlockChaining.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ class CipherBlockChaining extends FeedbackCipher  {
     /*
      * output buffer
      */
-    private byte[] k;
+    private final byte[] k;
 
     // variables for save/restore calls
     private byte[] rSave = null;

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/CipherCore.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/CipherCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,12 +58,12 @@ final class CipherCore {
     /*
      * internal buffer
      */
-    private byte[] buffer = null;
+    private final byte[] buffer;
 
     /*
      * block size of cipher in bytes
      */
-    private int blockSize = 0;
+    private final int blockSize;
 
     /*
      * unit size (number of input bytes that can be processed at a time)

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/CipherFeedback.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/CipherFeedback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ final class CipherFeedback extends FeedbackCipher {
      * number of bytes for each stream unit, defaults to the blocksize
      * of the embedded cipher
      */
-    private int numBytes;
+    private final int numBytes;
 
     // variables for save/restore calls
     private byte[] registerSave = null;

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GHASH.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GHASH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ final class GHASH implements Cloneable, GCM {
 
     // hashtable subkeyHtbl holds 2*9 powers of subkeyH computed using
     // carry-less multiplication
-    private long[] subkeyHtbl;
+    private final long[] subkeyHtbl;
 
     // buffer for storing hash
     private final long[] state;

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GaloisCounterMode.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GaloisCounterMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,8 +71,8 @@ import static com.tencent.kona.crypto.util.Constants.SM4_BLOCK_SIZE;
  * @since 1.8
  */
 abstract class GaloisCounterMode extends CipherSpi {
-    static int DEFAULT_IV_LEN = 12; // in bytes
-    static int DEFAULT_TAG_LEN = 16; // in bytes
+    private static final int DEFAULT_IV_LEN = 12; // in bytes
+    private static final int DEFAULT_TAG_LEN = 16; // in bytes
     // In NIST SP 800-38D, GCM input size is limited to be no longer
     // than (2^36 - 32) bytes. Otherwise, the counter will wrap
     // around and lead to a leak of plaintext.
@@ -93,7 +93,7 @@ abstract class GaloisCounterMode extends CipherSpi {
 
     private boolean initialized = false;
 
-    SymmetricCipher blockCipher;
+    final SymmetricCipher blockCipher;
     // Engine instance for encryption or decryption
     private GCMEngine engine;
     private boolean encryption = true;
@@ -101,7 +101,7 @@ abstract class GaloisCounterMode extends CipherSpi {
     // Default value is 128bits, this is in bytes.
     int tagLenBytes = DEFAULT_TAG_LEN;
     // Key size if the value is passed, in bytes.
-    int keySize;
+    private final int keySize;
     // Prevent reuse of iv or key
     boolean reInit = false;
     byte[] lastKey = EMPTY_BUF;

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/OutputFeedback.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/OutputFeedback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,18 +45,18 @@ final class OutputFeedback extends FeedbackCipher {
     /*
      * output buffer
      */
-    private byte[] k = null;
+    private final byte[] k;
 
     /*
      * register buffer
      */
-    private byte[] register = null;
+    private final byte[] register;
 
     /*
      * number of bytes for each stream unit, defaults to the blocksize
      * of the embedded cipher
      */
-    private int numBytes;
+    private final int numBytes;
 
     // variables for save/restore calls
     private byte[] registerSave = null;

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBEKeyFactory.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBEKeyFactory.java
@@ -45,7 +45,7 @@ import java.util.Locale;
  */
 abstract class PBEKeyFactory extends SecretKeyFactorySpi {
 
-    private String type;
+    private final String type;
     private static final HashSet<String> validTypes;
 
     /**

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBES2Parameters.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBES2Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,18 +93,18 @@ import com.tencent.kona.sun.security.util.*;
  */
 abstract class PBES2Parameters extends AlgorithmParametersSpi {
 
-    private static ObjectIdentifier sm4128CBC_OID =
+    private static final ObjectIdentifier sm4128CBC_OID =
             ObjectIdentifier.of(KnownOIDs.SM4$CBC$NoPadding);
 
-    private static ObjectIdentifier pkcs5PBKDF2_OID =
+    private static final ObjectIdentifier pkcs5PBKDF2_OID =
             ObjectIdentifier.of(KnownOIDs.PBKDF2WithHmacSHA1);
-    private static ObjectIdentifier pkcs5PBES2_OID =
+    private static final ObjectIdentifier pkcs5PBES2_OID =
             ObjectIdentifier.of(KnownOIDs.PBES2);
-    private static ObjectIdentifier aes128CBC_OID =
+    private static final ObjectIdentifier aes128CBC_OID =
             ObjectIdentifier.of(KnownOIDs.AES_128$CBC$NoPadding);
-    private static ObjectIdentifier aes192CBC_OID =
+    private static final ObjectIdentifier aes192CBC_OID =
             ObjectIdentifier.of(KnownOIDs.AES_192$CBC$NoPadding);
-    private static ObjectIdentifier aes256CBC_OID =
+    private static final ObjectIdentifier aes256CBC_OID =
             ObjectIdentifier.of(KnownOIDs.AES_256$CBC$NoPadding);
 
     // the PBES2 algorithm name

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBKDF2KeyImpl.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBKDF2KeyImpl.java
@@ -59,10 +59,10 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
 
     private static final long serialVersionUID = -2234868909660948157L;
 
-    private char[] passwd;
-    private byte[] salt;
-    private int iterCount;
-    private byte[] key;
+    private final char[] passwd;
+    private final byte[] salt;
+    private final int iterCount;
+    private final byte[] key;
 
     // The following fields are not Serializable. See writeReplace method.
     private final transient Mac prf;
@@ -91,9 +91,8 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
         this.passwd = keySpec.getPassword();
         // Convert the password from char[] to byte[]
         byte[] passwdBytes = getPasswordBytes(this.passwd);
-        // remove local copy
-        if (passwd != null) Arrays.fill(passwd, '\0');
 
+        byte[] key = null;
         try {
             this.salt = keySpec.getSalt();
             if (salt == null) {
@@ -113,7 +112,7 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
             }
 //            this.prf = Mac.getInstance(prfAlgo, SunJCE.getInstance());
             this.prf = CryptoInsts.getMac(prfAlgo);
-            this.key = deriveKey(prf, passwdBytes, salt, iterCount, keyLength);
+            key = deriveKey(prf, passwdBytes, salt, iterCount, keyLength);
         } catch (NoSuchAlgorithmException nsae) {
             // not gonna happen; re-throw just in case
             throw new InvalidKeySpecException(nsae);
@@ -124,7 +123,7 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
             }
         }
         // Use the cleaner to zero the key when no longer referenced
-        final byte[] k = this.key;
+        final byte[] k = this.key = key;
         final char[] p = this.passwd;
         sweeper.register(this,
                 () -> {

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PKCS5Padding.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PKCS5Padding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import java.util.Arrays;
  */
 final class PKCS5Padding implements Padding {
 
-    private int blockSize;
+    private final int blockSize;
 
     PKCS5Padding(int blockSize) {
         this.blockSize = blockSize;


### PR DESCRIPTION
This is a backport of [JDK-8315974]: Make fields final in 'com.sun.crypto.provider' package.

This PR will resolves #474.

[JDK-8315974]:
<https://bugs.openjdk.org/browse/JDK-8315974>