### PR TITLE
TKSS-515: kona-crypto should use JCAUtil::getSecureRandom

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyPairGenerator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyPairGenerator.java
@@ -23,6 +23,7 @@ package com.tencent.kona.crypto.provider;
 import com.tencent.kona.crypto.spec.SM2ParameterSpec;
 import com.tencent.kona.crypto.util.Constants;
 import com.tencent.kona.sun.security.ec.point.Point;
+import com.tencent.kona.sun.security.jca.JCAUtil;
 import com.tencent.kona.sun.security.util.ArrayUtil;
 import com.tencent.kona.sun.security.util.KnownOIDs;
 import com.tencent.kona.sun.security.util.NamedCurve;
@@ -68,7 +69,7 @@ public final class SM2KeyPairGenerator extends KeyPairGeneratorSpi {
     @Override
     public KeyPair generateKeyPair() {
         if (random == null) {
-            random = new SecureRandom();
+            random = JCAUtil.getSecureRandom();
         }
 
         byte[] privArr = SM2OPS.generatePrivateScalar(random);

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM3HMacKeyGenerator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM3HMacKeyGenerator.java
@@ -20,6 +20,8 @@
 
 package com.tencent.kona.crypto.provider;
 
+import com.tencent.kona.sun.security.jca.JCAUtil;
+
 import javax.crypto.KeyGeneratorSpi;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -60,7 +62,7 @@ public final class SM3HMacKeyGenerator extends KeyGeneratorSpi {
     @Override
     protected SecretKey engineGenerateKey() {
         if (random == null) {
-            random = new SecureRandom();
+            random = JCAUtil.getSecureRandom();
         }
 
         byte[] key = new byte[keySize];

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4KeyGenerator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4KeyGenerator.java
@@ -20,6 +20,8 @@
 
 package com.tencent.kona.crypto.provider;
 
+import com.tencent.kona.sun.security.jca.JCAUtil;
+
 import javax.crypto.KeyGeneratorSpi;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -58,7 +60,7 @@ public final class SM4KeyGenerator extends KeyGeneratorSpi {
     @Override
     protected SecretKey engineGenerateKey() {
         if (random == null) {
-            random = new SecureRandom();
+            random = JCAUtil.getSecureRandom();
         }
 
         byte[] keyBytes = new byte[SM4_KEY_SIZE];

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4ParameterGenerator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4ParameterGenerator.java
@@ -22,6 +22,7 @@ package com.tencent.kona.crypto.provider;
 
 import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.crypto.util.Constants;
+import com.tencent.kona.sun.security.jca.JCAUtil;
 
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
@@ -61,7 +62,7 @@ public final class SM4ParameterGenerator extends AlgorithmParameterGeneratorSpi 
     @Override
     protected AlgorithmParameters engineGenerateParameters() {
         if (random == null) {
-            random = new SecureRandom();
+            random = JCAUtil.getSecureRandom();
         }
 
         return paramSpec.getParamSpecClass().equals(IvParameterSpec.class)


### PR DESCRIPTION
`kona-crypto` would use the shared `SecureRandom` via `JCAUtil::getSecureRandom` instead of `new SecureRandom()`.

This PR will resolves #515.