### PR TITLE
TKSS-499: SM2Signature should not set/get parameters via names

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoUtils.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoUtils.java
@@ -234,16 +234,15 @@ public final class CryptoUtils {
         return new ECPoint(x, y);
     }
 
-    public static byte[] pubKey(ECPoint pubKeyPoint) {
-        byte[] x = bigIntToBytes32(pubKeyPoint.getAffineX());
-        byte[] y = bigIntToBytes32(pubKeyPoint.getAffineY());
+    public static byte[] pubKey(ECPoint pubPoint) {
+        byte[] x = bigIntToBytes32(pubPoint.getAffineX());
+        byte[] y = bigIntToBytes32(pubPoint.getAffineY());
 
-        byte[] pubKey = new byte[Constants.SM2_PUBKEY_LEN];
-        byte[] flag = toBytes("04");
-        System.arraycopy(flag, 0, pubKey, 0, flag.length);
-        System.arraycopy(x, 0, pubKey, flag.length, x.length);
-        System.arraycopy(y, 0, pubKey, flag.length + x.length, y.length);
-        return pubKey;
+        byte[] encoded = new byte[65];
+        encoded[0] = 0x04;
+        System.arraycopy(x, 0, encoded, 1, 32);
+        System.arraycopy(y, 0, encoded, 33, 32);
+        return encoded;
     }
 
     public static byte[] priKey(BigInteger priKeyValue) {

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyFactory.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyFactory.java
@@ -46,7 +46,7 @@ public class SM2KeyFactory extends KeyFactorySpi {
 
         SM2PublicKeySpec spec = (SM2PublicKeySpec) keySpec;
         ECPoint pubPoint = spec.getW();
-        if (pubPoint == null || pubPoint.getAffineY() == null
+        if (pubPoint == null || pubPoint.getAffineX() == null
                 || pubPoint.getAffineY() == null) {
             throw new InvalidKeySpecException("No public key");
         }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2Signature.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2Signature.java
@@ -46,15 +46,12 @@ import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.ECPoint;
-import java.util.Arrays;
-import java.util.Objects;
 
 import static com.tencent.kona.crypto.CryptoUtils.bigIntToBytes32;
 import static com.tencent.kona.crypto.CryptoUtils.toByteArrayLE;
 import static com.tencent.kona.crypto.spec.SM2ParameterSpec.CURVE;
 import static com.tencent.kona.crypto.spec.SM2ParameterSpec.GENERATOR;
 import static com.tencent.kona.crypto.spec.SM2ParameterSpec.ORDER;
-import static com.tencent.kona.crypto.util.Constants.defaultId;
 import static com.tencent.kona.sun.security.ec.SM2Operations.isInfinitePoint;
 import static com.tencent.kona.sun.security.ec.SM2Operations.SM2OPS;
 import static com.tencent.kona.sun.security.ec.SM2Operations.toECPoint;
@@ -63,8 +60,10 @@ import static java.math.BigInteger.ZERO;
 
 public class SM2Signature extends SignatureSpi {
 
-    private static final String PARAM_ID = "id";
-    private static final String PARAM_PUBLIC_KEY = "publicKey";
+    // The default ID 1234567812345678
+    private static final byte[] DEFAULT_ID = new byte[] {
+            49, 50, 51, 52, 53, 54, 55, 56,
+            49, 50, 51, 52, 53, 54, 55, 56};
 
     private SM2PrivateKey privateKey;
     private SM2PublicKey publicKey;
@@ -144,50 +143,15 @@ public class SM2Signature extends SignatureSpi {
     @Override
     protected void engineSetParameter(String param, Object value)
             throws InvalidParameterException {
-        Objects.requireNonNull(param);
-        Objects.requireNonNull(value);
-
-        if (isParamId(param)) {
-            id = ((byte[]) value).clone();
-        } else if (isParamPublicKey(param)) {
-            SM2PublicKey key = new SM2PublicKey((ECPublicKey) value);
-            byte[] encodedKey = key.getEncoded();
-
-            if (encodedKey.length == 0) {
-                throw new InvalidParameterException(
-                        "Invalid public key of parameter");
-            }
-
-            if (publicKey != null) {
-                if (!Arrays.equals(publicKey.getEncoded(), encodedKey)) {
-                    throw new InvalidParameterException(
-                            "Public key of parameter is not match");
-                }
-            }
-        } else {
-            throw new InvalidParameterException("Unsupported parameter: " + param);
-        }
+        throw new UnsupportedOperationException(
+                "Use setParameter(AlgorithmParameterSpec params) instead");
     }
 
     @Override
     protected Object engineGetParameter(String param)
             throws InvalidParameterException {
-        if (isParamId(param)) {
-            return id == null ? defaultId() : id.clone();
-        } else if (isParamPublicKey(param)) {
-            return publicKey;
-        } else {
-            throw new InvalidParameterException(
-                    "Only support id and publicKey: " + param);
-        }
-    }
-
-    private static boolean isParamId(String paramName) {
-        return PARAM_ID.equalsIgnoreCase(paramName);
-    }
-
-    private static boolean isParamPublicKey(String paramName) {
-        return PARAM_PUBLIC_KEY.equalsIgnoreCase(paramName);
+        throw new UnsupportedOperationException(
+                "getParameter(String param) not supported");
     }
 
     private void resetDigest() {
@@ -370,7 +334,7 @@ public class SM2Signature extends SignatureSpi {
     private byte[] z() {
         MessageDigest md = new SM3MessageDigest();
 
-        byte[] userId = id == null ? defaultId() : id;
+        byte[] userId = id == null ? DEFAULT_ID : id;
         int userIdLen = userId.length << 3;
         md.update((byte)(userIdLen >>> 8));
         md.update((byte)userIdLen);

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/util/Constants.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/util/Constants.java
@@ -57,8 +57,10 @@ public class Constants {
     public static final int SM4_GCM_IV_LEN = 12;
     public static final int SM4_GCM_TAG_LEN = 16;
 
-    // The default ID: 1234567812345678
-    private static final byte[] DEFAULT_ID = "1234567812345678".getBytes();
+    // The default ID 1234567812345678
+    private static final byte[] DEFAULT_ID = new byte[] {
+            49, 50, 51, 52, 53, 54, 55, 56,
+            49, 50, 51, 52, 53, 54, 55, 56};
 
     public static byte[] defaultId() {
         return DEFAULT_ID.clone();


### PR DESCRIPTION
`SM2Signature` should support only `engineSetParameter(AlgorithmParameterSpec params)`, and remove `engineSetParameter(String param, Object value)` and `engineGetParameter(String param)`.

This PR will resolves #499.