### PR TITLE
TKSS-564: CryptoInsts::getKeyFactory should return KonaCrypto ECKeyFactory

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoInsts.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoInsts.java
@@ -61,7 +61,7 @@ public class CryptoInsts {
     }
 
     private static final Set<String> KEY_FACTORY_ALGOS
-            = new HashSet<>(Arrays.asList("SM2"));
+            = new HashSet<>(Arrays.asList("EC", "SM2"));
 
     public static KeyFactory getKeyFactory(String algorithm)
             throws NoSuchAlgorithmException {


### PR DESCRIPTION
`CryptoInsts::getKeyFactory` should return the `ECKeyFactory` implementation from provide `KonaCrypto`.
#548 introduced this change.

This PR will resolves #564.