### PR TITLE
TKSS-512: Backport JDK-8316964: Security tools should not call System.exit

### DIFF
--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4KeyGeneratorTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4KeyGeneratorTest.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.tencent.kona.crypto.provider;
 
 import com.tencent.kona.crypto.TestUtils;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/tools/keytool/Main.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/tools/keytool/Main.java
@@ -409,26 +409,37 @@ public final class Main {
         collator.setStrength(Collator.PRIMARY);
     }
 
-    private Main() { }
-
     public static void main(String[] args) throws Exception {
         Main kt = new Main();
-        kt.run(args, System.out);
+        int exitCode = kt.run(args, System.out);
+        if (exitCode != 0) {
+            System.exit(exitCode);
+        }
     }
 
-    private void run(String[] args, PrintStream out) throws Exception {
+    private static class ExitException extends RuntimeException {
+        static final long serialVersionUID = 0L;
+        private final int errorCode;
+        public ExitException(int errorCode) {
+            this.errorCode = errorCode;
+        }
+    }
+
+    public int run(String[] args, PrintStream out) throws Exception {
         try {
-            args = parseArgs(args);
+            parseArgs(args);
             if (command != null) {
                 doCommands(out);
             }
+        } catch (ExitException ee) {
+            return ee.errorCode;
         } catch (Exception e) {
             System.out.println(rb.getString("keytool.error.") + e);
             if (verbose) {
                 e.printStackTrace(System.out);
             }
             if (!debug) {
-                System.exit(1);
+                return 1;
             } else {
                 throw e;
             }
@@ -440,11 +451,11 @@ public final class Main {
                     pass = null;
                 }
             }
-
             if (ksStream != null) {
                 ksStream.close();
             }
         }
+        return 0;
     }
 
     /**
@@ -5285,7 +5296,7 @@ public final class Main {
         if (debug) {
             throw new RuntimeException("NO BIG ERROR, SORRY");
         } else {
-            System.exit(1);
+            throw new ExitException(1);
         }
     }
 


### PR DESCRIPTION
This is a backport of [JDK-8316964]: Security tools should not call System.exit.

This PR will resolves #512.

[JDK-8316964]:
<https://bugs.openjdk.org/browse/JDK-8316964>