### PR TITLE
TKSS-494: ECOperator should use ECPoint.POINT_INFINITY as infinite point

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECOperator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECOperator.java
@@ -28,16 +28,18 @@ import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 import java.security.spec.EllipticCurve;
 
-import static java.math.BigInteger.*;
+import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.ZERO;
+import static java.security.spec.ECPoint.POINT_INFINITY;
 
 import static com.tencent.kona.crypto.CryptoUtils.toBigInt;
 
-/**
+/*
  * The operator for EC point arithmetic operations.
  * The main algorithms refer to the wikipedia page:
  * https://en.wikipedia.org/wiki/Elliptic_curve_point_multiplication
  *
- * CAUTION: Just for demonstration purposes, not use it in real products.
+ * CAUTION: Just for demonstration purposes, don't use it in real products.
  */
 @Deprecated
 public class ECOperator {
@@ -65,8 +67,6 @@ public class ECOperator {
                         toBigInt("483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8")),
             toBigInt("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"),
             1);
-
-    public final static ECPoint INFINITY = new ECPoint(ZERO, ONE);
 
     private final static BigInteger TWO = new BigInteger("2");
     private final static BigInteger THREE = new BigInteger("3");
@@ -162,7 +162,7 @@ public class ECOperator {
     public ECPoint add(ECPoint p1, ECPoint p2) {
         if (isInfinity(p1)) {
             return isInfinity(p2)
-                    ? INFINITY
+                    ? POINT_INFINITY
                     : new ECPoint(p2.getAffineX(), p2.getAffineY());
         }
 
@@ -176,10 +176,10 @@ public class ECOperator {
                 // Here, p1 == p2
                 lambda = lambda(p1, p2);
                 if (lambda == null) {
-                    return INFINITY;
+                    return POINT_INFINITY;
                 }
             } else {
-                return INFINITY;
+                return POINT_INFINITY;
             }
         } else {
             BigInteger nom = p2.getAffineY().subtract(p1.getAffineY());
@@ -205,12 +205,12 @@ public class ECOperator {
 
         BigInteger denom = p.getAffineY().multiply(TWO).mod(prime);
         if (ZERO.equals(denom)) {
-            return INFINITY;
+            return POINT_INFINITY;
         }
 
         BigInteger lambda = lambda(p, p);
         if (lambda == null) {
-            return INFINITY;
+            return POINT_INFINITY;
         }
 
         return calcPoint(p, p, lambda);
@@ -261,7 +261,7 @@ public class ECOperator {
 
     // Montgomery ladder algorithm
     private ECPoint montgomeryLadder(ECPoint p, BigInteger k) {
-        ECPoint p0 = INFINITY;
+        ECPoint p0 = POINT_INFINITY;
         ECPoint p1 = p;
         int idx = k.bitLength();
 
@@ -281,7 +281,7 @@ public class ECOperator {
     // Double-and-Add algorithm
     private ECPoint doubleAndAdd(ECPoint p, BigInteger k) {
         if (isInfinity(p) || k.equals(ZERO)) {
-            return INFINITY;
+            return POINT_INFINITY;
         }
 
         if (k.equals(ONE)) {
@@ -327,12 +327,12 @@ public class ECOperator {
     }
 
     private static boolean isInfinity(ECPoint p) {
-        return p.equals(INFINITY);
+        return p.equals(POINT_INFINITY);
     }
 
     private static ECPoint negate(ECPoint p) {
         return isInfinity(p)
-                ? INFINITY
+                ? POINT_INFINITY
                 : new ECPoint(p.getAffineX(), p.getAffineY().negate());
     }
 }

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2CipherTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2CipherTest.java
@@ -183,7 +183,7 @@ public class SM2CipherTest {
         testKeyRange(1);
 
         // privateKey = order
-        Assertions.assertThrows(InvalidKeyException.class,
+        Assertions.assertThrows(IllegalArgumentException.class,
                 () -> testKeyRange(0));
 
         // privateKey = order + 1

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2SignatureTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2SignatureTest.java
@@ -158,7 +158,7 @@ public class SM2SignatureTest {
         Assertions.assertThrows(InvalidKeyException.class, () -> testKeyRange(1));
 
         // privateKey = order
-        Assertions.assertThrows(InvalidKeyException.class, () -> testKeyRange(0));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> testKeyRange(0));
 
         // privateKey = order + 1
         Assertions.assertThrows(InvalidKeyException.class, () -> testKeyRange(-1));

--- a/kona-crypto/src/test/java/com/tencent/kona/sun/security/ec/ECOperatorTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/sun/security/ec/ECOperatorTest.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.Test;
 import java.math.BigInteger;
 import java.security.spec.ECPoint;
 
+import static java.security.spec.ECPoint.POINT_INFINITY;
+
 /**
  * The test for EC operator.
  */
@@ -47,7 +49,7 @@ public class ECOperatorTest {
     @Test
     public void testIsOnCurve() {
         // The infinity point always be on the curve.
-        Assertions.assertTrue(DUMMY.isOnCurve(ECOperator.INFINITY));
+        Assertions.assertTrue(DUMMY.isOnCurve(POINT_INFINITY));
 
         // The generator point must be on the curve.
         Assertions.assertTrue(DUMMY.isOnCurve(DUMMY.getGenerator()));
@@ -63,7 +65,7 @@ public class ECOperatorTest {
 
     @Test
     public void testCheckOrder() {
-        Assertions.assertTrue(DUMMY.checkOrder(ECOperator.INFINITY));
+        Assertions.assertTrue(DUMMY.checkOrder(POINT_INFINITY));
         Assertions.assertTrue(DUMMY.checkOrder(DUMMY_GENERATOR));
         Assertions.assertTrue(DUMMY.checkOrder(new ECPoint(
                 BigInteger.valueOf(11), BigInteger.valueOf(1))));
@@ -83,11 +85,11 @@ public class ECOperatorTest {
         ECPoint point = new ECPoint(
                 BigInteger.valueOf(2), BigInteger.valueOf(7));
 
-        ECPoint sum = DUMMY.add(point, ECOperator.INFINITY);
+        ECPoint sum = DUMMY.add(point, POINT_INFINITY);
         Assertions.assertEquals(point.getAffineX(), sum.getAffineX());
         Assertions.assertEquals(point.getAffineY(), sum.getAffineY());
 
-        sum = DUMMY.add(ECOperator.INFINITY, point);
+        sum = DUMMY.add(POINT_INFINITY, point);
         Assertions.assertEquals(point.getAffineX(), sum.getAffineX());
         Assertions.assertEquals(point.getAffineY(), sum.getAffineY());
     }
@@ -106,11 +108,11 @@ public class ECOperatorTest {
         ECPoint point = new ECPoint(
                 BigInteger.valueOf(2), BigInteger.valueOf(10));
 
-        ECPoint diff = DUMMY.subtract(point, ECOperator.INFINITY);
+        ECPoint diff = DUMMY.subtract(point, POINT_INFINITY);
         Assertions.assertEquals(point.getAffineX(), diff.getAffineX());
         Assertions.assertEquals(point.getAffineY(), diff.getAffineY());
 
-        diff = DUMMY.subtract(ECOperator.INFINITY, point);
+        diff = DUMMY.subtract(POINT_INFINITY, point);
         Assertions.assertEquals(point.getAffineX(), diff.getAffineX());
         Assertions.assertEquals(point.getAffineY().negate(), diff.getAffineY());
     }
@@ -122,16 +124,16 @@ public class ECOperatorTest {
         Assertions.assertEquals(BigInteger.valueOf(8), product.getAffineY());
 
         product = DUMMY.multiply(DUMMY_GENERATOR, 0);
-        Assertions.assertEquals(ECOperator.INFINITY, product);
+        Assertions.assertEquals(POINT_INFINITY, product);
 
         // 18 is the order of this finite field.
         product = DUMMY.multiply(DUMMY_GENERATOR, 18);
-        Assertions.assertEquals(ECOperator.INFINITY, product);
+        Assertions.assertEquals(POINT_INFINITY, product);
     }
 
     @Test
     public void testMultiplyInfinity() {
-        ECPoint product = DUMMY.multiply(ECOperator.INFINITY, 6);
-        Assertions.assertEquals(ECOperator.INFINITY, product);
+        ECPoint product = DUMMY.multiply(POINT_INFINITY, 6);
+        Assertions.assertEquals(POINT_INFINITY, product);
     }
 }


### PR DESCRIPTION
ECOperator should use `ECPoint.POINT_INFINITY` rather than self-defined `ECPoint(0, 0)` as infinite point.

This PR will resolves #494.