### PR TITLE
TKSS-623: Remove redundant aliases from KonaSSLProvider

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/ssl/KonaSSLProvider.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/ssl/KonaSSLProvider.java
@@ -98,18 +98,10 @@ public class KonaSSLProvider extends Provider {
 
         provider.put("KeyGenerator.TlcpKeyMaterial",
                 "com.tencent.kona.sun.security.provider.TlcpKeyMaterialGenerator");
-        provider.put("Alg.Alias.KeyGenerator.TlcpKeyMaterial", "TlcpKeyMaterial");
-
         provider.put("KeyGenerator.TlcpSM2PremasterSecret",
                 "com.tencent.kona.sun.security.provider.TlcpSM2PremasterSecretGenerator");
-        provider.put("Alg.Alias.KeyGenerator.TlcpSM2PremasterSecret",
-                "TlcpSM2PremasterSecret");
-
         provider.put("KeyGenerator.TlcpMasterSecret",
                 "com.tencent.kona.sun.security.provider.TlcpMasterSecretGenerator");
-        provider.put("Alg.Alias.KeyGenerator.TlcpMasterSecret",
-                "TlcpMasterSecret");
-
         provider.put("KeyGenerator.TlcpPrf",
                 "com.tencent.kona.sun.security.provider.TlcpPrfGenerator");
     }

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/provider/TlcpMasterSecretGenerator.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/provider/TlcpMasterSecretGenerator.java
@@ -41,7 +41,7 @@ import java.security.spec.AlgorithmParameterSpec;
 public final class TlcpMasterSecretGenerator extends KeyGeneratorSpi {
 
     private final static String MSG = "TlcpMasterSecretGenerator must be "
-            + "initialized using a TlcpMasterSecretParameterSpec";
+            + "initialized using a TlsMasterSecretParameterSpec";
 
     private TlsMasterSecretParameterSpec spec;
 
@@ -54,7 +54,7 @@ public final class TlcpMasterSecretGenerator extends KeyGeneratorSpi {
 
     @Override
     protected void engineInit(AlgorithmParameterSpec params,
-                              SecureRandom random) throws InvalidAlgorithmParameterException {
+            SecureRandom random) throws InvalidAlgorithmParameterException {
         if (!(params instanceof TlsMasterSecretParameterSpec)) {
             throw new InvalidAlgorithmParameterException(MSG);
         }

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/provider/TlcpSM2PremasterSecretGenerator.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/provider/TlcpSM2PremasterSecretGenerator.java
@@ -41,7 +41,6 @@ public final class TlcpSM2PremasterSecretGenerator extends KeyGeneratorSpi {
     private static final String MSG = "TlcpSM2PremasterSecretGenerator must be "
         + "initialized using a TlcpSM2PremasterSecretParameterSpec";
 
-    @SuppressWarnings("deprecation")
     private TlcpSM2PremasterSecretParameterSpec spec;
     private SecureRandom random;
 


### PR DESCRIPTION
KonaSSLProvider contains some aliases for TLCP KeyGenerators , like `TlcpKeyMaterial`.
However these aliases are not necessary.

This PR will resolves #623.