### PR TITLE
TKSS-596: Backport JDK-8202598: keytool -certreq output contains inconsistent line separators

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs10/PKCS10.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs10/PKCS10.java
@@ -308,9 +308,12 @@ public class PKCS10 {
 
 
         byte[] CRLF = new byte[] {'\r', '\n'};
-        out.println("-----BEGIN NEW CERTIFICATE REQUEST-----");
-        out.println(Base64.getMimeEncoder(64, CRLF).encodeToString(encoded));
-        out.println("-----END NEW CERTIFICATE REQUEST-----");
+        out.print("-----BEGIN NEW CERTIFICATE REQUEST-----");
+        out.print("\r\n");
+        out.print(Base64.getMimeEncoder(64, CRLF).encodeToString(encoded));
+        out.print("\r\n");
+        out.print("-----END NEW CERTIFICATE REQUEST-----");
+        out.print("\r\n");
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/tools/keytool/Main.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/tools/keytool/Main.java
@@ -1637,9 +1637,12 @@ public final class Main {
                 new X509CRLImpl.TBSCertList(owner, firstDate, lastDate, badCerts),
                 privateKey, sigAlgName);
         if (rfc) {
-            out.println("-----BEGIN X509 CRL-----");
-            out.println(Base64.getMimeEncoder(64, CRLF).encodeToString(crl.getEncodedInternal()));
-            out.println("-----END X509 CRL-----");
+            out.print("-----BEGIN X509 CRL-----");
+            out.print("\r\n");
+            out.print(Base64.getMimeEncoder(64, CRLF).encodeToString(crl.getEncodedInternal()));
+            out.print("\r\n");
+            out.print("-----END X509 CRL-----");
+            out.print("\r\n");
         } else {
             out.write(crl.getEncodedInternal());
         }
@@ -2814,9 +2817,12 @@ public final class Main {
             throws Exception {
         X509CRL xcrl = (X509CRL)crl;
         if (rfc) {
-            out.println("-----BEGIN X509 CRL-----");
-            out.println(Base64.getMimeEncoder(64, CRLF).encodeToString(xcrl.getEncoded()));
-            out.println("-----END X509 CRL-----");
+            out.print("-----BEGIN X509 CRL-----");
+            out.print("\r\n");
+            out.print(Base64.getMimeEncoder(64, CRLF).encodeToString(xcrl.getEncoded()));
+            out.print("\r\n");
+            out.print("-----END X509 CRL-----");
+            out.print("\r\n");
         } else {
             String s;
             if (crl instanceof X509CRLImpl) {
@@ -3832,9 +3838,12 @@ public final class Main {
         throws IOException, CertificateException
     {
         if (rfc) {
-            out.println(X509Factory.BEGIN_CERT);
-            out.println(Base64.getMimeEncoder(64, CRLF).encodeToString(cert.getEncoded()));
-            out.println(X509Factory.END_CERT);
+            out.print(X509Factory.BEGIN_CERT);
+            out.print("\r\n");
+            out.print(Base64.getMimeEncoder(64, CRLF).encodeToString(cert.getEncoded()));
+            out.print("\r\n");
+            out.print(X509Factory.END_CERT);
+            out.print("\r\n");
         } else {
             out.write(cert.getEncoded()); // binary
         }


### PR DESCRIPTION
This is a backport of [JDK-8202598]: keytool -certreq output contains inconsistent line separators.

This PR will resolves #596.

[JDK-8202598]:
<https://bugs.openjdk.org/browse/JDK-8202598>