### PR TITLE
TKSS-548: KonaCrypto should not support RSA and RSASSA-PSS

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoInsts.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoInsts.java
@@ -25,7 +25,6 @@ import javax.crypto.KeyAgreement;
 import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.NoSuchPaddingException;
-import java.security.AlgorithmParameterGenerator;
 import java.security.AlgorithmParameters;
 import java.security.KeyFactory;
 import java.security.KeyPairGenerator;
@@ -44,7 +43,7 @@ public class CryptoInsts {
             "com.tencent.kona.crypto.provider.name", KonaCryptoProvider.NAME);
 
     private static final Set<String> ALGO_PARAMS_ALGOS
-            = new HashSet<>(Arrays.asList("EC", "SM4", "RSASSA-PSS", "PBES2"));
+            = new HashSet<>(Arrays.asList("EC", "SM4", "PBES2"));
 
     public static AlgorithmParameters getAlgorithmParameters(String algorithm)
             throws NoSuchAlgorithmException {
@@ -61,26 +60,8 @@ public class CryptoInsts {
         return algoParams;
     }
 
-    private static final Set<String> ALGO_PARAM_GEN_ALGOS
-            = new HashSet<>(Collections.singletonList("SM4"));
-
-    public static AlgorithmParameterGenerator getAlgorithmParameterGenerator(
-            String algorithm) throws NoSuchAlgorithmException {
-        AlgorithmParameterGenerator algoParamGen  = null;
-        if (ALGO_PARAM_GEN_ALGOS.contains(algorithm)) {
-            try {
-                algoParamGen = AlgorithmParameterGenerator.getInstance(algorithm, PROV_NAME);
-            } catch (NoSuchProviderException e) {
-                throw new IllegalStateException("No provider: " + PROV_NAME, e);
-            }
-        } else {
-            algoParamGen = AlgorithmParameterGenerator.getInstance(algorithm);
-        }
-        return algoParamGen;
-    }
-
     private static final Set<String> KEY_FACTORY_ALGOS
-            = new HashSet<>(Arrays.asList("EC", "SM2", "RSA", "RSASSA-PSS"));
+            = new HashSet<>(Arrays.asList("SM2"));
 
     public static KeyFactory getKeyFactory(String algorithm)
             throws NoSuchAlgorithmException {
@@ -98,7 +79,7 @@ public class CryptoInsts {
     }
 
     private static final Set<String> KEY_GEN_ALGOS
-            = new HashSet<>(Arrays.asList("SM3HMac", "SM4"));
+            = new HashSet<>(Arrays.asList("SM4", "HmacSM3", "SM3HMac"));
 
     public static KeyGenerator getKeyGenerator(String algorithm)
             throws NoSuchAlgorithmException {
@@ -116,7 +97,7 @@ public class CryptoInsts {
     }
 
     private static final Set<String> KEY_PAIR_GEN_ALGOS
-            = new HashSet<>(Arrays.asList("SM2", "RSA", "RSASSA-PSS"));
+            = new HashSet<>(Arrays.asList("SM2"));
 
     public static KeyPairGenerator getKeyPairGenerator(String algorithm)
             throws NoSuchAlgorithmException {
@@ -171,7 +152,7 @@ public class CryptoInsts {
     }
 
     private static final Set<String> MAC_ALGOS
-            = new HashSet<>(Collections.singletonList("SM3HMac"));
+            = new HashSet<>(Arrays.asList("HmacSM3", "SM3HMac"));
 
     public static Mac getMac(String algorithm) throws NoSuchAlgorithmException {
         Mac mac  = null;
@@ -192,13 +173,7 @@ public class CryptoInsts {
                     "SM2", "SM3withSM2",
                     "NONEwithECDSA", "SHA1withECDSA",
                     "SHA224withECDSA", "SHA256withECDSA",
-                    "SHA384withECDSA", "SHA512withECDSA",
-                    "SHA1withRSA", "SHA224withRSA",
-                    "SHA256withRSA", "SHA384withRSA",
-                    "SHA512withRSA", "SHA512/224withRSA",
-                    "SHA512/256withRSA", "SHA3-224withRSA",
-                    "SHA3-256withRSA", "SHA3-384withRSA",
-                    "SHA3-512withRSA"));
+                    "SHA384withECDSA", "SHA512withECDSA"));
 
     public static Signature getSignature(String algorithm)
             throws NoSuchAlgorithmException {
@@ -216,7 +191,7 @@ public class CryptoInsts {
     }
 
     private static final Set<String> KEY_AGREEMENT_ALGOS
-            = new HashSet<>(Arrays.asList("SM2", "ECDH"));
+            = new HashSet<>(Arrays.asList("SM2"));
 
     public static KeyAgreement getKeyAgreement(String algorithm)
             throws NoSuchAlgorithmException {

--- a/kona-pkix/src/main/java/com/tencent/kona/pkix/PKIXUtils.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/pkix/PKIXUtils.java
@@ -22,9 +22,9 @@ package com.tencent.kona.pkix;
 
 import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.crypto.spec.RFC5915EncodedKeySpec;
+import com.tencent.kona.crypto.spec.SM2ParameterSpec;
 import com.tencent.kona.sun.security.util.DerInputStream;
 import com.tencent.kona.sun.security.util.KnownOIDs;
-import com.tencent.kona.sun.security.util.NamedCurve;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -38,6 +38,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
@@ -155,8 +156,8 @@ public class PKIXUtils {
             return false;
         }
 
-        NamedCurve curve = (NamedCurve) ((ECPublicKey) cert.getPublicKey()).getParams();
-        return KnownOIDs.curveSM2.value().equals(curve.getObjectId())
+        ECParameterSpec ecParams = ((ECPublicKey) cert.getPublicKey()).getParams();
+        return SM2ParameterSpec.ORDER.equals(ecParams.getOrder())
                 && KnownOIDs.SM3withSM2.value().equals(cert.getSigAlgOID());
     }
 

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertificateFactoryTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertificateFactoryTest.java
@@ -27,7 +27,6 @@ import com.tencent.kona.sun.security.util.KnownOIDs;
 import com.tencent.kona.sun.security.util.ObjectIdentifier;
 import com.tencent.kona.sun.security.x509.AlgorithmId;
 import com.tencent.kona.sun.security.x509.SMCertificate;
-import com.tencent.kona.sun.security.x509.X509Key;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -39,6 +38,8 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -65,10 +66,8 @@ public class CertificateFactoryTest {
         CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
         X509Certificate cert = (X509Certificate) cf.generateCertificate(
                 new ByteArrayInputStream(TestUtils.certBytes("ca-rsarsa.crt")));
-        X509Key pubKey = (X509Key) cert.getPublicKey();
-        AlgorithmId algId = pubKey.getAlgorithmId();
-        Assertions.assertEquals(KnownOIDs.RSA.value(), algId.getOID().toString());
-        Assertions.assertEquals("RSA", algId.getName());
+        RSAPublicKey pubKey = (RSAPublicKey) cert.getPublicKey();
+        Assertions.assertEquals("RSA", pubKey.getAlgorithm());
         Assertions.assertEquals(KnownOIDs.SHA256withRSA.value(), cert.getSigAlgOID());
         Assertions.assertEquals("SHA256withRSA", cert.getSigAlgName());
     }
@@ -78,10 +77,8 @@ public class CertificateFactoryTest {
         CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
         X509Certificate cert = (X509Certificate) cf.generateCertificate(
                 new ByteArrayInputStream(TestUtils.certBytes("ca-p256ecdsa.crt")));
-        X509Key pubKey = (X509Key) cert.getPublicKey();
-        AlgorithmId algId = pubKey.getAlgorithmId();
-        Assertions.assertEquals(KnownOIDs.EC.value(), algId.getOID().toString());
-        Assertions.assertEquals("EC", algId.getName());
+        ECPublicKey pubKey = (ECPublicKey) cert.getPublicKey();
+        Assertions.assertEquals("EC", pubKey.getAlgorithm());
         Assertions.assertEquals(KnownOIDs.SHA256withECDSA.value(), cert.getSigAlgOID());
         Assertions.assertEquals("SHA256withECDSA", cert.getSigAlgName());
     }
@@ -91,10 +88,8 @@ public class CertificateFactoryTest {
         CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
         X509Certificate cert = (X509Certificate) cf.generateCertificate(
                 new ByteArrayInputStream(TestUtils.certBytes("ca-p256sm2.crt")));
-        X509Key pubKey = (X509Key) cert.getPublicKey();
-        AlgorithmId algId = pubKey.getAlgorithmId();
-        Assertions.assertEquals(KnownOIDs.EC.value(), algId.getOID().toString());
-        Assertions.assertEquals("EC", algId.getName());
+        ECPublicKey pubKey = (ECPublicKey) cert.getPublicKey();
+        Assertions.assertEquals("EC", pubKey.getAlgorithm());
         Assertions.assertEquals(
                 KnownOIDs.SM3withSM2.value(),
                 cert.getSigAlgOID());
@@ -106,10 +101,8 @@ public class CertificateFactoryTest {
         CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
         X509Certificate cert = (X509Certificate) cf.generateCertificate(
                 new ByteArrayInputStream(TestUtils.certBytes("ca-sm2ecdsa.crt")));
-        X509Key pubKey = (X509Key) cert.getPublicKey();
-        AlgorithmId algId = pubKey.getAlgorithmId();
-        Assertions.assertEquals(KnownOIDs.EC.value(), algId.getOID().toString());
-        Assertions.assertEquals("EC", algId.getName());
+        ECPublicKey pubKey = (ECPublicKey) cert.getPublicKey();
+        Assertions.assertEquals("EC", pubKey.getAlgorithm());
         Assertions.assertEquals(
                 KnownOIDs.SHA256withECDSA.value(),
                 cert.getSigAlgOID());
@@ -121,10 +114,8 @@ public class CertificateFactoryTest {
         CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
         X509Certificate cert = (X509Certificate) cf.generateCertificate(
                 new ByteArrayInputStream(TestUtils.certBytes("ca-sm2sm2.crt")));
-        X509Key pubKey = (X509Key) cert.getPublicKey();
-        AlgorithmId algId = pubKey.getAlgorithmId();
-        Assertions.assertEquals(KnownOIDs.EC.value(), algId.getOID().toString());
-        Assertions.assertEquals("EC", algId.getName());
+        ECPublicKey pubKey = (ECPublicKey) cert.getPublicKey();
+        Assertions.assertEquals("EC", pubKey.getAlgorithm());
         Assertions.assertEquals(
                 KnownOIDs.SM3withSM2.value(),
                 cert.getSigAlgOID());

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/KeyFactoryTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/KeyFactoryTest.java
@@ -146,7 +146,7 @@ public class KeyFactoryTest {
 
         PKCS8EncodedKeySpec pkcs8KeySpec = keyFactory.getKeySpec(
                 privateKey, PKCS8EncodedKeySpec.class);
-        PKCS8Key pkcs8Key = (PKCS8Key) keyFactory.generatePrivate(
+        RSAPrivateKey pkcs8Key = (RSAPrivateKey) keyFactory.generatePrivate(
                 pkcs8KeySpec);
         Assertions.assertArrayEquals(
                 privateKey.getEncoded(), pkcs8Key.getEncoded());
@@ -164,7 +164,7 @@ public class KeyFactoryTest {
 
         PKCS8EncodedKeySpec pkcs8KeySpec = keyFactory.getKeySpec(
                 privateKey, PKCS8EncodedKeySpec.class);
-        PKCS8Key pkcs8Key = (PKCS8Key) keyFactory.generatePrivate(
+        ECPrivateKey pkcs8Key = (ECPrivateKey) keyFactory.generatePrivate(
                 pkcs8KeySpec);
         Assertions.assertArrayEquals(
                 privateKey.getEncoded(), pkcs8Key.getEncoded());


### PR DESCRIPTION
`KonaCrypto` would remove the support on `RSA` and `RSASSA-PSS`.

This PR will resolves #548.