### PR TITLE
TKSS-587: HashAlg contains a redundant comma

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CipherSuite.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CipherSuite.java
@@ -1180,7 +1180,7 @@ enum CipherSuite {
         H_NONE      ("NONE",    0,    0),
         H_SHA256    ("SHA-256", 32,  64),
         H_SHA384    ("SHA-384", 48, 128),
-        H_SM3       ("SM3",     32,  64),;
+        H_SM3       ("SM3",     32,  64);
 
         final String name;
         final int hashLength;


### PR DESCRIPTION
`HashAlg` `H_SM3` in `CipherSuite` contains a redundant comma, like the below,
```
H_SM3       ("SM3",     32,  64),;
```

This PR will resolves #587.