### PR TITLE
TKSS-544: Some parameter spec public methods miss Javadoc

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2KeyAgreementParamSpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2KeyAgreementParamSpec.java
@@ -118,30 +118,66 @@ public final class SM2KeyAgreementParamSpec implements AlgorithmParameterSpec {
              DEFAULT_ID, peerPublicKey, isInitiator, sharedKeyLength);
     }
 
+    /**
+     * Returns the ID.
+     *
+     * @return the ID.
+     */
     public byte[] id() {
         return id.clone();
     }
 
+    /**
+     * Returns the private key.
+     *
+     * @return the private key.
+     */
     public ECPrivateKey privateKey() {
         return privateKey;
     }
 
+    /**
+     * Returns the public key.
+     *
+     * @return the public key.
+     */
     public ECPublicKey publicKey() {
         return publicKey;
     }
 
+    /**
+     * Returns the peer's ID.
+     *
+     * @return the peer's ID.
+     */
     public byte[] peerId() {
         return peerId.clone();
     }
 
+    /**
+     * Returns the peer's public key.
+     *
+     * @return the peer's public key.
+     */
     public ECPublicKey peerPublicKey() {
         return peerPublicKey;
     }
 
+    /**
+     * Indicates if it is initiator.
+     *
+     * @return true indicates it initiates the key exchanging;
+     *         false indicates peer initiates the key exchange.
+     */
     public boolean isInitiator() {
         return isInitiator;
     }
 
+    /**
+     * Returns the length of the shared key.
+     *
+     * @return the length of the shared key.
+     */
     public int sharedKeyLength() {
         return sharedKeyLength;
     }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2ParameterSpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2ParameterSpec.java
@@ -41,10 +41,29 @@ public final class SM2ParameterSpec extends ECParameterSpec {
         return InstanceHolder.INSTANCE;
     }
 
+    /**
+     * The SM2 elliptic curve.
+     */
     public static final EllipticCurve CURVE = curve();
+
+    /**
+     * The generator or base point.
+     */
     public static final ECPoint GENERATOR = generator();
+
+    /**
+     * The order of the generator.
+     */
     public static final BigInteger ORDER = order();
+
+    /**
+     * The cofactor.
+     */
     public static final BigInteger COFACTOR = cofactor();
+
+    /**
+     * The OID of the SM2 elliptic curve.
+     */
     public static final String OID = "1.2.156.10197.1.301";
 
     // 0x06082A811CCF5501822D
@@ -77,14 +96,6 @@ public final class SM2ParameterSpec extends ECParameterSpec {
 
     private static BigInteger cofactor() {
         return BigInteger.ONE;
-    }
-
-    public String oid() {
-        return OID;
-    }
-
-    public byte[] encoded() {
-        return ENCODED_OID.clone();
     }
 
     @Override

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2SignatureParameterSpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2SignatureParameterSpec.java
@@ -70,10 +70,20 @@ public final class SM2SignatureParameterSpec implements AlgorithmParameterSpec {
         this(DEFAULT_ID, publicKey);
     }
 
+    /**
+     * Returns the ID.
+     *
+     * @return the ID.
+     */
     public byte[] getId() {
         return id.clone();
     }
 
+    /**
+     * Returns the public key.
+     *
+     * @return the public key.
+     */
     public ECPublicKey getPublicKey() {
         return publicKey;
     }


### PR DESCRIPTION
Although most of public methods in parameter spec classes have Javadoc, some getter methods miss it.

This PR will resolves #544.