### PR TITLE
TKSS-597: Backport JDK-8296787: Unify debug printing format of X.509 cert serial numbers

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/jca/JCAUtil.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/jca/JCAUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package com.tencent.kona.sun.security.jca;
 
 import java.security.SecureRandom;
+import sun.security.util.Debug;
 
 /**
  * Collection of static utility methods used by the security framework.

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/Debug.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/Debug.java
@@ -332,4 +332,7 @@ public class Debug {
         return HexFormat.ofDelimiter(":").formatHex(b);
     }
 
+    public static String toString(BigInteger b) {
+        return toString(b.toByteArray());
+    }
 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/SignerInfo.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/SignerInfo.java
@@ -711,14 +711,15 @@ public class SignerInfo implements DerEncoder {
                 md.digest(encryptedDigest))) {
 
             throw new SignatureException("Signature timestamp (#" +
-                    token.getSerialNumber() + ") generated on " + token.getDate() +
-                    " is inapplicable");
+                Debug.toString(token.getSerialNumber()) +
+                ") generated on " + token.getDate() + " is inapplicable");
         }
 
         if (debug != null) {
             debug.println();
             debug.println("Detected signature timestamp (#" +
-                    token.getSerialNumber() + ") generated on " + token.getDate());
+                Debug.toString(token.getSerialNumber()) +
+                ") generated on " + token.getDate());
             debug.println();
         }
     }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/BasicChecker.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/BasicChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -246,7 +246,7 @@ class BasicChecker extends PKIXCertPathChecker {
             debug.println("BasicChecker.updateState issuer: " +
                     currCert.getIssuerX500Principal().toString() + "; subject: " +
                     currCert.getSubjectX500Principal() + "; serial#: " +
-                    currCert.getSerialNumber().toString());
+                    Debug.toString(currCert.getSerialNumber()));
         }
         if (PKIX.isDSAPublicKeyWithoutParams(cKey)) {
             // cKey needs to inherit DSA parameters from prev key

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/Builder.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/Builder.java
@@ -429,8 +429,7 @@ public abstract class Builder {
                 if (debug != null) {
                     debug.println("Builder.addMatchingCerts: " +
                             "adding target cert" +
-                            "\n  SN: " + Debug.toHexString(
-                            targetCert.getSerialNumber()) +
+                            "\n SN: " + Debug.toString(targetCert.getSerialNumber()) +
                             "\n  Subject: " + targetCert.getSubjectX500Principal() +
                             "\n  Issuer: " + targetCert.getIssuerX500Principal());
                 }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/CertId.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/CertId.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import javax.security.auth.x500.X500Principal;
 
 import com.tencent.kona.crypto.CryptoInsts;
+import com.tencent.kona.sun.security.util.Debug;
 import com.tencent.kona.sun.security.util.DerEncoder;
 import com.tencent.kona.sun.security.util.DerInputStream;
 import com.tencent.kona.sun.security.util.DerOutputStream;
@@ -114,7 +115,7 @@ public class CertId implements DerEncoder {
                     encoder.encodeBuffer(issuerNameHash));
             System.out.println("issuerKeyHash is " +
                     encoder.encodeBuffer(issuerKeyHash));
-            System.out.println("SerialNumber is " + serialNumber.getNumber());
+            System.out.println("SerialNumber is " + Debug.toString(serialNumber.getNumber()));
         }
     }
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/DistributionPointFetcher.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/DistributionPointFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -326,7 +326,7 @@ public class DistributionPointFetcher {
         if (debug != null) {
             debug.println("DistributionPointFetcher.verifyCRL: " +
                     "checking revocation status for" +
-                    "\n  SN: " + Debug.toHexString(certImpl.getSerialNumber()) +
+                    "\n SN: " + Debug.toString(certImpl.getSerialNumber()) +
                     "\n  Subject: " + certImpl.getSubjectX500Principal() +
                     "\n  Issuer: " + certImpl.getIssuerX500Principal());
         }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/ForwardBuilder.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/ForwardBuilder.java
@@ -279,7 +279,7 @@ class ForwardBuilder extends Builder {
                     debug.println("ForwardBuilder.getMatchingCACerts: " +
                             "found matching trust anchor." +
                             "\n  SN: " +
-                            Debug.toHexString(trustedCert.getSerialNumber()) +
+                            Debug.toString(trustedCert.getSerialNumber()) +
                             "\n  Subject: " +
                             trustedCert.getSubjectX500Principal() +
                             "\n  Issuer: " +
@@ -678,7 +678,7 @@ class ForwardBuilder extends Builder {
     {
         if (debug != null) {
             debug.println("ForwardBuilder.verifyCert(SN: "
-                    + Debug.toHexString(cert.getSerialNumber())
+                    + Debug.toString(cert.getSerialNumber())
                     + "\n  Issuer: " + cert.getIssuerX500Principal() + ")"
                     + "\n  Subject: " + cert.getSubjectX500Principal() + ")");
         }

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/OCSPResponse.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/OCSPResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -416,7 +416,8 @@ public final class OCSPResponse {
             }
             if (debug != null) {
                 debug.println("Status of certificate (with serial number " +
-                        certId.getSerialNumber() + ") is: " + sr.getCertStatus());
+                    Debug.toString(certId.getSerialNumber()) +
+                    ") is: " + sr.getCertStatus());
             }
         }
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/RevocationChecker.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/RevocationChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -360,7 +360,7 @@ class RevocationChecker extends PKIXRevocationChecker {
     {
         if (debug != null) {
             debug.println("RevocationChecker.check: checking cert" +
-                    "\n  SN: " + Debug.toHexString(xcert.getSerialNumber()) +
+                    "\n  SN: " + Debug.toString(xcert.getSerialNumber()) +
                     "\n  Subject: " + xcert.getSubjectX500Principal() +
                     "\n  Issuer: " + xcert.getIssuerX500Principal());
         }
@@ -655,7 +655,7 @@ class RevocationChecker extends PKIXRevocationChecker {
             debug.println("RevocationChecker.checkApprovedCRLs() " +
                     "starting the final sweep...");
             debug.println("RevocationChecker.checkApprovedCRLs()" +
-                    " cert SN: " + sn.toString());
+                    " cert SN: " + Debug.toString(sn));
         }
 
         CRLReason reasonCode = CRLReason.UNSPECIFIED;

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/Vertex.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/Vertex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -142,7 +142,7 @@ public class Vertex {
         sb.append("Subject:    ").append
                 (x509Cert.getSubjectX500Principal()).append("\n");
         sb.append("SerialNum:  ").append
-                (x509Cert.getSerialNumber().toString(16)).append("\n");
+                (Debug.toString(x509Cert.getSerialNumber())).append("\n");
         sb.append("Expires:    ").append
                 (x509Cert.getNotAfter().toString()).append("\n");
         boolean[] iUID = x509Cert.getIssuerUniqueID();

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/SSLLogger.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/SSLLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package com.tencent.kona.sun.security.util;
 
 import com.tencent.kona.sun.security.action.GetPropertyAction;
+import com.tencent.kona.sun.security.util.Debug;
 import com.tencent.kona.sun.security.x509.CertificateExtensions;
 import com.tencent.kona.sun.security.x509.X509CertImpl;
 import com.tencent.kona.sun.security.x509.X509CertInfo;
@@ -476,8 +477,7 @@ public class SSLLogger {
                 if (certExts == null) {
                     Object[] certFields = {
                             x509.getVersion(),
-                            Utilities.toHexString(
-                                    x509.getSerialNumber().toByteArray()),
+                            Debug.toString(x509.getSerialNumber()),
                             x509.getSigAlgName(),
                             x509.getIssuerX500Principal().toString(),
                             dateFormat.get().format(x509.getNotBefore()),
@@ -501,8 +501,7 @@ public class SSLLogger {
                     }
                     Object[] certFields = {
                             x509.getVersion(),
-                            Utilities.toHexString(
-                                    x509.getSerialNumber().toByteArray()),
+                            Debug.toString(x509.getSerialNumber()),
                             x509.getSigAlgName(),
                             x509.getIssuerX500Principal().toString(),
                             dateFormat.get().format(x509.getNotBefore()),

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SerialNumber.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SerialNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,7 +104,7 @@ public class SerialNumber {
      * Return the SerialNumber as user readable string.
      */
     public String toString() {
-        return "SerialNumber: [" + Debug.toHexString(serialNum) + ']';
+        return "SerialNumber: " + Debug.toString(serialNum);
     }
 
     /**

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/StatusResponseManager.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/StatusResponseManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,7 @@ import com.tencent.kona.sun.security.provider.certpath.ResponderId;
 import com.tencent.kona.sun.security.ssl.CertStatusExtension.*;
 import com.tencent.kona.sun.security.ssl.X509Authentication.X509Possession;
 import com.tencent.kona.sun.security.util.Cache;
+import com.tencent.kona.sun.security.util.Debug;
 import com.tencent.kona.sun.security.x509.PKIXExtensions;
 import com.tencent.kona.sun.security.x509.SerialNumber;
 
@@ -336,8 +337,8 @@ final class StatusResponseManager {
 
         if (SSLLogger.isOn && SSLLogger.isOn("respmgr")) {
             SSLLogger.fine(
-                    "Check cache for SN" + cid.getSerialNumber() + ": " +
-                    (respEntry != null ? "HIT" : "MISS"));
+                    "Check cache for SN" + Debug.toString(cid.getSerialNumber())
+                    + ": " + (respEntry != null ? "HIT" : "MISS"));
         }
         return respEntry;
     }
@@ -403,7 +404,7 @@ final class StatusResponseManager {
         public String toString() {
             return "StatusInfo:" + "\n\tCert: " +
                    this.cert.getSubjectX500Principal() +
-                   "\n\tSerial: " + this.cert.getSerialNumber() +
+                   "\n\tSerial: " + Debug.toString(this.cert.getSerialNumber()) +
                    "\n\tResponder: " + this.responder +
                    "\n\tResponse data: " +
                    (this.responseData != null ?
@@ -449,7 +450,7 @@ final class StatusResponseManager {
                 } else {
                     throw new IOException(
                             "Unable to find SingleResponse for SN " +
-                            cid.getSerialNumber());
+                            Debug.toString(cid.getSerialNumber()));
                 }
             } else {
                 nextUpdate = null;
@@ -500,7 +501,7 @@ final class StatusResponseManager {
             if (SSLLogger.isOn && SSLLogger.isOn("respmgr")) {
                 SSLLogger.fine(
                     "Starting fetch for SN " +
-                    statInfo.cid.getSerialNumber());
+                    Debug.toString(statInfo.cid.getSerialNumber()));
             }
             try {
                 ResponseCacheEntry cacheEntry;
@@ -585,7 +586,7 @@ final class StatusResponseManager {
                 if (SSLLogger.isOn && SSLLogger.isOn("respmgr")) {
                     SSLLogger.fine(
                         "Added response for SN " +
-                        certId.getSerialNumber() +
+                        Debug.toString(certId.getSerialNumber()) +
                         " to cache");
                 }
             }


### PR DESCRIPTION
This is a backport of [JDK-8296787]: Unify debug printing format of X.509 cert serial numbers.

This PR will resolves #597.

[JDK-8296787]:
https://bugs.openjdk.org/browse/JDK-8296787