### PR TITLE
TKSS-510: SM2 private key would not be order - 1

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoUtils.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoUtils.java
@@ -77,6 +77,13 @@ public final class CryptoUtils {
         return HEX.parseHex(hex);
     }
 
+    // little-endian byte array
+    public static byte[] toBytesLE(String hex) {
+        byte[] byteArr = toBytes(hex);
+        ArrayUtil.reverse(byteArr);
+        return byteArr;
+    }
+
     public static BigInteger toBigInt(byte[] value, int offset, int length) {
         byte[] valueCopy = copy(value, offset, length);
         return new BigInteger(1, valueCopy);


### PR DESCRIPTION
SM2 private key range would be better in `[1, order - 2]` instead of `[1, order - 1]`, though the possibility of hitting `order - 1` is quite low.

This PR will resolves #510.