### PR TITLE
TKSS-586: Backport JDK-8318756: Create better internal buffer for AEADs

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/AEADBufferedStream.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/AEADBufferedStream.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.tencent.kona.crypto.provider;
+
+import com.tencent.kona.java.util.HexFormat;
+import com.tencent.kona.jdk.internal.util.ArraysSupport;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+/**
+ * This class extends ByteArrayOutputStream by optimizing internal buffering.
+ * It skips bounds checking, as the buffers are known and input previously
+ * checked.  toByteArray() returns the internal buffer to avoid an extra copy.
+ *
+ * This uses `count` to determine the state of `buf`.  `buf` can still
+ * point to an array while `count` equals zero.
+ */
+final class AEADBufferedStream extends ByteArrayOutputStream {
+
+    /**
+     * Create an instance with the specified buffer
+     */
+
+    public AEADBufferedStream(int len) {
+        super(len);
+    }
+
+    /**
+     * This method saves memory by returning the internal buffer. The calling
+     * method must use {@code size()} for the relevant data length as the
+     * returning byte[] maybe larger.
+     *
+     * @return internal buffer.
+     */
+    public byte[] getBuffer() {
+        return buf;
+    }
+
+    /**
+     * This method with expand the buffer if {@code count} + {@code len}
+     * is larger than the buffer byte[] length.
+     * @param len length to add to the current buffer
+     */
+    private void checkCapacity(int len) {
+        int blen = buf.length;
+        // Create a new larger buffer and append the new data
+        if (blen < count + len) {
+            buf = Arrays.copyOf(buf, ArraysSupport.newLength(blen, len, blen));
+        }
+    }
+
+    /**
+     * Takes a ByteBuffer writing non-blocksize data directly to the internal
+     * buffer.
+     * @param src remaining non-blocksize ByteBuffer
+     */
+    public void write(ByteBuffer src) {
+        int pos = src.position();
+        int len = src.remaining();
+
+        if (src.hasArray()) {
+            write(src.array(), pos + src.arrayOffset(), len);
+            src.position(pos + len);
+            return;
+        }
+
+        checkCapacity(len);
+        src.get(buf, count, len);
+        count += len;
+    }
+
+    @Override
+    public void write(byte[] in, int offset, int len) {
+        checkCapacity(len);
+        System.arraycopy(in, offset, buf, count, len);
+        count += len;
+    }
+
+    @Override
+    public String toString() {
+        return (count == 0 ? "null" : HexFormat.of().formatHex(buf));
+    }
+}

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GaloisCounterMode.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GaloisCounterMode.java
@@ -40,8 +40,6 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.ShortBufferException;
 import javax.crypto.spec.GCMParameterSpec;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
