### PR TITLE
TKSS-612: A redundant return in method padWithLen

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PKCS5Padding.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PKCS5Padding.java
@@ -71,7 +71,6 @@ final class PKCS5Padding implements Padding {
 
         byte paddingOctet = (byte) (len & 0xff);
         Arrays.fill(in, off, idx, paddingOctet);
-        return;
     }
 
     /**


### PR DESCRIPTION
This is a backport of [JDK-8322734]: A redundant return in method padWithLen.

This PR will resolves #612.

[JDK-8322734]:
https://bugs.openjdk.org/browse/JDK-8322734