### PR TITLE
TKSS-560: Use default ID value directly

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyAgreement.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyAgreement.java
@@ -44,7 +44,6 @@ import static com.tencent.kona.crypto.spec.SM2ParameterSpec.COFACTOR;
 import static com.tencent.kona.crypto.spec.SM2ParameterSpec.CURVE;
 import static com.tencent.kona.crypto.spec.SM2ParameterSpec.GENERATOR;
 import static com.tencent.kona.crypto.spec.SM2ParameterSpec.ORDER;
-import static com.tencent.kona.crypto.util.Constants.defaultId;
 import static com.tencent.kona.crypto.util.Constants.SM3_DIGEST_LEN;
 import static com.tencent.kona.crypto.CryptoUtils.bigIntToBytes32;
 import static com.tencent.kona.crypto.CryptoUtils.intToBytes4;
@@ -58,6 +57,11 @@ import static java.math.BigInteger.ZERO;
  * SM2 key agreement in compliance with GB/T 32918.3-2016.
  */
 public final class SM2KeyAgreement extends KeyAgreementSpi {
+
+    // The default ID 1234567812345678
+    private static final byte[] DEFAULT_ID = new byte[] {
+            49, 50, 51, 52, 53, 54, 55, 56,
+            49, 50, 51, 52, 53, 54, 55, 56};
 
     private ECPrivateKey ephemeralPrivateKey;
     private SM2KeyAgreementParamSpec paramSpec;
@@ -284,7 +288,7 @@ public final class SM2KeyAgreement extends KeyAgreementSpi {
     private static final byte[] GEN_Y = bigIntToBytes32(GENERATOR.getAffineY());
 
     private byte[] z(byte[] origId, ECPoint pubPoint) {
-        byte[] id = origId == null ? defaultId() : origId;
+        byte[] id = origId == null ? DEFAULT_ID : origId;
         int idLen = id.length << 3;
         sm3.update((byte)(idLen >>> 8));
         sm3.update((byte)idLen);

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertImpl.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/X509CertImpl.java
@@ -38,7 +38,6 @@ import javax.security.auth.x500.X500Principal;
 
 import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.crypto.spec.SM2SignatureParameterSpec;
-import com.tencent.kona.crypto.util.Constants;
 import com.tencent.kona.pkix.PKIXUtils;
 import com.tencent.kona.sun.security.provider.X509Factory;
 import com.tencent.kona.sun.security.util.Debug;
@@ -86,6 +85,11 @@ public class X509CertImpl extends X509Certificate
         implements DerEncoder, SMCertificate {
 
     private static final long serialVersionUID = -3457612960190864406L;
+
+    // The default ID 1234567812345678
+    private static final byte[] DEFAULT_ID = new byte[] {
+            49, 50, 51, 52, 53, 54, 55, 56,
+            49, 50, 51, 52, 53, 54, 55, 56};
 
     public static final String NAME = "x509";
 
@@ -230,7 +234,7 @@ public class X509CertImpl extends X509Certificate
         }
 
         return id == null || id.length == 0
-                ? Constants.defaultId()
+                ? DEFAULT_ID.clone()
                 : id.clone();
     }
 

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateVerify.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateVerify.java
@@ -678,7 +678,6 @@ final class CertificateVerify {
                 SM2SignatureParameterSpec smSignParamSpec = null;
                 if (PKIXUtils.isSM3withSM2(signatureScheme.name)) {
                     smSignParamSpec = new SM2SignatureParameterSpec(
-                            Constants.defaultId(),
                             (ECPublicKey) x509Credentials.popPublicKey);
                 }
 

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2EClientKeyExchange.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2EClientKeyExchange.java
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.ssl;
 
 import com.tencent.kona.crypto.provider.SM2PublicKey;
 import com.tencent.kona.crypto.spec.SM2KeyAgreementParamSpec;
-import com.tencent.kona.crypto.util.Constants;
 import com.tencent.kona.sun.security.ssl.SM2EKeyExchange.SM2ECredentials;
 import com.tencent.kona.sun.security.ssl.SM2EKeyExchange.SM2EPossession;
 import com.tencent.kona.sun.security.ssl.SSLHandshake.HandshakeMessage;
@@ -200,10 +199,8 @@ public class SM2EClientKeyExchange {
                         "Not supported key exchange type");
             } else {
                 SM2KeyAgreementParamSpec params = new SM2KeyAgreementParamSpec(
-                        Constants.defaultId(),
                         (ECPrivateKey) tlcpPossession.popEncPrivateKey,
                         (ECPublicKey) tlcpPossession.popEncPublicKey,
-                        Constants.defaultId(),
                         (ECPublicKey) tlcpCredentials.popEncPublicKey,
                         false,
                         48);
@@ -299,10 +296,8 @@ public class SM2EClientKeyExchange {
 
             // update the states
             SM2KeyAgreementParamSpec params = new SM2KeyAgreementParamSpec(
-                    Constants.defaultId(),
                     sm2ePossession.popEncPrivateKey,
                     sm2ePossession.popEncPublicKey,
-                    Constants.defaultId(),
                     (ECPublicKey) tlcpCredentials.popEncPublicKey,
                     true,
                     48);

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2EKeyExchange.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2EKeyExchange.java
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.ssl;
 
 import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.crypto.spec.SM2KeyAgreementParamSpec;
-import com.tencent.kona.crypto.util.Constants;
 import com.tencent.kona.ssl.SSLUtils;
 import com.tencent.kona.sun.security.ssl.TLCPAuthentication.TLCPPossession;
 import com.tencent.kona.sun.security.util.ECUtil;
@@ -147,10 +146,8 @@ public class SM2EKeyExchange {
                 throws SSLHandshakeException {
             try {
                 SM2KeyAgreementParamSpec params = new SM2KeyAgreementParamSpec(
-                        Constants.defaultId(),
                         popEncPrivateKey,
                         popEncPublicKey,
-                        Constants.defaultId(),
                         peerEphemeralPublicKey,
                         isInitiator,
                         32);

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2EServerKeyExchange.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2EServerKeyExchange.java
@@ -45,7 +45,6 @@ import java.util.Map;
 import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.crypto.provider.SM2PublicKey;
 import com.tencent.kona.crypto.spec.SM2SignatureParameterSpec;
-import com.tencent.kona.crypto.util.Constants;
 import com.tencent.kona.crypto.CryptoUtils;
 import com.tencent.kona.sun.security.ssl.TLCPAuthentication.TLCPCredentials;
 import com.tencent.kona.sun.security.ssl.TLCPAuthentication.TLCPPossession;
@@ -164,7 +163,6 @@ public class SM2EServerKeyExchange {
                             SignatureScheme.SM2SIG_SM3.algorithm);
 
                     signer.setParameter(new SM2SignatureParameterSpec(
-                            Constants.defaultId(),
                             (ECPublicKey) tlcpPossession.popSignPublicKey));
 
                     signer.initSign(tlcpPossession.popSignPrivateKey);
@@ -289,7 +287,6 @@ public class SM2EServerKeyExchange {
                             SignatureScheme.SM2SIG_SM3.algorithm);
 
                     signer.setParameter(new SM2SignatureParameterSpec(
-                            Constants.defaultId(),
                             (ECPublicKey) tlcpCredentials.popSignPublicKey));
 
                     signer.initVerify(tlcpCredentials.popSignPublicKey);

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2ServerKeyExchange.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2ServerKeyExchange.java
@@ -40,7 +40,6 @@ import java.util.Locale;
 
 import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.crypto.spec.SM2SignatureParameterSpec;
-import com.tencent.kona.crypto.util.Constants;
 import com.tencent.kona.sun.security.ssl.TLCPAuthentication.TLCPCredentials;
 import com.tencent.kona.sun.security.ssl.TLCPAuthentication.TLCPPossession;
 import com.tencent.kona.sun.security.ssl.SSLHandshake.HandshakeMessage;
@@ -114,7 +113,6 @@ final class SM2ServerKeyExchange {
 
                 // Set ID and public key for SM3withSM2.
                 signer.setParameter(new SM2SignatureParameterSpec(
-                        Constants.defaultId(),
                         (ECPublicKey) tlcpPossession.popSignPublicKey));
 
                 signer.initSign(tlcpPossession.popSignPrivateKey);
@@ -188,7 +186,6 @@ final class SM2ServerKeyExchange {
 
                 // Set ID and public key for SM3withSM2.
                 signer.setParameter(new SM2SignatureParameterSpec(
-                        Constants.defaultId(),
                         (ECPublicKey) tlcpCredentials.popSignCert.getPublicKey()));
 
                 signer.initVerify(tlcpCredentials.popSignPublicKey);

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SignatureScheme.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SignatureScheme.java
@@ -509,10 +509,11 @@ enum SignatureScheme {
 
         // Just select sm2sig_sm3 for curveSM2.
         if (namedGroup == NamedGroup.CURVESM2) {
-            byte[] id = !version.useTLS13PlusSpec()
-                    ? Constants.defaultId() : Utilities.TLS13_SM_ID;
-            Signature signer = SignatureScheme.SM2SIG_SM3.getSigner(signingKey,
-                    new SM2SignatureParameterSpec(id, (ECPublicKey) publicKey));
+            SM2SignatureParameterSpec paramSpec = !version.useTLS13PlusSpec()
+                    ? new SM2SignatureParameterSpec((ECPublicKey) publicKey)
+                    : new SM2SignatureParameterSpec(Utilities.TLS13_SM_ID,
+                            (ECPublicKey) publicKey);
+            Signature signer = SignatureScheme.SM2SIG_SM3.getSigner(signingKey, paramSpec);
             return new SimpleImmutableEntry<>(SignatureScheme.SM2SIG_SM3, signer);
         }
 

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPCertificateVerify.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPCertificateVerify.java
@@ -26,7 +26,6 @@
 package com.tencent.kona.sun.security.ssl;
 
 import com.tencent.kona.crypto.spec.SM2SignatureParameterSpec;
-import com.tencent.kona.crypto.util.Constants;
 import com.tencent.kona.pkix.PKIXUtils;
 import com.tencent.kona.sun.security.util.HexDumpEncoder;
 
@@ -77,7 +76,7 @@ final class TLCPCertificateVerify {
             try {
                 Signature signer = SignatureScheme.SM2SIG_SM3.getSigner(
                         tlcpPossession.popSignPrivateKey,
-                        new SM2SignatureParameterSpec(Constants.defaultId(),
+                        new SM2SignatureParameterSpec(
                                 (ECPublicKey) tlcpPossession.popSignPublicKey));
                 signer.update(chc.handshakeHash.digest());
                 temporary = signer.sign();
@@ -155,7 +154,6 @@ final class TLCPCertificateVerify {
                 Signature signer = SignatureScheme.SM2SIG_SM3.getVerifier(
                         tlcpCredentials.popSignPublicKey,
                         new SM2SignatureParameterSpec(
-                                Constants.defaultId(),
                                 (ECPublicKey) tlcpCredentials.popSignPublicKey));
 
                 signer.update(shc.handshakeHash.digest());


### PR DESCRIPTION
It would not to invoke `Constants::defaultId` to get the default ID, instead, directly use the ID value,
`new byte[] { 49, 50, 51, 52, 53, 54, 55, 56, 49, 50, 51, 52, 53, 54, 55, 56}`

This PR will resolves #560.