### PR TITLE
TKSS-604: TLS13_SM_ID would be private

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SignatureScheme.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SignatureScheme.java
@@ -234,6 +234,12 @@ enum SignatureScheme {
     private static final Set<CryptoPrimitive> SIGNATURE_PRIMITIVE_SET =
         Collections.unmodifiableSet(EnumSet.of(CryptoPrimitive.SIGNATURE));
 
+    // This ID, exactly TLSv1.3+GM+Cipher+Suite, is defined by RFC 8998.
+    // It is only used by signature scheme sm2sig_sm3 for TLS 1.3 handshaking.
+    private static final byte[] TLS13_SM2_ID = new byte[] {
+            0x54, 0x4c, 0x53, 0x76, 0x31, 0x2e, 0x33, 0x2b,
+            0x47, 0x4d, 0x2b, 0x43, 0x69, 0x70, 0x68, 0x65,
+            0x72, 0x2b, 0x53, 0x75, 0x69, 0x74, 0x65};
 
     private SignatureScheme(int id, String name,
             String algorithm, String keyAlgorithm,
@@ -605,7 +611,7 @@ enum SignatureScheme {
         // sm2sig_sm3 uses "TLSv1.3+GM+Cipher+Suite" as ID for TLS 1.3.
         if (this == SM2SIG_SM3 && isTLS13) {
             verifier.setParameter(new SM2SignatureParameterSpec(
-                    Utilities.TLS13_SM_ID, (ECPublicKey) publicKey));
+                    TLS13_SM2_ID, (ECPublicKey) publicKey));
         }
 
         SignatureUtil.initVerifyWithParam(verifier, publicKey,
@@ -636,7 +642,7 @@ enum SignatureScheme {
             // And it uses "TLSv1.3+GM+Cipher+Suite" as ID for TLS 1.3.
             if (this == SM2SIG_SM3) {
                 SM2SignatureParameterSpec paramSpec = isTLS13
-                        ? new SM2SignatureParameterSpec(Utilities.TLS13_SM_ID,
+                        ? new SM2SignatureParameterSpec(TLS13_SM2_ID,
                                 (ECPublicKey) publicKey)
                         : new SM2SignatureParameterSpec((ECPublicKey) publicKey);
                 signer.setParameter(paramSpec);

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/Utilities.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/Utilities.java
@@ -25,10 +25,6 @@ import java.nio.charset.StandardCharsets;
 
 public class Utilities extends com.tencent.kona.sun.security.util.Utilities {
 
-    // The ID used by TLS 1.3 handshaking with signature scheme SM3withSM2.
-    public static final byte[] TLS13_SM_ID
-            = "TLSv1.3+GM+Cipher+Suite".getBytes(StandardCharsets.ISO_8859_1);
-
     public static final boolean SUPPORT_ALPN = supportALPN();
 
     private static boolean supportALPN() {


### PR DESCRIPTION
`TLS13_SM_ID` is used by `SignatureScheme` only, so it is unnecessary to expose it.

This PR will resolves #604.