### PR TITLE
TKSS-530: SM2KeyAgreementParamSpec should check ID length

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoUtils.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoUtils.java
@@ -256,5 +256,12 @@ public final class CryptoUtils {
         return bigIntToBytes32(priKeyValue);
     }
 
+    public static void checkId(byte[] id) {
+        if (id.length >= 8192) {
+            throw new IllegalArgumentException(
+                    "The length of ID must be less than 8192-bytes");
+        }
+    }
+
     private CryptoUtils() { }
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2KeyAgreementParamSpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2KeyAgreementParamSpec.java
@@ -20,6 +20,8 @@
 
 package com.tencent.kona.crypto.spec;
 
+import com.tencent.kona.crypto.CryptoUtils;
+
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
@@ -70,6 +72,9 @@ public final class SM2KeyAgreementParamSpec implements AlgorithmParameterSpec {
         Objects.requireNonNull(publicKey, "publicKey must not null");
         Objects.requireNonNull(peerId, "peerId must not null");
         Objects.requireNonNull(peerPublicKey, "peerPublicKey must not null");
+
+        CryptoUtils.checkId(id);
+        CryptoUtils.checkId(peerId);
 
         this.id = id.clone();
         this.privateKey = privateKey;

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2SignatureParameterSpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2SignatureParameterSpec.java
@@ -20,6 +20,8 @@
 
 package com.tencent.kona.crypto.spec;
 
+import com.tencent.kona.crypto.CryptoUtils;
+
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Objects;
@@ -50,10 +52,7 @@ public final class SM2SignatureParameterSpec implements AlgorithmParameterSpec {
         Objects.requireNonNull(id);
         Objects.requireNonNull(publicKey);
 
-        if (id.length >= 8192) {
-            throw new IllegalArgumentException(
-                    "The length of ID must be less than 8192-bytes");
-        }
+        CryptoUtils.checkId(id);
 
         this.id = id.clone();
         this.publicKey = publicKey;

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2KeyAgreementTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2KeyAgreementTest.java
@@ -53,6 +53,46 @@ public class SM2KeyAgreementTest {
     }
 
     @Test
+    public void testParameterSpec() throws Exception {
+        KeyPairGenerator keyPairGenerator
+                = KeyPairGenerator.getInstance("SM2", PROVIDER);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+        SM2KeyAgreementParamSpec paramSpec = new SM2KeyAgreementParamSpec(
+                ID,
+                (ECPrivateKey) keyPair.getPrivate(),
+                (ECPublicKey) keyPair.getPublic(),
+                ID,
+                (ECPublicKey) keyPair.getPublic(),
+                true, 32);
+        Assertions.assertArrayEquals(ID, paramSpec.id());
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                ()-> new SM2KeyAgreementParamSpec(
+                        TestUtils.dataKB(8),
+                        (ECPrivateKey) keyPair.getPrivate(),
+                        (ECPublicKey) keyPair.getPublic(),
+                        TestUtils.dataKB(1),
+                        (ECPublicKey) keyPair.getPublic(),
+                        true, 32));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                ()-> new SM2KeyAgreementParamSpec(
+                        TestUtils.dataKB(1),
+                        (ECPrivateKey) keyPair.getPrivate(),
+                        (ECPublicKey) keyPair.getPublic(),
+                        TestUtils.dataKB(8),
+                        (ECPublicKey) keyPair.getPublic(),
+                        true, 32));
+        Assertions.assertThrows(NullPointerException.class,
+                ()-> new SM2KeyAgreementParamSpec(
+                        TestUtils.dataKB(1),
+                        (ECPrivateKey) keyPair.getPrivate(),
+                        (ECPublicKey) keyPair.getPublic(),
+                        TestUtils.dataKB(1), null,
+                        true, 32));
+    }
+
+    @Test
     public void testInit() throws Exception {
         ECPrivateKey priKey = TestUtils.privateKey(PRI_KEY);
         ECPublicKey pubKey = TestUtils.publicKey(PUB_KEY);


### PR DESCRIPTION
`SM2KeyAgreementParamSpec` should check if the IDs are longer than 8192-bytes.

This PR will resolves #530.