### PR TITLE
TKSS-534: Backport JDK-8311596: Add separate system properties for TLS server and client for maximum chain length

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateMessage.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,12 +136,16 @@ final class CertificateMessage {
                     byte[] encodedCert = Record.getBytes24(m);
                     listLen -= (3 + encodedCert.length);
                     encodedCerts.add(encodedCert);
-                    if (encodedCerts.size() > SSLConfiguration.maxCertificateChainLength) {
+                    int maxAllowedChainLength = handshakeContext.sslConfig.isClientMode ?
+                            SSLConfiguration.maxInboundServerCertChainLen :
+                            SSLConfiguration.maxInboundClientCertChainLen;
+
+                    if (encodedCerts.size() > maxAllowedChainLength) {
                         throw new SSLProtocolException(
                                 "The certificate chain length ("
                                 + encodedCerts.size()
                                 + ") exceeds the maximum allowed length ("
-                                + SSLConfiguration.maxCertificateChainLength
+                                + maxAllowedChainLength
                                 + ")");
                     }
 
@@ -867,12 +871,16 @@ final class CertificateMessage {
                 SSLExtensions extensions =
                         new SSLExtensions(this, m, enabledExtensions);
                 certList.add(new CertificateEntry(encodedCert, extensions));
-                if (certList.size() > SSLConfiguration.maxCertificateChainLength) {
+                int maxAllowedChainLength = handshakeContext.sslConfig.isClientMode ?
+                        SSLConfiguration.maxInboundServerCertChainLen :
+                        SSLConfiguration.maxInboundClientCertChainLen;
+
+                if (certList.size() > maxAllowedChainLength) {
                     throw new SSLProtocolException(
                             "The certificate chain length ("
                             + certList.size()
                             + ") exceeds the maximum allowed length ("
-                            + SSLConfiguration.maxCertificateChainLength
+                            + maxAllowedChainLength
                             + ")");
                 }
             }

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPCertificate.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPCertificate.java
@@ -129,13 +129,17 @@ final class TLCPCertificate {
                     byte[] encodedCert = Record.getBytes24(m);
                     listLen -= (3 + encodedCert.length);
                     encodedCerts.add(encodedCert);
-                    if (encodedCerts.size() > SSLConfiguration.maxCertificateChainLength) {
+                    int maxAllowedChainLength = handshakeContext.sslConfig.isClientMode ?
+                            SSLConfiguration.maxInboundServerCertChainLen :
+                            SSLConfiguration.maxInboundClientCertChainLen;
+
+                    if (encodedCerts.size() > maxAllowedChainLength) {
                         throw new SSLProtocolException(
                                 "The certificate chain length ("
-                                        + encodedCerts.size()
-                                        + ") exceeds the maximum allowed length ("
-                                        + SSLConfiguration.maxCertificateChainLength
-                                        + ")");
+                                + encodedCerts.size()
+                                + ") exceeds the maximum allowed length ("
+                                + maxAllowedChainLength
+                                + ")");
                     }
 
                 }


### PR DESCRIPTION
This is a backport of [JDK-8311596]: Add separate system properties for TLS server and client for maximum chain length.

This PR will resolves #534.

[JDK-8311596]:
<https://bugs.openjdk.org/browse/JDK-8311596>