### PR TITLE
TKSS-577: SM3Test adds case on reusing MessageDigest instance

### DIFF
--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3Test.java
@@ -184,6 +184,17 @@ public class SM3Test {
     }
 
     @Test
+    public void testReuse() throws Exception {
+        MessageDigest md = MessageDigest.getInstance("SM3", PROVIDER);
+
+        byte[] digestShort = md.digest(MESSAGE_SHORT);
+        Assertions.assertArrayEquals(DIGEST_SHORT, digestShort);
+
+        byte[] digestLong = md.digest(MESSAGE_LONG);
+        Assertions.assertArrayEquals(DIGEST_LONG, digestLong);
+    }
+
+    @Test
     public void testReset() throws Exception {
         MessageDigest md = MessageDigest.getInstance("SM3", PROVIDER);
 


### PR DESCRIPTION
`SM3Test` would add a case on reusing `SM3MessageDigest` instance.

This PR will resolves #577.