### PR TITLE
TKSS-481: EC infinite point is not (0, 0)

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2Signature.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2Signature.java
@@ -55,7 +55,7 @@ import static com.tencent.kona.crypto.spec.SM2ParameterSpec.CURVE;
 import static com.tencent.kona.crypto.spec.SM2ParameterSpec.GENERATOR;
 import static com.tencent.kona.crypto.spec.SM2ParameterSpec.ORDER;
 import static com.tencent.kona.crypto.util.Constants.defaultId;
-import static com.tencent.kona.crypto.util.Constants.INFINITY;
+import static com.tencent.kona.sun.security.ec.SM2Operations.isInfinitePoint;
 import static com.tencent.kona.sun.security.ec.SM2Operations.SM2OPS;
 import static com.tencent.kona.sun.security.ec.SM2Operations.toECPoint;
 import static java.math.BigInteger.ONE;
@@ -330,10 +330,10 @@ public class SM2Signature extends SignatureSpi {
         MutablePoint p = SM2OPS.multiply(GENERATOR, toByteArrayLE(s));
         MutablePoint p2 = SM2OPS.multiply(publicPoint, toByteArrayLE(t));
         SM2OPS.setSum(p, p2.asAffine());
-        ECPoint point = toECPoint(p);
-        if (point.equals(INFINITY)) {
+        if (isInfinitePoint(p)) {
             return false;
         }
+        ECPoint point = toECPoint(p);
 
         // B7
         BigInteger expectedR = e.add(point.getAffineX()).mod(ORDER);

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/util/Constants.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/util/Constants.java
@@ -23,17 +23,11 @@ package com.tencent.kona.crypto.util;
 import com.tencent.kona.crypto.CryptoUtils;
 
 import java.math.BigInteger;
-import java.security.spec.ECPoint;
-
-import static java.math.BigInteger.ONE;
-import static java.math.BigInteger.ZERO;
 
 public class Constants {
 
     public static final BigInteger TWO = BigInteger.valueOf(2);
     public static final BigInteger THREE = BigInteger.valueOf(3);
-
-    public final static ECPoint INFINITY = new ECPoint(ZERO, ONE);
 
     public static final String JDK_VERSION = CryptoUtils.privilegedGetProperty(
             "java.specification.version");

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/SM2Operations.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/SM2Operations.java
@@ -49,4 +49,9 @@ public class SM2Operations extends ECOperations {
                 affPoint.getX().asBigInteger(),
                 affPoint.getY().asBigInteger());
     }
+
+    public static boolean isInfinitePoint(Point point) {
+        AffinePoint affPoint = point.asAffine();
+        return affPoint.getX() == null || affPoint.getY() == null;
+    }
 }


### PR DESCRIPTION
In JDK, the infinite point on ECC is `(null, null)`, not `(0, 0)`.

This PR will resolves #481.