### PR TITLE
TKSS-600: Test and demos would not use XXXInsts classes

### DIFF
--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
@@ -307,7 +307,7 @@ public class TestUtils {
     public static KeyStore trustStore(String[] aliases, String[] certStrs)
             throws KeyStoreException, CertificateException, IOException,
             NoSuchAlgorithmException, NoSuchProviderException {
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         keyStore.load(null, null);
 
         for (int i = 0; i < aliases.length; i++) {
@@ -319,7 +319,7 @@ public class TestUtils {
 
     public static KeyStore keyStore(String alias, String keyStr,
             char[] password, String[] certStrs) throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");;
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         keyStore.load(null, null);
 
         keyStore.setKeyEntry(

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/demo/PKIDemo.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/demo/PKIDemo.java
@@ -19,8 +19,6 @@
 
 package com.tencent.kona.pkix.demo;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.pkix.PKIXInsts;
 import com.tencent.kona.pkix.TestUtils;
 import org.junit.jupiter.api.Test;
 
@@ -218,7 +216,7 @@ public class PKIDemo {
                 = (X509Certificate) keyStore.getCertificate("ee-demo");
         CertPath certPath = createCertPath(new X509Certificate[] { eeCert });
 
-        CertPathValidator validator = PKIXInsts.getCertPathValidator("PKIX");
+        CertPathValidator validator = CertPathValidator.getInstance("PKIX", "KonaPKIX");
 
         // Validate the cert path with the trusted CA,
         // and not check the revocation status.
@@ -259,7 +257,7 @@ public class PKIDemo {
         X509Certificate eeCert = loadCert(eeStr);
 
         // Create a PKCS#12 key store
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         keyStore.load(null, null);
 
         // Add the CA as trusted certificate
@@ -279,8 +277,8 @@ public class PKIDemo {
 
     // Load a certificate
     private static X509Certificate loadCert(String certPEM) throws Exception {
-        CertificateFactory certFactory = PKIXInsts.getCertificateFactory(
-                "X.509");
+        CertificateFactory certFactory = CertificateFactory.getInstance(
+                "X.509", "KonaPKIX");
         return (X509Certificate) certFactory.generateCertificate(
                 new ByteArrayInputStream(certPEM.getBytes()));
     }
@@ -289,21 +287,21 @@ public class PKIDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = CryptoInsts.getKeyFactory("EC");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
         return keyFactory.generatePrivate(privateKeySpec);
     }
 
     // Create a certificate path from a certificate collection
     private static CertPath createCertPath(X509Certificate[] certChain)
             throws Exception {
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
         return cf.generateCertPath(Arrays.asList(certChain));
     }
 
     // Load a certificate revocation list
     private static X509CRL loadCrl(String crlPEM) throws Exception {
-        CertificateFactory certFactory = PKIXInsts.getCertificateFactory(
-                "X.509");
+        CertificateFactory certFactory = CertificateFactory.getInstance(
+                "X.509", "KonaPKIX");
         return (X509CRL) certFactory.generateCRL(
                 new ByteArrayInputStream(crlPEM.getBytes()));
     }
@@ -311,7 +309,7 @@ public class PKIDemo {
     // Create a cert store with certificate revocation lists
     private static CertStore createCertStore(Collection<X509CRL> crls)
             throws Exception {
-        return PKIXInsts.getCertStore("Collection",
-                new CollectionCertStoreParameters(crls));
+        return CertStore.getInstance("Collection",
+                new CollectionCertStoreParameters(crls), "KonaPKIX");
     }
 }

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/demo/SignatureDemo.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/demo/SignatureDemo.java
@@ -19,8 +19,6 @@
 
 package com.tencent.kona.pkix.demo;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.pkix.PKIXInsts;
 import com.tencent.kona.pkix.PKIXUtils;
 import com.tencent.kona.pkix.TestUtils;
 import org.junit.jupiter.api.Assertions;
@@ -109,13 +107,13 @@ public class SignatureDemo {
     @Test
     public void testSignature() throws Exception {
         PrivateKey privateKey = privateKey(KEY);
-        Signature signer = CryptoInsts.getSignature("SM3withSM2");
+        Signature signer = Signature.getInstance("SM3withSM2", "KonaCrypto");
         signer.initSign(privateKey);
         signer.update(DATA);
         byte[] sign = signer.sign();
 
         Certificate certificate = certificate(CERT);
-        Signature verifier = CryptoInsts.getSignature("SM3withSM2");
+        Signature verifier = Signature.getInstance("SM3withSM2", "KonaCrypto");
         verifier.initVerify(certificate);
         verifier.update(DATA);
         boolean verified = verifier.verify(sign);
@@ -127,8 +125,8 @@ public class SignatureDemo {
             InvalidKeySpecException, NoSuchProviderException {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(removeBELines(pkcs8PEM)));
-        KeyFactory keyFactory = CryptoInsts.getKeyFactory(
-                "EC");
+        KeyFactory keyFactory = KeyFactory.getInstance(
+                "EC", "KonaCrypto");
         return keyFactory.generatePrivate(privateKeySpec);
     }
 
@@ -139,8 +137,8 @@ public class SignatureDemo {
 
     private static Certificate certificate(String certPEM)
             throws CertificateException, NoSuchProviderException {
-        CertificateFactory certFactory = PKIXInsts.getCertificateFactory(
-                "X.509");
+        CertificateFactory certFactory = CertificateFactory.getInstance(
+                "X.509", "KonaPKIX");
         return certFactory.generateCertificate(
                 new ByteArrayInputStream(certPEM.getBytes(StandardCharsets.UTF_8)));
     }
@@ -149,13 +147,13 @@ public class SignatureDemo {
     @Test
     public void testSignatureWithCustomAPI() throws Exception {
         PrivateKey privateKey = PKIXUtils.getPrivateKey("EC", KEY);
-        Signature signer = CryptoInsts.getSignature("SM3withSM2");
+        Signature signer = Signature.getInstance("SM3withSM2", "KonaCrypto");
         signer.initSign(privateKey);
         signer.update(DATA);
         byte[] sign = signer.sign();
 
         Certificate certificate = PKIXUtils.getCertificate(CERT);
-        Signature verifier = CryptoInsts.getSignature("SM3withSM2");
+        Signature verifier = Signature.getInstance("SM3withSM2", "KonaCrypto");
         verifier.initVerify(certificate);
         verifier.update(DATA);
         Assertions.assertTrue(verifier.verify(sign));

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertPathBuilderTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertPathBuilderTest.java
@@ -20,7 +20,6 @@
 package com.tencent.kona.pkix.provider;
 
 import com.tencent.kona.pkix.KonaPKIXProvider;
-import com.tencent.kona.pkix.PKIXInsts;
 import com.tencent.kona.pkix.TestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -52,7 +51,7 @@ public class CertPathBuilderTest {
 
     @Test
     public void testGetCertPathBuilder() throws Exception {
-        CertPathBuilder cpb = PKIXInsts.getCertPathBuilder("PKIX");
+        CertPathBuilder cpb = CertPathBuilder.getInstance("PKIX", "KonaPKIX");
         Assertions.assertTrue(cpb.getProvider() instanceof KonaPKIXProvider);
     }
 
@@ -79,11 +78,11 @@ public class CertPathBuilderTest {
         Collection<X509Certificate> certs = new HashSet<>();
         certs.add(TestUtils.certAsFile(ee));
         certs.add(TestUtils.certAsFile(intCa));
-        CertStore certStore = PKIXInsts.getCertStore("Collection",
-                new CollectionCertStoreParameters(certs));
+        CertStore certStore = CertStore.getInstance("Collection",
+                new CollectionCertStoreParameters(certs), "KonaPKIX");
         params.addCertStore(certStore);
 
-        CertPathBuilder cpb = PKIXInsts.getCertPathBuilder("PKIX");
+        CertPathBuilder cpb = CertPathBuilder.getInstance("PKIX", "KonaPKIX");
         CertPathBuilderResult result = cpb.build(params);
         CertPath certPath = result.getCertPath();
 

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertPathValidatorTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertPathValidatorTest.java
@@ -20,7 +20,6 @@
 package com.tencent.kona.pkix.provider;
 
 import com.tencent.kona.pkix.KonaPKIXProvider;
-import com.tencent.kona.pkix.PKIXInsts;
 import com.tencent.kona.pkix.TestUtils;
 import com.tencent.kona.pkix.SimpleOCSPServer;
 import com.tencent.kona.sun.security.x509.SMCertificate;
@@ -72,7 +71,7 @@ public class CertPathValidatorTest {
 
     @Test
     public void testGetCertPathValidator() throws Exception {
-        CertPathValidator cpv = PKIXInsts.getCertPathValidator("PKIX");
+        CertPathValidator cpv = CertPathValidator.getInstance("PKIX", "KonaPKIX");
         Assertions.assertTrue(cpv.getProvider() instanceof KonaPKIXProvider);
     }
 
@@ -403,7 +402,7 @@ public class CertPathValidatorTest {
     private void validateWithCrl(String[] certChain, String[] ids,
             String[] cas, String[] crls, boolean checkCertStatus,
             Class<? extends Exception> expectedEx) throws Exception {
-        CertPathValidator cpv = PKIXInsts.getCertPathValidator("PKIX");
+        CertPathValidator cpv = CertPathValidator.getInstance("PKIX", "KonaPKIX");
         try {
             cpv.validate(certPath(certChain, ids), certPathParams(
                     cas, crls, checkCertStatus));
@@ -434,7 +433,7 @@ public class CertPathValidatorTest {
             certs.add(x509Cert);
         }
 
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");;
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");;
         return cf.generateCertPath(certs);
     }
 
@@ -459,8 +458,8 @@ public class CertPathValidatorTest {
             for (String crl : crls) {
                 x509Crls.add(TestUtils.crlAsFile(crl));
             }
-            CertStore certStore = PKIXInsts.getCertStore("Collection",
-                    new CollectionCertStoreParameters(x509Crls));
+            CertStore certStore = CertStore.getInstance("Collection",
+                    new CollectionCertStoreParameters(x509Crls), "KonaPKIX");
             params.addCertStore(certStore);
         }
 
@@ -469,7 +468,7 @@ public class CertPathValidatorTest {
 
     private SimpleOCSPServer createOCSPServer(
             String issuerCertName, String issuerKeyName) throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         keyStore.load(null, null);
 
         String password = "password";

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertStoreTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertStoreTest.java
@@ -20,7 +20,6 @@
 package com.tencent.kona.pkix.provider;
 
 import com.tencent.kona.pkix.KonaPKIXProvider;
-import com.tencent.kona.pkix.PKIXInsts;
 import com.tencent.kona.pkix.TestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -46,8 +45,8 @@ public class CertStoreTest {
 
     @Test
     public void testGetCertStore() throws Exception {
-        CertStore certStore = PKIXInsts.getCertStore("Collection",
-                new CollectionCertStoreParameters());
+        CertStore certStore = CertStore.getInstance("Collection",
+                new CollectionCertStoreParameters(), "KonaPKIX");
         Assertions.assertTrue(certStore.getProvider() instanceof KonaPKIXProvider);
     }
 
@@ -75,8 +74,8 @@ public class CertStoreTest {
         certs.add(TestUtils.certAsFile(intCa));
         certs.add(TestUtils.certAsFile(ca));
 
-        CertStore certStore = PKIXInsts.getCertStore("Collection",
-                new CollectionCertStoreParameters(certs));
+        CertStore certStore = CertStore.getInstance("Collection",
+                new CollectionCertStoreParameters(certs), "KonaPKIX");
 
         X509CertSelector certSelector = new X509CertSelector();
         certSelector.setCertificate(target);

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertificateFactoryTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertificateFactoryTest.java
@@ -21,7 +21,6 @@ package com.tencent.kona.pkix.provider;
 
 import com.tencent.kona.crypto.util.Constants;
 import com.tencent.kona.pkix.KonaPKIXProvider;
-import com.tencent.kona.pkix.PKIXInsts;
 import com.tencent.kona.pkix.TestUtils;
 import com.tencent.kona.sun.security.util.KnownOIDs;
 import com.tencent.kona.sun.security.util.ObjectIdentifier;
@@ -57,13 +56,13 @@ public class CertificateFactoryTest {
 
     @Test
     public void testGetCertificateFactory() throws Exception {
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");;
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
         Assertions.assertTrue(cf.getProvider() instanceof KonaPKIXProvider);
     }
 
     @Test
     public void testGenCertCaRsaRsa() throws Exception {
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
         X509Certificate cert = (X509Certificate) cf.generateCertificate(
                 new ByteArrayInputStream(TestUtils.certBytes("ca-rsarsa.crt")));
         RSAPublicKey pubKey = (RSAPublicKey) cert.getPublicKey();
@@ -74,7 +73,7 @@ public class CertificateFactoryTest {
 
     @Test
     public void testGenCertCaP256Ecdsa() throws Exception {
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
         X509Certificate cert = (X509Certificate) cf.generateCertificate(
                 new ByteArrayInputStream(TestUtils.certBytes("ca-p256ecdsa.crt")));
         ECPublicKey pubKey = (ECPublicKey) cert.getPublicKey();
@@ -85,7 +84,7 @@ public class CertificateFactoryTest {
 
     @Test
     public void testGenCertCaP256Sm2() throws Exception {
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
         X509Certificate cert = (X509Certificate) cf.generateCertificate(
                 new ByteArrayInputStream(TestUtils.certBytes("ca-p256sm2.crt")));
         ECPublicKey pubKey = (ECPublicKey) cert.getPublicKey();
@@ -98,7 +97,7 @@ public class CertificateFactoryTest {
 
     @Test
     public void testGenCertCaSm2Ecdsa() throws Exception {
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
         X509Certificate cert = (X509Certificate) cf.generateCertificate(
                 new ByteArrayInputStream(TestUtils.certBytes("ca-sm2ecdsa.crt")));
         ECPublicKey pubKey = (ECPublicKey) cert.getPublicKey();
@@ -111,7 +110,7 @@ public class CertificateFactoryTest {
 
     @Test
     public void testGenCertCaSm2Sm2() throws Exception {
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
         X509Certificate cert = (X509Certificate) cf.generateCertificate(
                 new ByteArrayInputStream(TestUtils.certBytes("ca-sm2sm2.crt")));
         ECPublicKey pubKey = (ECPublicKey) cert.getPublicKey();
@@ -124,7 +123,7 @@ public class CertificateFactoryTest {
 
     @Test
     public void testSetId() throws Exception {
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
         SMCertificate sm2Cert = (SMCertificate) cf.generateCertificate(
                 new ByteArrayInputStream(TestUtils.certBytes("ca-sm2sm2-id.crt")));
         Assertions.assertArrayEquals(
@@ -157,7 +156,7 @@ public class CertificateFactoryTest {
                 "ca-sm2sm2.crt",
                 "ca-sm2ecdsa.crt").getBytes(StandardCharsets.UTF_8);
 
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
         Collection<? extends Certificate> certs = cf.generateCertificates(
                 new ByteArrayInputStream(certBytes));
         Iterator<? extends Certificate> iterator = certs.iterator();
@@ -175,7 +174,7 @@ public class CertificateFactoryTest {
 
     @Test
     public void testGetCertPathEncodings() throws Exception {
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
         Iterator<String> it = cf.getCertPathEncodings();
         Assertions.assertEquals("PkiPath", it.next());
         Assertions.assertEquals("PKCS7", it.next());
@@ -190,7 +189,7 @@ public class CertificateFactoryTest {
         certs.add(TestUtils.certAsFile("ca-sm2sm2.crt"));
         certs.add(TestUtils.certAsFile("ca-sm2ecdsa.crt"));
 
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
 
         CertPath certPath = cf.generateCertPath(certs);
         Assertions.assertEquals(certs.size(), certPath.getCertificates().size());
@@ -221,7 +220,7 @@ public class CertificateFactoryTest {
 
     private void testGenCRL(String crlFileName, ObjectIdentifier sigAlgOid)
             throws Exception {
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
         X509CRL crl = (X509CRL) cf.generateCRL(new ByteArrayInputStream(
                 TestUtils.crlBytes(crlFileName)));
         Assertions.assertEquals(sigAlgOid.toString(), crl.getSigAlgOID());
@@ -229,7 +228,7 @@ public class CertificateFactoryTest {
 
     @Test
     public void testGenCRLs() throws Exception {
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
 
         @SuppressWarnings("unchecked")
         List<? extends X509CRL> crls = (List<? extends X509CRL>) cf.generateCRLs(

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/KeyFactoryTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/KeyFactoryTest.java
@@ -19,8 +19,6 @@
 
 package com.tencent.kona.pkix.provider;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.sun.security.pkcs.PKCS8Key;
 import com.tencent.kona.sun.security.x509.X509Key;
 import com.tencent.kona.pkix.TestUtils;
 import org.junit.jupiter.api.Assertions;
@@ -57,7 +55,7 @@ public class KeyFactoryTest {
         X509Certificate x509Cert = TestUtils.certAsFile("ca-sm2sm2.crt");
         PublicKey publicKey = x509Cert.getPublicKey();
 
-        KeyFactory keyFactory = CryptoInsts.getKeyFactory("EC");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
 
         ECPublicKeySpec publicKeySpec = keyFactory.getKeySpec(
                 publicKey, ECPublicKeySpec.class);
@@ -83,7 +81,7 @@ public class KeyFactoryTest {
         X509Certificate x509Cert = TestUtils.certAsFile("ca-sm2sm2.crt");
         ECPublicKey publicKey = (ECPublicKey) x509Cert.getPublicKey();
 
-        KeyFactory keyFactory = CryptoInsts.getKeyFactory("EC");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
 
         ECPublicKeySpec ecPublicKeySpec = keyFactory.getKeySpec(
                 publicKey, ECPublicKeySpec.class);
@@ -134,7 +132,7 @@ public class KeyFactoryTest {
 
     private void testGenerateRSAPrivateKey(RSAPrivateKey privateKey)
             throws Exception {
-        KeyFactory keyFactory = CryptoInsts.getKeyFactory("RSA");
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
 
         RSAPrivateKeySpec rsaPrivateKeySpec = keyFactory.getKeySpec(
                 privateKey, RSAPrivateKeySpec.class);
@@ -154,7 +152,7 @@ public class KeyFactoryTest {
 
     private void testGenerateECPrivateKey(ECPrivateKey privateKey)
             throws Exception {
-        KeyFactory keyFactory = CryptoInsts.getKeyFactory("EC");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
 
         ECPrivateKeySpec ecPrivateKeySpec = keyFactory.getKeySpec(
                 privateKey, ECPrivateKeySpec.class);

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/KeyStoreTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/KeyStoreTest.java
@@ -20,7 +20,6 @@
 package com.tencent.kona.pkix.provider;
 
 import com.tencent.kona.crypto.spec.SM2ParameterSpec;
-import com.tencent.kona.pkix.PKIXInsts;
 import com.tencent.kona.pkix.TestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -61,7 +60,7 @@ public class KeyStoreTest {
     }
 
     private void testGetKeyStore(String type) throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore(type);
+        KeyStore keyStore = KeyStore.getInstance(type, "KonaPKIX");
         Assertions.assertEquals(
                 PROVIDER, keyStore.getProvider().getName());
         Assertions.assertEquals(type, keyStore.getType());
@@ -74,7 +73,7 @@ public class KeyStoreTest {
     }
 
     private void testCreateTrustStore(String type) throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore(type);
+        KeyStore keyStore = KeyStore.getInstance(type, "KonaPKIX");
         keyStore.load(null, null);
 
         keyStore.setCertificateEntry("ca-rsarsa",
@@ -121,7 +120,7 @@ public class KeyStoreTest {
     }
 
     private void testCreateKeyStore(String type) throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore(type);
+        KeyStore keyStore = KeyStore.getInstance(type, "KonaPKIX");
         keyStore.load(null, null);
 
         keyStore.setKeyEntry(
@@ -222,7 +221,7 @@ public class KeyStoreTest {
 
     @Test
     public void testCreatePKCS12KeyStoreLoadEncryptedKey() throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         keyStore.load(null, null);
 
         keyStore.setKeyEntry(
@@ -267,7 +266,7 @@ public class KeyStoreTest {
     }
 
     private void testSaveAndLoadKeyStore(String type) throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore(type);
+        KeyStore keyStore = KeyStore.getInstance(type, "KonaPKIX");
         keyStore.load(null, null);
 
         keyStore.setCertificateEntry("ca-rsarsa",
@@ -309,7 +308,7 @@ public class KeyStoreTest {
             keyStore.store(out, PASSWD_CHARS);
         }
 
-        KeyStore loadedKeyStore = PKIXInsts.getKeyStore(type);
+        KeyStore loadedKeyStore = KeyStore.getInstance(type, "KonaPKIX");
         try (FileInputStream keyStoreIn
                 = new FileInputStream(tempKeyStoreFile.toFile())) {
             loadedKeyStore.load(keyStoreIn, PASSWD_CHARS);
@@ -341,7 +340,7 @@ public class KeyStoreTest {
             String loadProvider) throws Exception {
         KeyStore keyStore = null;
         if ("JDK".equals(genProvider)) {
-            keyStore = PKIXInsts.getKeyStore(type);
+            keyStore = KeyStore.getInstance(type, "KonaPKIX");
         } else {
             keyStore = KeyStore.getInstance(type, genProvider);
         }
@@ -367,7 +366,7 @@ public class KeyStoreTest {
 
         KeyStore loadedKeyStore = null;
         if ("JDK".equals(loadProvider)) {
-            loadedKeyStore = PKIXInsts.getKeyStore(type);
+            loadedKeyStore = KeyStore.getInstance(type, "KonaPKIX");
         } else {
             loadedKeyStore = KeyStore.getInstance(type, loadProvider);
         }

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/tool/KeyStoreToolTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/tool/KeyStoreToolTest.java
@@ -19,7 +19,6 @@
 
 package com.tencent.kona.pkix.tool;
 
-import com.tencent.kona.pkix.PKIXInsts;
 import com.tencent.kona.pkix.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -120,7 +119,7 @@ public class KeyStoreToolTest {
         KeyStoreTool.main(args);
         Assertions.assertTrue(Files.exists(storePath));
 
-        KeyStore trustStore = PKIXInsts.getKeyStore(type);
+        KeyStore trustStore = KeyStore.getInstance(type, "KonaPKIX");
         try (InputStream in = new FileInputStream(storePath.toString())) {
             trustStore.load(in, storePasswd.toCharArray());
         }
@@ -173,7 +172,7 @@ public class KeyStoreToolTest {
                 "-storePasswd", storePasswd };
         KeyStoreTool.main(encArgs);
 
-        KeyStore trustStore = PKIXInsts.getKeyStore(type);
+        KeyStore trustStore = KeyStore.getInstance(type, "KonaPKIX");
         try (InputStream in = new FileInputStream(storePath.toString())) {
             trustStore.load(in, storePasswd.toCharArray());
         }

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/TestUtils.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/TestUtils.java
@@ -22,7 +22,6 @@ package com.tencent.kona.ssl;
 import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.crypto.KonaCryptoProvider;
 import com.tencent.kona.pkix.KonaPKIXProvider;
-import com.tencent.kona.pkix.PKIXInsts;
 
 import javax.crypto.Cipher;
 import javax.crypto.EncryptedPrivateKeyInfo;
@@ -341,7 +340,7 @@ public class TestUtils {
     public static KeyStore trustStore(String[] aliases, String[] certStrs)
             throws KeyStoreException, CertificateException, IOException,
             NoSuchAlgorithmException, NoSuchProviderException {
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         keyStore.load(null, null);
 
         for (int i = 0; i < aliases.length; i++) {
@@ -353,7 +352,7 @@ public class TestUtils {
 
     public static KeyStore keyStore(String alias, String keyStr,
             char[] password, String[] certStrs) throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");;
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");;
         keyStore.load(null, null);
 
         keyStore.setKeyEntry(

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithGRPCDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithGRPCDemo.java
@@ -19,9 +19,6 @@
 
 package com.tencent.kona.ssl.demo;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.pkix.PKIXInsts;
-import com.tencent.kona.ssl.SSLInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import io.grpc.Channel;
@@ -289,23 +286,23 @@ public class TLCPWithGRPCDemo {
 
     private static SSLContext createContext() throws Exception {
         KeyStore trustStore = createTrustStore(CA, null);
-        TrustManagerFactory tmf = SSLInsts.getTrustManagerFactory("PKIX");
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX", "KonaSSL");
         tmf.init(trustStore);
 
         KeyStore keyStore = createKeyStore(
                 SIGN_EE, SIGN_EE_ID, SIGN_EE_KEY,
                 ENC_EE, ENC_EE_ID, ENC_EE_KEY);
-        KeyManagerFactory kmf = SSLInsts.getKeyManagerFactory("NewSunX509");
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509", "KonaSSL");
         kmf.init(keyStore, PASSWORD.toCharArray());
 
-        SSLContext context = SSLInsts.getSSLContext("TLCPv1.1");
+        SSLContext context = SSLContext.getInstance("TLCPv1.1", "KonaSSL");
         context.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
         return context;
     }
 
     private static KeyStore createTrustStore(String caStr, String caId)
             throws Exception {
-        KeyStore trustStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore trustStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         trustStore.load(null, null);
         trustStore.setCertificateEntry("tlcp-trust-demo", loadCert(caStr, caId));
         return trustStore;
@@ -315,7 +312,7 @@ public class TLCPWithGRPCDemo {
             String signEeStr, String signEeId, String signEeKeyStr,
             String encEeStr, String encEeId, String encEeKeyStr)
             throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         keyStore.load(null, null);
 
         keyStore.setKeyEntry("tlcp-sign-ee-demo",
@@ -332,8 +329,8 @@ public class TLCPWithGRPCDemo {
 
     private static X509Certificate loadCert(String certPEM, String id)
             throws Exception {
-        CertificateFactory certFactory = PKIXInsts.getCertificateFactory(
-                "X.509");
+        CertificateFactory certFactory = CertificateFactory.getInstance(
+                "X.509", "KonaPKIX");
         X509Certificate x509Cert = (X509Certificate) certFactory.generateCertificate(
                 new ByteArrayInputStream(certPEM.getBytes()));
 
@@ -348,7 +345,7 @@ public class TLCPWithGRPCDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = CryptoInsts.getKeyFactory("EC");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithHttpClientDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithHttpClientDemo.java
@@ -19,9 +19,6 @@
 
 package com.tencent.kona.ssl.demo;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.pkix.PKIXInsts;
-import com.tencent.kona.ssl.SSLInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -285,7 +282,7 @@ public class TLCPWithHttpClientDemo {
 
     private static void createTrustStoreFile(String caStr, String caId)
             throws Exception {
-        KeyStore trustStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore trustStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         trustStore.load(null, null);
         trustStore.setCertificateEntry("tlcp-trust-demo", loadCert(caStr, caId));
         try (FileOutputStream out = new FileOutputStream(TRUSTSTORE.toFile())) {
@@ -297,7 +294,7 @@ public class TLCPWithHttpClientDemo {
             String signEeStr, String signEeId, String signEeKeyStr,
             String encEeStr, String encEeId, String encEeKeyStr)
             throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         keyStore.load(null, null);
 
         keyStore.setKeyEntry("tlcp-sign-ee-demo",
@@ -316,8 +313,8 @@ public class TLCPWithHttpClientDemo {
 
     private static X509Certificate loadCert(String certPEM, String id)
             throws Exception {
-        CertificateFactory certFactory = PKIXInsts.getCertificateFactory(
-                "X.509");
+        CertificateFactory certFactory = CertificateFactory.getInstance(
+                "X.509", "KonaPKIX");
         X509Certificate x509Cert = (X509Certificate) certFactory.generateCertificate(
                 new ByteArrayInputStream(certPEM.getBytes()));
 
@@ -332,7 +329,7 @@ public class TLCPWithHttpClientDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = CryptoInsts.getKeyFactory("EC");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC");
         return keyFactory.generatePrivate(privateKeySpec);
     }
 
@@ -404,25 +401,25 @@ public class TLCPWithHttpClientDemo {
 
     private static SSLContext createContext() throws Exception {
         // Load trust store
-        KeyStore trustStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore trustStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         try (FileInputStream keyStoreIn = new FileInputStream(
                 TRUSTSTORE.toFile())) {
             trustStore.load(keyStoreIn, PASSWORD.toCharArray());
         }
 
-        TrustManagerFactory tmf = SSLInsts.getTrustManagerFactory("PKIX");
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX", "KonaSSL");
         tmf.init(trustStore);
 
         // Load key store
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         try (FileInputStream keyStoreIn = new FileInputStream(
                 KEYSTORE.toFile())) {
             keyStore.load(keyStoreIn, PASSWORD.toCharArray());
         }
-        KeyManagerFactory kmf = SSLInsts.getKeyManagerFactory("NewSunX509");
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509", "KonaSSL");
         kmf.init(keyStore, PASSWORD.toCharArray());
 
-        SSLContext context = SSLInsts.getSSLContext("TLCPv1.1");
+        SSLContext context = SSLContext.getInstance("TLCPv1.1", "KonaSSL");
         context.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
         return context;
     }

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithJettyDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithJettyDemo.java
@@ -19,9 +19,6 @@
 
 package com.tencent.kona.ssl.demo;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.pkix.PKIXInsts;
-import com.tencent.kona.ssl.SSLInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import org.eclipse.jetty.client.HttpClient;
@@ -308,23 +305,23 @@ public class TLCPWithJettyDemo {
 
     private static SSLContext createContext() throws Exception {
         KeyStore trustStore = createTrustStore(CA, null);
-        TrustManagerFactory tmf = SSLInsts.getTrustManagerFactory("PKIX");
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX", "KonaSSL");
         tmf.init(trustStore);
 
         KeyStore keyStore = createKeyStore(
                 SIGN_EE, SIGN_EE_ID, SIGN_EE_KEY,
                 ENC_EE, ENC_EE_ID, ENC_EE_KEY);
-        KeyManagerFactory kmf = SSLInsts.getKeyManagerFactory("NewSunX509");
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509", "KonaSSL");
         kmf.init(keyStore, PASSWORD.toCharArray());
 
-        SSLContext context = SSLInsts.getSSLContext("TLCPv1.1");
+        SSLContext context = SSLContext.getInstance("TLCPv1.1", "KonaSSL");
         context.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
         return context;
     }
 
     private static KeyStore createTrustStore(String caStr, String caId)
             throws Exception {
-        KeyStore trustStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore trustStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         trustStore.load(null, null);
         trustStore.setCertificateEntry("tlcp-trust-demo", loadCert(caStr, caId));
         return trustStore;
@@ -334,7 +331,7 @@ public class TLCPWithJettyDemo {
             String signEeStr, String signEeId, String signEeKeyStr,
             String encEeStr, String encEeId, String encEeKeyStr)
             throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         keyStore.load(null, null);
 
         keyStore.setKeyEntry("tlcp-sign-ee-demo",
@@ -351,8 +348,8 @@ public class TLCPWithJettyDemo {
 
     private static X509Certificate loadCert(String certPEM, String id)
             throws Exception {
-        CertificateFactory certFactory = PKIXInsts.getCertificateFactory(
-                "X.509");
+        CertificateFactory certFactory = CertificateFactory.getInstance(
+                "X.509", "KonaPKIX");
         X509Certificate x509Cert = (X509Certificate) certFactory.generateCertificate(
                 new ByteArrayInputStream(certPEM.getBytes()));
 
@@ -367,7 +364,7 @@ public class TLCPWithJettyDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = CryptoInsts.getKeyFactory("EC");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithNettyDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithNettyDemo.java
@@ -19,9 +19,6 @@
 
 package com.tencent.kona.ssl.demo;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.pkix.PKIXInsts;
-import com.tencent.kona.ssl.SSLInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import io.netty.bootstrap.Bootstrap;
@@ -407,23 +404,23 @@ public class TLCPWithNettyDemo {
 
     private static SSLContext createContext() throws Exception {
         KeyStore trustStore = createTrustStore(CA, null);
-        TrustManagerFactory tmf = SSLInsts.getTrustManagerFactory("PKIX");
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX", "KonaSSL");
         tmf.init(trustStore);
 
         KeyStore keyStore = createKeyStore(
                 SIGN_EE, SIGN_EE_ID, SIGN_EE_KEY,
                 ENC_EE, ENC_EE_ID, ENC_EE_KEY);
-        KeyManagerFactory kmf = SSLInsts.getKeyManagerFactory("NewSunX509");
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509", "KonaSSL");
         kmf.init(keyStore, PASSWORD.toCharArray());
 
-        SSLContext context = SSLInsts.getSSLContext("TLCPv1.1");
+        SSLContext context = SSLContext.getInstance("TLCPv1.1", "KonaSSL");
         context.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
         return context;
     }
 
     private static KeyStore createTrustStore(String caStr, String caId)
             throws Exception {
-        KeyStore trustStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore trustStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         trustStore.load(null, null);
         trustStore.setCertificateEntry("tlcp-trust-demo", loadCert(caStr, caId));
         return trustStore;
@@ -433,7 +430,7 @@ public class TLCPWithNettyDemo {
             String signEeStr, String signEeId, String signEeKeyStr,
             String encEeStr, String encEeId, String encEeKeyStr)
             throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         keyStore.load(null, null);
 
         keyStore.setKeyEntry("tlcp-sign-ee-demo",
@@ -450,8 +447,8 @@ public class TLCPWithNettyDemo {
 
     private static X509Certificate loadCert(String certPEM, String id)
             throws Exception {
-        CertificateFactory certFactory = PKIXInsts.getCertificateFactory(
-                "X.509");
+        CertificateFactory certFactory = CertificateFactory.getInstance(
+                "X.509", "KonaPKIX");
         X509Certificate x509Cert = (X509Certificate) certFactory.generateCertificate(
                 new ByteArrayInputStream(certPEM.getBytes()));
 
@@ -466,7 +463,7 @@ public class TLCPWithNettyDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = CryptoInsts.getKeyFactory("EC");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
         return keyFactory.generatePrivate(privateKeySpec);
     }
 }

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithTomcatDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithTomcatDemo.java
@@ -19,9 +19,6 @@
 
 package com.tencent.kona.ssl.demo;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.pkix.PKIXInsts;
-import com.tencent.kona.ssl.SSLInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import org.apache.catalina.Context;
@@ -66,6 +63,7 @@ import java.security.KeyFactory;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
 import java.security.cert.Certificate;
@@ -335,23 +333,23 @@ public class TLCPWithTomcatDemo {
 
     private static SSLContext createContext() throws Exception {
         KeyStore trustStore = createTrustStore(CA, null);
-        TrustManagerFactory tmf = SSLInsts.getTrustManagerFactory("PKIX");
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX", "KonaSSL");
         tmf.init(trustStore);
 
         KeyStore keyStore = createKeyStore(
                 SIGN_EE, SIGN_EE_ID, SIGN_EE_KEY,
                 ENC_EE, ENC_EE_ID, ENC_EE_KEY);
-        KeyManagerFactory kmf = SSLInsts.getKeyManagerFactory("NewSunX509");
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509", "KonaSSL");
         kmf.init(keyStore, PASSWORD.toCharArray());
 
-        SSLContext context = SSLInsts.getSSLContext("TLCPv1.1");
+        SSLContext context = SSLContext.getInstance("TLCPv1.1", "KonaSSL");
         context.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
         return context;
     }
 
     private static KeyStore createTrustStore(String caStr, String caId)
             throws Exception {
-        KeyStore trustStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore trustStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         trustStore.load(null, null);
         trustStore.setCertificateEntry("tlcp-trust-demo", loadCert(caStr, caId));
         return trustStore;
@@ -361,7 +359,7 @@ public class TLCPWithTomcatDemo {
             String signEeStr, String signEeId, String signEeKeyStr,
             String encEeStr, String encEeId, String encEeKeyStr)
             throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         keyStore.load(null, null);
 
         keyStore.setKeyEntry("tlcp-sign-ee-demo",
@@ -378,8 +376,8 @@ public class TLCPWithTomcatDemo {
 
     private static X509Certificate loadCert(String certPEM, String id)
             throws Exception {
-        CertificateFactory certFactory = PKIXInsts.getCertificateFactory(
-                "X.509");
+        CertificateFactory certFactory = CertificateFactory.getInstance(
+                "X.509", "KonaPKIX");
         X509Certificate x509Cert = (X509Certificate) certFactory.generateCertificate(
                 new ByteArrayInputStream(certPEM.getBytes()));
 
@@ -394,7 +392,7 @@ public class TLCPWithTomcatDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = CryptoInsts.getKeyFactory("EC");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
         return keyFactory.generatePrivate(privateKeySpec);
     }
 
@@ -466,7 +464,7 @@ public class TLCPWithTomcatDemo {
 
         @Override
         public KeyManager[] getKeyManagers() throws Exception {
-            KeyManagerFactory kmf = SSLInsts.getKeyManagerFactory("NewSunX509");
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509", "KonaSSL");
             kmf.init(certificate.getCertificateKeystore(),
                     certificate.getCertificateKeystorePassword().toCharArray());
             return kmf.getKeyManagers();
@@ -495,7 +493,8 @@ public class TLCPWithTomcatDemo {
 
         @Override
         public org.apache.tomcat.util.net.SSLContext createSSLContextInternal(
-                List<String> negotiableProtocols) throws NoSuchAlgorithmException {
+                List<String> negotiableProtocols)
+                throws NoSuchAlgorithmException, NoSuchProviderException {
             return new KonaSSLContext(sslHostConfig.getSslProtocol());
         }
     }
@@ -507,8 +506,9 @@ public class TLCPWithTomcatDemo {
         private KeyManager[] kms;
         private TrustManager[] tms;
 
-        public KonaSSLContext(String protocol) throws NoSuchAlgorithmException {
-            context = SSLInsts.getSSLContext(protocol);
+        public KonaSSLContext(String protocol)
+                throws NoSuchAlgorithmException, NoSuchProviderException {
+            context = SSLContext.getInstance(protocol, "KonaSSL");
         }
 
         @Override

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithoutCertValidationDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithoutCertValidationDemo.java
@@ -19,9 +19,6 @@
 
 package com.tencent.kona.ssl.demo;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.pkix.PKIXInsts;
-import com.tencent.kona.ssl.SSLInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -282,7 +279,7 @@ public class TLCPWithoutCertValidationDemo {
 
     private static void createTrustStoreFile(String caStr, String caId)
             throws Exception {
-        KeyStore trustStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore trustStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         trustStore.load(null, null);
         trustStore.setCertificateEntry("tlcp-trust-demo", loadCert(caStr, caId));
         try (FileOutputStream out = new FileOutputStream(
@@ -295,7 +292,7 @@ public class TLCPWithoutCertValidationDemo {
             String signEeStr, String signEeId, String signEeKeyStr,
             String encEeStr, String encEeId, String encEeKeyStr)
             throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         keyStore.load(null, null);
 
         keyStore.setKeyEntry("tlcp-sign-ee-demo",
@@ -315,8 +312,8 @@ public class TLCPWithoutCertValidationDemo {
 
     private static X509Certificate loadCert(String certPEM, String id)
             throws Exception {
-        CertificateFactory certFactory = PKIXInsts.getCertificateFactory(
-                "X.509");
+        CertificateFactory certFactory = CertificateFactory.getInstance(
+                "X.509", "KonaPKIX");
         X509Certificate x509Cert = (X509Certificate) certFactory.generateCertificate(
                 new ByteArrayInputStream(certPEM.getBytes()));
 
@@ -331,7 +328,7 @@ public class TLCPWithoutCertValidationDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = CryptoInsts.getKeyFactory("EC");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
         return keyFactory.generatePrivate(privateKeySpec);
     }
 
@@ -404,13 +401,13 @@ public class TLCPWithoutCertValidationDemo {
 
     private static SSLContext createContext() throws Exception {
         // Load trust store
-        KeyStore trustStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore trustStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         try (FileInputStream keyStoreIn = new FileInputStream(
                 TRUSTSTORE.toFile())) {
             trustStore.load(keyStoreIn, PASSWORD.toCharArray());
         }
 
-        TrustManagerFactory tmf = SSLInsts.getTrustManagerFactory("PKIX");
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX", "KonaSSL");
         tmf.init(trustStore);
 
         // Create the custom trust managers with the existing trust managers.
@@ -424,15 +421,15 @@ public class TLCPWithoutCertValidationDemo {
         }
 
         // Load key store
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         try (FileInputStream keyStoreIn = new FileInputStream(
                 KEYSTORE.toFile())) {
             keyStore.load(keyStoreIn, PASSWORD.toCharArray());
         }
-        KeyManagerFactory kmf = SSLInsts.getKeyManagerFactory("NewSunX509");
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509", "KonaSSL");
         kmf.init(keyStore, PASSWORD.toCharArray());
 
-        SSLContext context = SSLInsts.getSSLContext("TLCPv1.1");
+        SSLContext context = SSLContext.getInstance("TLCPv1.1", "KonaSSL");
         context.init(kmf.getKeyManagers(), trustManagers, new SecureRandom());
         return context;
     }

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithGRPCDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithGRPCDemo.java
@@ -19,9 +19,6 @@
 
 package com.tencent.kona.ssl.demo;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.pkix.PKIXInsts;
-import com.tencent.kona.ssl.SSLInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import io.grpc.Channel;
@@ -228,21 +225,21 @@ public class TLSWithGRPCDemo {
 
     private static SSLContext createContext() throws Exception {
         KeyStore trustStore = createTrustStore(CA, null);
-        TrustManagerFactory tmf = SSLInsts.getTrustManagerFactory("PKIX");
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX", "KonaSSL");
         tmf.init(trustStore);
 
         KeyStore keyStore = createKeyStore(EE, EE_ID, EE_KEY);
-        KeyManagerFactory kmf = SSLInsts.getKeyManagerFactory("NewSunX509");
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509", "KonaSSL");
         kmf.init(keyStore, PASSWORD.toCharArray());
 
-        SSLContext context = SSLInsts.getSSLContext("TLS");
+        SSLContext context = SSLContext.getInstance("TLS", "KonaSSL");
         context.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
         return context;
     }
 
     private static KeyStore createTrustStore(String caStr, String caId)
             throws Exception {
-        KeyStore trustStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore trustStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         trustStore.load(null, null);
         trustStore.setCertificateEntry("tls-trust-demo", loadCert(caStr, caId));
         return trustStore;
@@ -251,7 +248,7 @@ public class TLSWithGRPCDemo {
     private static KeyStore createKeyStore(
             String eeStr, String eeId, String eeKeyStr)
             throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         keyStore.load(null, null);
 
         PrivateKey privateKey = loadPrivateKey(eeKeyStr);
@@ -265,7 +262,7 @@ public class TLSWithGRPCDemo {
 
     private static X509Certificate loadCert(String certPEM, String id)
             throws Exception {
-        CertificateFactory certFactory = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory certFactory = CertificateFactory.getInstance("X.509", "KonaPKIX");
         X509Certificate x509Cert = (X509Certificate) certFactory.generateCertificate(
                 new ByteArrayInputStream(certPEM.getBytes()));
 
@@ -280,7 +277,7 @@ public class TLSWithGRPCDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = CryptoInsts.getKeyFactory("EC");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithJettyDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithJettyDemo.java
@@ -19,9 +19,6 @@
 
 package com.tencent.kona.ssl.demo;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.pkix.PKIXInsts;
-import com.tencent.kona.ssl.SSLInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import org.eclipse.jetty.client.HttpClient;
@@ -247,21 +244,21 @@ public class TLSWithJettyDemo {
 
     private static SSLContext createContext() throws Exception {
         KeyStore trustStore = createTrustStore(CA, null);
-        TrustManagerFactory tmf = SSLInsts.getTrustManagerFactory("PKIX");
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX", "KonaSSL");
         tmf.init(trustStore);
 
         KeyStore keyStore = createKeyStore(EE, EE_ID, EE_KEY);
-        KeyManagerFactory kmf = SSLInsts.getKeyManagerFactory("NewSunX509");
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509", "KonaSSL");
         kmf.init(keyStore, PASSWORD.toCharArray());
 
-        SSLContext context = SSLInsts.getSSLContext("TLS");
+        SSLContext context = SSLContext.getInstance("TLS", "KonaSSL");
         context.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
         return context;
     }
 
     private static KeyStore createTrustStore(String caStr, String caId)
             throws Exception {
-        KeyStore trustStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore trustStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         trustStore.load(null, null);
         trustStore.setCertificateEntry("tls-trust-demo", loadCert(caStr, caId));
         return trustStore;
@@ -270,7 +267,7 @@ public class TLSWithJettyDemo {
     private static KeyStore createKeyStore(
             String eeStr, String eeId, String eeKeyStr)
             throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         keyStore.load(null, null);
 
         PrivateKey privateKey = loadPrivateKey(eeKeyStr);
@@ -284,8 +281,8 @@ public class TLSWithJettyDemo {
 
     private static X509Certificate loadCert(String certPEM, String id)
             throws Exception {
-        CertificateFactory certFactory = PKIXInsts.getCertificateFactory(
-                "X.509");
+        CertificateFactory certFactory = CertificateFactory.getInstance(
+                "X.509", "KonaPKIX");
         X509Certificate x509Cert = (X509Certificate) certFactory.generateCertificate(
                 new ByteArrayInputStream(certPEM.getBytes()));
 
@@ -300,7 +297,7 @@ public class TLSWithJettyDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = CryptoInsts.getKeyFactory("EC");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithOkHttpDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithOkHttpDemo.java
@@ -19,9 +19,6 @@
 
 package com.tencent.kona.ssl.demo;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.pkix.PKIXInsts;
-import com.tencent.kona.ssl.SSLInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import okhttp3.ConnectionSpec;
@@ -245,7 +242,7 @@ public class TLSWithOkHttpDemo {
         SSLContext sslContext = createContext();
 
         KeyStore trustStore = createTrustStore(CA, null);
-        TrustManagerFactory tmf = SSLInsts.getTrustManagerFactory("PKIX");
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX", "KonaSSL");
         tmf.init(trustStore);
 
         ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
@@ -264,21 +261,21 @@ public class TLSWithOkHttpDemo {
 
     private static SSLContext createContext() throws Exception {
         KeyStore trustStore = createTrustStore(CA, null);
-        TrustManagerFactory tmf = SSLInsts.getTrustManagerFactory("PKIX");
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX", "KonaSSL");
         tmf.init(trustStore);
 
         KeyStore keyStore = createKeyStore(EE, EE_ID, EE_KEY);
-        KeyManagerFactory kmf = SSLInsts.getKeyManagerFactory("NewSunX509");
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509", "KonaSSL");
         kmf.init(keyStore, PASSWORD.toCharArray());
 
-        SSLContext context = SSLInsts.getSSLContext("TLS");
+        SSLContext context = SSLContext.getInstance("TLS", "KonaSSL");
         context.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
         return context;
     }
 
     private static KeyStore createTrustStore(String caStr, String caId)
             throws Exception {
-        KeyStore trustStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore trustStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         trustStore.load(null, null);
         trustStore.setCertificateEntry("tls-trust-demo", loadCert(caStr, caId));
         return trustStore;
@@ -287,7 +284,7 @@ public class TLSWithOkHttpDemo {
     private static KeyStore createKeyStore(
             String eeStr, String eeId, String eeKeyStr)
             throws Exception {
-        KeyStore keyStore = PKIXInsts.getKeyStore("PKCS12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12", "KonaPKIX");
         keyStore.load(null, null);
 
         PrivateKey privateKey = loadPrivateKey(eeKeyStr);
@@ -301,8 +298,8 @@ public class TLSWithOkHttpDemo {
 
     private static X509Certificate loadCert(String certPEM, String id)
             throws Exception {
-        CertificateFactory certFactory = PKIXInsts.getCertificateFactory(
-                "X.509");
+        CertificateFactory certFactory = CertificateFactory.getInstance(
+                "X.509", "KonaPKIX");
         X509Certificate x509Cert = (X509Certificate) certFactory.generateCertificate(
                 new ByteArrayInputStream(certPEM.getBytes()));
 
@@ -317,7 +314,7 @@ public class TLSWithOkHttpDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = CryptoInsts.getKeyFactory("EC");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/SSLEngineTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/SSLEngineTest.java
@@ -26,9 +26,6 @@
 
 package com.tencent.kona.ssl.tlcp;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.pkix.PKIXInsts;
-import com.tencent.kona.ssl.SSLInsts;
 import com.tencent.kona.ssl.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -123,12 +120,12 @@ public class SSLEngineTest {
         char[] passphrase = "passphrase".toCharArray();
 
         // Generate certificate from cert string.
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
 
         // Import the trused certs.
         ByteArrayInputStream is;
         if (trustedCerts != null && trustedCerts.length != 0) {
-            ts = PKIXInsts.getKeyStore("PKCS12");
+            ts = KeyStore.getInstance("PKCS12", "KonaPKIX");
             ts.load(null, null);
 
             Certificate[] trustedCert = new Certificate[trustedCerts.length];
@@ -147,15 +144,15 @@ public class SSLEngineTest {
 
         // Import the key materials.
         if (endEntityCerts != null && endEntityCerts.length != 0) {
-            ks = PKIXInsts.getKeyStore("PKCS12");
+            ks = KeyStore.getInstance("PKCS12", "KonaPKIX");
             ks.load(null, null);
 
             for (int i = 0; i < endEntityCerts.length; i++) {
                 // generate the private key.
                 PKCS8EncodedKeySpec priKeySpec = new PKCS8EncodedKeySpec(
                         Base64.getMimeDecoder().decode(endEntityCerts[i].privKeyStr));
-                KeyFactory kf = CryptoInsts.getKeyFactory(
-                        endEntityCerts[i].keyAlgo);
+                KeyFactory kf = KeyFactory.getInstance(
+                        endEntityCerts[i].keyAlgo, "KonaCrypto");
                 PrivateKey priKey = kf.generatePrivate(priKeySpec);
 
                 // generate certificate chain
@@ -178,13 +175,13 @@ public class SSLEngineTest {
 
         // Create an SSLContext object.
         TrustManagerFactory tmf =
-                SSLInsts.getTrustManagerFactory(params.tmAlgorithm);
+                TrustManagerFactory.getInstance(params.tmAlgorithm, "KonaSSL");
         tmf.init(ts);
 
-        SSLContext context = SSLInsts.getSSLContext(params.contextProtocol);
+        SSLContext context = SSLContext.getInstance(params.contextProtocol, "KonaSSL");
         if (endEntityCerts != null && endEntityCerts.length != 0 && ks != null) {
             KeyManagerFactory kmf =
-                    SSLInsts.getKeyManagerFactory(params.kmAlgorithm);
+                    KeyManagerFactory.getInstance(params.kmAlgorithm, "KonaSSL");
             kmf.init(ks, passphrase);
 
             context.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/SSLSocketTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/SSLSocketTest.java
@@ -36,9 +36,6 @@
 
 package com.tencent.kona.ssl.tlcp;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.pkix.PKIXInsts;
-import com.tencent.kona.ssl.SSLInsts;
 import com.tencent.kona.ssl.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -409,12 +406,12 @@ public class SSLSocketTest {
         char passphrase[] = "passphrase".toCharArray();
 
         // Generate certificate from cert string.
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
 
         // Import the trused certs.
         ByteArrayInputStream is;
         if (trustedCerts != null && trustedCerts.length != 0) {
-            ts = PKIXInsts.getKeyStore("PKCS12");
+            ts = KeyStore.getInstance("PKCS12", "KonaPKIX");
             ts.load(null, null);
 
             Certificate[] trustedCert = new Certificate[trustedCerts.length];
@@ -433,15 +430,15 @@ public class SSLSocketTest {
 
         // Import the key materials.
         if (endEntityCerts != null && endEntityCerts.length != 0) {
-            ks = PKIXInsts.getKeyStore("PKCS12");
+            ks = KeyStore.getInstance("PKCS12", "KonaPKIX");
             ks.load(null, null);
 
             for (int i = 0; i < endEntityCerts.length; i++) {
                 // generate the private key.
                 PKCS8EncodedKeySpec priKeySpec = new PKCS8EncodedKeySpec(
                         Base64.getMimeDecoder().decode(endEntityCerts[i].privKeyStr));
-                KeyFactory kf = CryptoInsts.getKeyFactory(
-                        endEntityCerts[i].keyAlgo);
+                KeyFactory kf = KeyFactory.getInstance(
+                        endEntityCerts[i].keyAlgo, "KonaCrypto");
                 PrivateKey priKey = kf.generatePrivate(priKeySpec);
 
                 // generate certificate chain
@@ -464,13 +461,13 @@ public class SSLSocketTest {
 
         // Create an SSLContext object.
         TrustManagerFactory tmf =
-                SSLInsts.getTrustManagerFactory(params.tmAlgorithm);
+                TrustManagerFactory.getInstance(params.tmAlgorithm, "KonaSSL");
         tmf.init(ts);
 
-        SSLContext context = SSLInsts.getSSLContext(params.contextProtocol);
+        SSLContext context = SSLContext.getInstance(params.contextProtocol, "KonaSSL");
         if (endEntityCerts != null && endEntityCerts.length != 0 && ks != null) {
             KeyManagerFactory kmf =
-                    SSLInsts.getKeyManagerFactory(params.kmAlgorithm);
+                    KeyManagerFactory.getInstance(params.kmAlgorithm, "KonaSSL");
             kmf.init(ks, passphrase);
 
             context.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/SSLSocketOnTLS12Test.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/SSLSocketOnTLS12Test.java
@@ -36,9 +36,6 @@
 
 package com.tencent.kona.ssl.tls;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.pkix.PKIXInsts;
-import com.tencent.kona.ssl.SSLInsts;
 import com.tencent.kona.ssl.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -409,12 +406,12 @@ public class SSLSocketOnTLS12Test {
         char passphrase[] = "passphrase".toCharArray();
 
         // Generate certificate from cert string.
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
 
         // Import the trused certs.
         ByteArrayInputStream is;
         if (trustedCerts != null && trustedCerts.length != 0) {
-            ts = PKIXInsts.getKeyStore("PKCS12");
+            ts = KeyStore.getInstance("PKCS12", "KonaPKIX");
             ts.load(null, null);
 
             Certificate[] trustedCert = new Certificate[trustedCerts.length];
@@ -433,15 +430,15 @@ public class SSLSocketOnTLS12Test {
 
         // Import the key materials.
         if (endEntityCerts != null && endEntityCerts.length != 0) {
-            ks = PKIXInsts.getKeyStore("PKCS12");
+            ks = KeyStore.getInstance("PKCS12", "KonaPKIX");
             ks.load(null, null);
 
             for (int i = 0; i < endEntityCerts.length; i++) {
                 // generate the private key.
                 PKCS8EncodedKeySpec priKeySpec = new PKCS8EncodedKeySpec(
                     Base64.getMimeDecoder().decode(endEntityCerts[i].privKeyStr));
-                KeyFactory kf = CryptoInsts.getKeyFactory(
-                        endEntityCerts[i].keyAlgo);
+                KeyFactory kf = KeyFactory.getInstance(
+                        endEntityCerts[i].keyAlgo, "KonaCrypto");
                 PrivateKey priKey = kf.generatePrivate(priKeySpec);
 
                 // generate certificate chain
@@ -464,13 +461,13 @@ public class SSLSocketOnTLS12Test {
 
         // Create an SSLContext object.
         TrustManagerFactory tmf =
-                SSLInsts.getTrustManagerFactory(params.tmAlgorithm);
+                TrustManagerFactory.getInstance(params.tmAlgorithm, "KonaSSL");
         tmf.init(ts);
 
-        SSLContext context = SSLInsts.getSSLContext(params.contextProtocol);
+        SSLContext context = SSLContext.getInstance(params.contextProtocol, "KonaSSL");
         if (endEntityCerts != null && endEntityCerts.length != 0 && ks != null) {
             KeyManagerFactory kmf =
-                    SSLInsts.getKeyManagerFactory(params.kmAlgorithm);
+                    KeyManagerFactory.getInstance(params.kmAlgorithm, "KonaSSL");
             kmf.init(ks, passphrase);
 
             context.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/SSLSocketOnTLS13Test.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/SSLSocketOnTLS13Test.java
@@ -36,9 +36,6 @@
 
 package com.tencent.kona.ssl.tls;
 
-import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.pkix.PKIXInsts;
-import com.tencent.kona.ssl.SSLInsts;
 import com.tencent.kona.ssl.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -409,12 +406,12 @@ public class SSLSocketOnTLS13Test {
         char passphrase[] = "passphrase".toCharArray();
 
         // Generate certificate from cert string.
-        CertificateFactory cf = PKIXInsts.getCertificateFactory("X.509");
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "KonaPKIX");
 
         // Import the trused certs.
         ByteArrayInputStream is;
         if (trustedCerts != null && trustedCerts.length != 0) {
-            ts = PKIXInsts.getKeyStore("PKCS12");
+            ts = KeyStore.getInstance("PKCS12", "KonaPKIX");
             ts.load(null, null);
 
             Certificate[] trustedCert = new Certificate[trustedCerts.length];
@@ -433,15 +430,15 @@ public class SSLSocketOnTLS13Test {
 
         // Import the key materials.
         if (endEntityCerts != null && endEntityCerts.length != 0) {
-            ks = PKIXInsts.getKeyStore("PKCS12");
+            ks = KeyStore.getInstance("PKCS12", "KonaPKIX");
             ks.load(null, null);
 
             for (int i = 0; i < endEntityCerts.length; i++) {
                 // generate the private key.
                 PKCS8EncodedKeySpec priKeySpec = new PKCS8EncodedKeySpec(
                     Base64.getMimeDecoder().decode(endEntityCerts[i].privKeyStr));
-                KeyFactory kf = CryptoInsts.getKeyFactory(
-                        endEntityCerts[i].keyAlgo);
+                KeyFactory kf = KeyFactory.getInstance(
+                        endEntityCerts[i].keyAlgo, "KonaCrypto");
                 PrivateKey priKey = kf.generatePrivate(priKeySpec);
 
                 // generate certificate chain
@@ -464,13 +461,13 @@ public class SSLSocketOnTLS13Test {
 
         // Create an SSLContext object.
         TrustManagerFactory tmf =
-                SSLInsts.getTrustManagerFactory(params.tmAlgorithm);
+                TrustManagerFactory.getInstance(params.tmAlgorithm, "KonaSSL");
         tmf.init(ts);
 
-        SSLContext context = SSLInsts.getSSLContext(params.contextProtocol);
+        SSLContext context = SSLContext.getInstance(params.contextProtocol, "KonaSSL");
         if (endEntityCerts != null && endEntityCerts.length != 0 && ks != null) {
             KeyManagerFactory kmf =
-                    SSLInsts.getKeyManagerFactory(params.kmAlgorithm);
+                    KeyManagerFactory.getInstance(params.kmAlgorithm, "KonaSSL");
             kmf.init(ks, passphrase);
 
             context.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);


### PR DESCRIPTION
`CryptoInsts`, `PKIXInsts` and `SSLInsts` are used by the implementations only.
The tests, especially demos, would not use them.

This PR will resolves #600.