@@ -244,7 +242,7 @@ abstract class GaloisCounterMode extends CipherSpi {
     protected AlgorithmParameters engineGetParameters() {
         GCMParameterSpec spec;
         spec = new GCMParameterSpec(tagLenBytes * 8,
-            iv == null ? createIv(random) : iv.clone());
+            iv == null ? createIv(random) : iv); // iv.clone() not necessary
         try {
             AlgorithmParameters params =
                     CryptoInsts.getAlgorithmParameters("GCM");
@@ -693,12 +691,12 @@ abstract class GaloisCounterMode extends CipherSpi {
         final int blockSize;
 
         // buffer for AAD data; if null, meaning update has been called
-        ByteArrayOutputStream aadBuffer = null;
+        AEADBufferedStream aadBuffer = null;
         int sizeOfAAD = 0;
         boolean aadProcessed = false;
 
         // buffer data for crypto operation
-        ByteArrayOutputStream ibuffer = null;
+        AEADBufferedStream ibuffer = null;
 
         // Original dst buffer if there was an overlap situation
         ByteBuffer originalDst = null;
@@ -749,7 +747,7 @@ abstract class GaloisCounterMode extends CipherSpi {
         // Initialize internal data buffer, if not already.
         void initBuffer(int len) {
             if (ibuffer == null) {
-                ibuffer = new ByteArrayOutputStream(len);
+                ibuffer = new AEADBufferedStream(len);
             }
         }
 
@@ -802,20 +800,6 @@ abstract class GaloisCounterMode extends CipherSpi {
         }
 
         /**
-         * The method takes two buffers to create one block of data.  The
-         * difference with the other mergeBlock is this will calculate
-         * the bufLen from the existing 'buffer' length & offset
-         *
-         * This is only called when buffer length is less than a blockSize
-         * @return number of bytes used from 'in'
-         */
-        int mergeBlock(byte[] buffer, int bufOfs, byte[] in, int inOfs,
-            int inLen, byte[] block) {
-            return mergeBlock(buffer, bufOfs, buffer.length - bufOfs, in,
-                inOfs, inLen, block);
-        }
-
-        /**
          * The method takes two buffers to create one block of data
          *
          * This is only called when buffer length is less than a blockSize
@@ -835,7 +819,7 @@ abstract class GaloisCounterMode extends CipherSpi {
         }
 
         /**
-         * Continues a multi-part update of the Additional Authentication
+         * Continues a multipart update of the Additional Authentication
          * Data (AAD), using a subset of the provided buffer.  All AAD must be
          * supplied before beginning operations on the ciphertext (via the
          * {@code update} and {@code doFinal} methods).
@@ -856,7 +840,7 @@ abstract class GaloisCounterMode extends CipherSpi {
 
             if (aadBuffer == null) {
                 if (sizeOfAAD == 0 && !aadProcessed) {
-                    aadBuffer = new ByteArrayOutputStream(len);
+                    aadBuffer = new AEADBufferedStream(len);
                 } else {
                     // update has already been called
                     throw new IllegalStateException
@@ -869,18 +853,17 @@ abstract class GaloisCounterMode extends CipherSpi {
         // Feed the AAD data to GHASH, pad if necessary
         void processAAD() {
             if (aadBuffer != null) {
-                if (aadBuffer.size() > 0) {
-                    byte[] aad = aadBuffer.toByteArray();
-                    sizeOfAAD = aad.length;
-
-                    int lastLen = aad.length % blockSize;
+                sizeOfAAD = aadBuffer.size();
+                if (sizeOfAAD > 0) {
+                    byte[] aad = aadBuffer.getBuffer();
+                    int lastLen = sizeOfAAD % blockSize;
                     if (lastLen != 0) {
-                        ghash.update(aad, 0, aad.length - lastLen);
+                        ghash.update(aad, 0, sizeOfAAD - lastLen);
                         byte[] padded = expandToOneBlock(aad,
-                            aad.length - lastLen, lastLen, blockSize);
+                            sizeOfAAD - lastLen, lastLen, blockSize);
                         ghash.update(padded);
                     } else {
-                        ghash.update(aad);
+                        ghash.update(aad, 0, sizeOfAAD);
                     }
                 }
                 aadBuffer = null;
@@ -1194,7 +1177,7 @@ abstract class GaloisCounterMode extends CipherSpi {
 
             // if there is enough data in the ibuffer and 'in', encrypt it.
             if (bLen > 0) {
-                byte[] buffer = ibuffer.toByteArray();
+                byte[] buffer = ibuffer.getBuffer();
                 // number of bytes not filling a block
                 int remainder = blockSize - bLen;
 
@@ -1214,7 +1197,7 @@ abstract class GaloisCounterMode extends CipherSpi {
                 }
             }
 
-            // Encrypt the remaining blocks inside of 'in'
+            // Encrypt the remaining blocks inside 'in'
             if (inLen >= PARALLEL_LEN) {
                 int r = GaloisCounterMode.implGCMCrypt(in, inOfs, inLen, out,
                     outOfs, out, outOfs, gctr, ghash);
@@ -1270,7 +1253,8 @@ abstract class GaloisCounterMode extends CipherSpi {
                 // Check if there is enough 'src' and 'buffer' to fill a block
                 if (src.remaining() >= remainder) {
                     byte[] block = new byte[blockSize];
-                    ByteBuffer buffer = ByteBuffer.wrap(ibuffer.toByteArray());
+                    ByteBuffer buffer = ByteBuffer.wrap(ibuffer.getBuffer(),
+                        0, ibuffer.size());
                     buffer.get(block, 0, bLen);
                     src.get(block, bLen, remainder);
                     len += op.update(ByteBuffer.wrap(block, 0, blockSize),
@@ -1298,14 +1282,8 @@ abstract class GaloisCounterMode extends CipherSpi {
             // Write the remaining bytes into the 'ibuffer'
             if (srcLen > 0) {
                 initBuffer(srcLen);
-                byte[] b = new byte[srcLen];
-                src.get(b);
                 // remainder offset is based on original buffer length
-                try {
-                    ibuffer.write(b);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
+                ibuffer.write(src);
             }
 
             restoreDst(dst);
@@ -1337,13 +1315,13 @@ abstract class GaloisCounterMode extends CipherSpi {
 
             // process what is in the ibuffer
             if (bLen > 0) {
-                byte[] buffer = ibuffer.toByteArray();
+                byte[] buffer = ibuffer.getBuffer();
 
                 // Make a block if the remaining ibuffer and 'in' can make one.
                 if (bLen + inLen >= blockSize) {
                     int r;
                     block = new byte[blockSize];
-                    r = mergeBlock(buffer, 0, in, inOfs, inLen, block);
+                    r = mergeBlock(buffer, 0, ibuffer.size(), in, inOfs, inLen, block);
                     inOfs += r;
                     inLen -= r;
                     op.update(block, 0, blockSize, out, outOfs);
@@ -1400,7 +1378,8 @@ abstract class GaloisCounterMode extends CipherSpi {
             if (len > 0) {
                 processed += doLastBlock(op,
                     (ibuffer == null || ibuffer.size() == 0) ? null :
-                        ByteBuffer.wrap(ibuffer.toByteArray()), src, dst);
+                        ByteBuffer.wrap(ibuffer.getBuffer(), 0,
+                            ibuffer.size()), src, dst);
             }
 
             // release buffer if needed
@@ -1474,9 +1453,10 @@ abstract class GaloisCounterMode extends CipherSpi {
                     tagLenBytes);
             } else {
                 // tagOfs will be negative
-                byte[] buffer = ibuffer.toByteArray();
-                tagOfs = mergeBlock(buffer,
-                    buffer.length - (tagLenBytes - inLen), in, inOfs, inLen,
+                byte[] buffer = ibuffer.getBuffer();
+                int ofs = ibuffer.size() - (tagLenBytes - inLen);
+                tagOfs = mergeBlock(buffer, ofs, ibuffer.size() - ofs,
+                    in, inOfs, inLen,
                     tag) - tagLenBytes;
             }
         }
@@ -1522,15 +1502,8 @@ abstract class GaloisCounterMode extends CipherSpi {
                         src.remaining(), null, 0);
                     src.position(src.limit());
                 } else {
-                    byte[] b = new byte[src.remaining()];
-                    src.get(b);
-                    initBuffer(b.length);
-                    try {
-                        ibuffer.write(b);
-                    } catch (IOException e) {
-                        throw new ProviderException(
-                            "Unable to add remaining input to the buffer", e);
-                    }
+                    initBuffer(src.remaining());
+                    ibuffer.write(src);
                 }
             }
             return 0;
@@ -1538,7 +1511,7 @@ abstract class GaloisCounterMode extends CipherSpi {
 
         /**
          * Use available data from ibuffer and 'in' to verify and decrypt the
-         * data.  If the verification fails, the 'out' left to it's original
+         * data. If the verification fails, the 'out' left to its original
          * values if crypto was in-place; otherwise 'out' is zeroed
          */
         @Override
@@ -1598,7 +1571,7 @@ abstract class GaloisCounterMode extends CipherSpi {
 
         /**
          * Use available data from ibuffer and 'src' to verify and decrypt the
-         * data.  If the verification fails, the 'dst' left to it's original
+         * data. If the verification fails, the 'dst' left to its original
          * values if crypto was in-place; otherwise 'dst' is zeroed
          */
         @Override
@@ -1615,7 +1588,8 @@ abstract class GaloisCounterMode extends CipherSpi {
 
             // Check if ibuffer has data
             if (getBufferedLength() != 0) {
-                buffer = ByteBuffer.wrap(ibuffer.toByteArray());
+                buffer = ByteBuffer.wrap(ibuffer.getBuffer(), 0,
+                    ibuffer.size());
                 len += buffer.remaining();
             }
 
@@ -1725,7 +1699,7 @@ abstract class GaloisCounterMode extends CipherSpi {
             }
 
             if (bLen > 0) {
-                buffer = ibuffer.toByteArray();
+                buffer = ibuffer.getBuffer();
 
                 if (bLen >= PARALLEL_LEN) {
                     len = GaloisCounterMode.implGCMCrypt(buffer, 0, bLen,

--- a/kona-crypto/src/main/java/com/tencent/kona/jdk/internal/util/ArraysSupport.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/jdk/internal/util/ArraysSupport.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.tencent.kona.jdk.internal.util;
+
+public class ArraysSupport {
+
+    /**
+     * A soft maximum array length imposed by array growth computations.
+     * Some JVMs (such as HotSpot) have an implementation limit that will cause
+     *
+     *     OutOfMemoryError("Requested array size exceeds VM limit")
+     *
+     * to be thrown if a request is made to allocate an array of some length near
+     * Integer.MAX_VALUE, even if there is sufficient heap available. The actual
+     * limit might depend on some JVM implementation-specific characteristics such
+     * as the object header size. The soft maximum value is chosen conservatively so
+     * as to be smaller than any implementation limit that is likely to be encountered.
+     */
+    public static final int SOFT_MAX_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
+
+    /**
+     * Computes a new array length given an array's current length, a minimum growth
+     * amount, and a preferred growth amount. The computation is done in an overflow-safe
+     * fashion.
+     *
+     * This method is used by objects that contain an array that might need to be grown
+     * in order to fulfill some immediate need (the minimum growth amount) but would also
+     * like to request more space (the preferred growth amount) in order to accommodate
+     * potential future needs. The returned length is usually clamped at the soft maximum
+     * length in order to avoid hitting the JVM implementation limit. However, the soft
+     * maximum will be exceeded if the minimum growth amount requires it.
+     *
+     * If the preferred growth amount is less than the minimum growth amount, the
+     * minimum growth amount is used as the preferred growth amount.
+     *
+     * The preferred length is determined by adding the preferred growth amount to the
+     * current length. If the preferred length does not exceed the soft maximum length
+     * (SOFT_MAX_ARRAY_LENGTH) then the preferred length is returned.
+     *
+     * If the preferred length exceeds the soft maximum, we use the minimum growth
+     * amount. The minimum required length is determined by adding the minimum growth
+     * amount to the current length. If the minimum required length exceeds Integer.MAX_VALUE,
+     * then this method throws OutOfMemoryError. Otherwise, this method returns the greater of
+     * the soft maximum or the minimum required length.
+     *
+     * Note that this method does not do any array allocation itself; it only does array
+     * length growth computations. However, it will throw OutOfMemoryError as noted above.
+     *
+     * Note also that this method cannot detect the JVM's implementation limit, and it
+     * may compute and return a length value up to and including Integer.MAX_VALUE that
+     * might exceed the JVM's implementation limit. In that case, the caller will likely
+     * attempt an array allocation with that length and encounter an OutOfMemoryError.
+     * Of course, regardless of the length value returned from this method, the caller
+     * may encounter OutOfMemoryError if there is insufficient heap to fulfill the request.
+     *
+     * @param oldLength   current length of the array (must be nonnegative)
+     * @param minGrowth   minimum required growth amount (must be positive)
+     * @param prefGrowth  preferred growth amount
+     * @return the new array length
+     * @throws OutOfMemoryError if the new length would exceed Integer.MAX_VALUE
+     */
+    public static int newLength(int oldLength, int minGrowth, int prefGrowth) {
+        // preconditions not checked because of inlining
+        // assert oldLength >= 0
+        // assert minGrowth > 0
+
+        int prefLength = oldLength + Math.max(minGrowth, prefGrowth); // might overflow
+        if (0 < prefLength && prefLength <= SOFT_MAX_ARRAY_LENGTH) {
+            return prefLength;
+        } else {
+            // put code cold in a separate method
+            return hugeLength(oldLength, minGrowth);
+        }
+    }
+
+    private static int hugeLength(int oldLength, int minGrowth) {
+        int minLength = oldLength + minGrowth;
+        if (minLength < 0) { // overflow
+            throw new OutOfMemoryError(
+                "Required array length " + oldLength + " + " + minGrowth + " is too large");
+        } else if (minLength <= SOFT_MAX_ARRAY_LENGTH) {
+            return SOFT_MAX_ARRAY_LENGTH;
+        } else {
+            return minLength;
+        }
+    }
+}


### PR DESCRIPTION
This is a backport of [JDK-8318756]: Create better internal buffer for AEADs.

This PR will resolves #586.

[JDK-8318756]:
<https://bugs.openjdk.org/browse/JDK-8318756>