### PR TITLE
TKSS-535: Backport JDK-8311546: Certificate name constraints improperly validated with leading period

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DNSName.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/DNSName.java
@@ -203,17 +203,11 @@ public class DNSName implements GeneralNameInterface {
      * </ul>.  These results are used in checking NameConstraints during
      * certification path verification.
      * <p>
-     * RFC5280: DNS name restrictions are expressed as host.example.com.
+     * RFC5280: For DNS names, restrictions MUST use the DNSName syntax in Section 4.2.1.6.
      * Any DNS name that can be constructed by simply adding zero or more
      * labels to the left-hand side of the name satisfies the name constraint.
      * For example, www.host.example.com would satisfy the constraint but
      * host1.example.com would not.
-     * <p>
-     * RFC 5280:  DNSName restrictions are expressed as foo.bar.com.
-     * Any DNSName that
-     * can be constructed by simply adding to the left-hand side of the name
-     * satisfies the name constraint. For example, www.foo.bar.com would
-     * satisfy the constraint but foo1.bar.com would not.
      * <p>
      * RFC1034: By convention, domain names can be stored with arbitrary case, but
      * domain name comparisons for all present domain functions are done in a
@@ -240,13 +234,13 @@ public class DNSName implements GeneralNameInterface {
                 constraintType = NAME_MATCH;
             else if (thisName.endsWith(inName)) {
                 int inNdx = thisName.lastIndexOf(inName);
-                if (thisName.charAt(inNdx-1) == '.' )
+                if (thisName.charAt(inNdx-1) == '.' ^ inName.charAt(0) == '.')
                     constraintType = NAME_WIDENS;
                 else
                     constraintType = NAME_SAME_TYPE;
             } else if (inName.endsWith(thisName)) {
                 int ndx = inName.lastIndexOf(thisName);
-                if (inName.charAt(ndx-1) == '.' )
+                if (inName.charAt(ndx-1) == '.' ^ thisName.charAt(0) == '.')
                     constraintType = NAME_NARROWS;
                 else
                     constraintType = NAME_SAME_TYPE;


### PR DESCRIPTION
This is a backport of [JDK-8311546]: Certificate name constraints improperly validated with leading period.

This PR will resolves #535.

[JDK-8311546]:
<https://bugs.openjdk.org/browse/JDK-8311546>