### PR TITLE
TKSS-479: SM2KeyPairGenerator must declare only SM2ParameterSpec is supported

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyPairGenerator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyPairGenerator.java
@@ -24,6 +24,8 @@ import com.tencent.kona.crypto.spec.SM2ParameterSpec;
 import com.tencent.kona.crypto.util.Constants;
 import com.tencent.kona.sun.security.ec.point.Point;
 import com.tencent.kona.sun.security.util.ArrayUtil;
+import com.tencent.kona.sun.security.util.KnownOIDs;
+import com.tencent.kona.sun.security.util.NamedCurve;
 
 import java.security.KeyPair;
 import java.security.KeyPairGeneratorSpi;
@@ -31,7 +33,6 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
-import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 import java.util.Arrays;
 
@@ -54,9 +55,11 @@ public class SM2KeyPairGenerator extends KeyPairGeneratorSpi {
 
     @Override
     public void initialize(AlgorithmParameterSpec params, SecureRandom random) {
-        if (!(params instanceof ECParameterSpec)) {
+        if (!(params instanceof SM2ParameterSpec)
+                && !KnownOIDs.curveSM2.value().equals(
+                        ((NamedCurve) params).getObjectId())) {
             throw new IllegalArgumentException(
-                    "params must be ECParameterSpec: " + params);
+                    "params must be SM2ParameterSpec or NamedCurve (curveSM2)");
         }
 
         this.random = random;

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2KeyPairGeneratorTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2KeyPairGeneratorTest.java
@@ -21,6 +21,7 @@ package com.tencent.kona.crypto.provider;
 
 import com.tencent.kona.crypto.TestUtils;
 import com.tencent.kona.crypto.spec.SM2ParameterSpec;
+import com.tencent.kona.sun.security.util.CurveDB;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -49,10 +50,26 @@ public class SM2KeyPairGeneratorTest {
     }
 
     @Test
-    public void testKeyPairGen() throws Exception {
-        KeyPairGenerator keyPairGenerator
+    public void testInitialize() throws Exception {
+        KeyPairGenerator keyPairGen
                 = KeyPairGenerator.getInstance("SM2", PROVIDER);
-        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+        keyPairGen.initialize(256);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> keyPairGen.initialize(128));
+
+        keyPairGen.initialize(SM2ParameterSpec.instance());
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> keyPairGen.initialize(CurveDB.P_256));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> keyPairGen.initialize(null));
+    }
+
+    @Test
+    public void testKeyPairGen() throws Exception {
+        KeyPairGenerator keyPairGen
+                = KeyPairGenerator.getInstance("SM2", PROVIDER);
+        KeyPair keyPair = keyPairGen.generateKeyPair();
         ECPublicKey pubKey = (ECPublicKey) keyPair.getPublic();
         ECPrivateKey priKey = (ECPrivateKey) keyPair.getPrivate();
         Assertions.assertEquals(SM2_PUBKEY_LEN, pubKey.getEncoded().length);
@@ -77,9 +94,9 @@ public class SM2KeyPairGeneratorTest {
 
     @Test
     public void testPubKeyPointOnCurve() throws Exception {
-        KeyPairGenerator keyPairGenerator
+        KeyPairGenerator keyPairGen
                 = KeyPairGenerator.getInstance("SM2", PROVIDER);
-        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        KeyPair keyPair = keyPairGen.generateKeyPair();
         ECPublicKey pubKey = (ECPublicKey) keyPair.getPublic();
         ECPoint pubKeyPoint = pubKey.getW();
         boolean onCurve = checkPointOnCurve(pubKeyPoint);


### PR DESCRIPTION
`SM2KeyPairGenerator` must declare that only `SM2ParameterSpec` or `NamedCurve` (`curveSM2`), but not general `ECParameterSpec`, is supported.

This PR will resolves #479.