### PR TITLE
TKSS-601: Upgrade BouncyCastle to 1.77

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@
 #
 
 [versions]
-bouncycastle = "1.76"
+bouncycastle = "1.77"
 
 grpc = "1.58.0"
 tomcat = "9.0.78"


### PR DESCRIPTION
BouncyCastle 1.77 was released last month.
It would be better to upgrade the test dependency on this component.

This PR will resolves #601.