### PR TITLE
TKSS-486: SM2KeyPairGenerator::initialize should not raise NullPointerException

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyPairGenerator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyPairGenerator.java
@@ -55,7 +55,7 @@ public class SM2KeyPairGenerator extends KeyPairGeneratorSpi {
 
     @Override
     public void initialize(AlgorithmParameterSpec params, SecureRandom random) {
-        if (!(params instanceof SM2ParameterSpec)
+        if (params == null || !(params instanceof SM2ParameterSpec)
                 && !KnownOIDs.curveSM2.value().equals(
                         ((NamedCurve) params).getObjectId())) {
             throw new IllegalArgumentException(

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2KeyPairGeneratorTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2KeyPairGeneratorTest.java
@@ -61,7 +61,7 @@ public class SM2KeyPairGeneratorTest {
         keyPairGen.initialize(SM2ParameterSpec.instance());
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> keyPairGen.initialize(CurveDB.P_256));
-        Assertions.assertThrows(NullPointerException.class,
+        Assertions.assertThrows(IllegalArgumentException.class,
                 () -> keyPairGen.initialize(null));
     }
 


### PR DESCRIPTION
`SM2KeyPairGenerator::initialize` should raise `IllegalArgumentException` even if the `params` is null.

This PR will resolves #486.