### PR TITLE
TKSS-621: CertListFormat.format should be private final

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPCertificate.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPCertificate.java
@@ -68,7 +68,7 @@ final class TLCPCertificate {
         // sign_cert | ca_list | enc_cert
         SIGN_CA_ENC("SIGN|CA|ENC");  // TASSL preference
 
-        String format;
+        private final String format;
 
         CertListFormat(String format) {
             this.format = format;


### PR DESCRIPTION
The field `format` in enum `CertListFormat` should be `private` and  `final`.

This PR will resolve #621.