### PR TITLE
TKSS-594: Enhance passing SM2SignatureParameterSpec to sm2sig_sm3

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateVerify.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateVerify.java
@@ -674,15 +674,8 @@ final class CertificateVerify {
             // opaque signature<0..2^16-1>;
             this.signature = Record.getBytes16(m);
             try {
-                // Set ID and public key for SM3withSM2.
-                SM2SignatureParameterSpec smSignParamSpec = null;
-                if (PKIXUtils.isSM3withSM2(signatureScheme.name)) {
-                    smSignParamSpec = new SM2SignatureParameterSpec(
-                            (ECPublicKey) x509Credentials.popPublicKey);
-                }
-
                 Signature signer = signatureScheme.getVerifier(
-                        x509Credentials.popPublicKey, smSignParamSpec);
+                        x509Credentials.popPublicKey);
                 signer.update(shc.handshakeHash.archived());
                 if (!signer.verify(signature)) {
                     throw shc.conContext.fatal(Alert.HANDSHAKE_FAILURE,
@@ -1019,18 +1012,8 @@ final class CertificateVerify {
             }
 
             try {
-                // Set ID and public key for SM3withSM2.
-                SM2SignatureParameterSpec smSignParamSpec = null;
-                X509Certificate popCert = x509Credentials.popCerts[0];
-                if (PKIXUtils.isSM3withSM2(popCert.getSigAlgName())) {
-                    smSignParamSpec = new SM2SignatureParameterSpec(
-                            Utilities.TLS13_SM_ID,
-                            (ECPublicKey) x509Credentials.popPublicKey);
-                }
-
                 Signature signer = signatureScheme.getVerifier(
-                        x509Credentials.popPublicKey, smSignParamSpec);
-
+                        x509Credentials.popPublicKey, true);
 
                 signer.update(contentCovered);
                 if (!signer.verify(signature)) {

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ProtocolVersion.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ProtocolVersion.java
@@ -365,6 +365,10 @@ enum ProtocolVersion {
         return this.id == TLS12.id;
     }
 
+    boolean isTLS13() {
+        return this.id == TLS13.id;
+    }
+
     /**
      * Return true if this ProtocolVersion object is of (D)TLS 1.3 or
      * newer version.

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPCertificateVerify.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPCertificateVerify.java
@@ -76,8 +76,8 @@ final class TLCPCertificateVerify {
             try {
                 Signature signer = SignatureScheme.SM2SIG_SM3.getSigner(
                         tlcpPossession.popSignPrivateKey,
-                        new SM2SignatureParameterSpec(
-                                (ECPublicKey) tlcpPossession.popSignPublicKey));
+                        tlcpPossession.popSignPublicKey,
+                        false);
                 signer.update(chc.handshakeHash.digest());
                 temporary = signer.sign();
             } catch (SignatureException se) {
@@ -152,9 +152,7 @@ final class TLCPCertificateVerify {
 
             try {
                 Signature signer = SignatureScheme.SM2SIG_SM3.getVerifier(
-                        tlcpCredentials.popSignPublicKey,
-                        new SM2SignatureParameterSpec(
-                                (ECPublicKey) tlcpCredentials.popSignPublicKey));
+                        tlcpCredentials.popSignPublicKey);
 
                 signer.update(shc.handshakeHash.digest());
                 if (!signer.verify(signature)) {


### PR DESCRIPTION
It would enhance passing `SM2SignatureParameterSpec` to signature scheme `sm2sig_sm3`.
`SignatureScheme` should handle the most of logics for this case.

This PR will resolves #594.