### PR TITLE
TKSS-539: ECOperatorPerfTest needs to use ECOperations

### DIFF
--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/ECOperatorPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/ECOperatorPerfTest.java
@@ -21,7 +21,7 @@ package com.tencent.kona.crypto.perf;
 
 import com.tencent.kona.crypto.CryptoUtils;
 import com.tencent.kona.crypto.spec.SM2ParameterSpec;
-import com.tencent.kona.sun.security.ec.SM2Operations;
+import com.tencent.kona.sun.security.ec.ECOperations;
 import org.bouncycastle.math.ec.FixedPointCombMultiplier;
 import org.bouncycastle.math.ec.custom.gm.SM2P256V1Curve;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -77,7 +77,7 @@ public class ECOperatorPerfTest {
 
     @Benchmark
     public Object multiple() {
-        return SM2Operations.SM2OPS.multiply(GENERATOR, PRIV_KEY);
+        return ECOperations.SM2OPS.multiply(GENERATOR, PRIV_KEY);
     }
 
     @Benchmark


### PR DESCRIPTION
`ECOperatorPerfTest ` needs to use `ECOperations` rather than `SM2Operations`.

This PR will resolves #539.