### PR TITLE
TKSS-627: Add aliases for trust manager and key manager

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/ssl/KonaSSLProvider.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/ssl/KonaSSLProvider.java
@@ -54,12 +54,13 @@ public class KonaSSLProvider extends Provider {
                 "com.tencent.kona.sun.security.ssl.KeyManagerFactoryImpl$SunX509");
         provider.put("KeyManagerFactory.NewSunX509",
                 "com.tencent.kona.sun.security.ssl.KeyManagerFactoryImpl$X509");
+        provider.put("Alg.Alias.KeyManagerFactory.PKIX", "NewSunX509");
 
         provider.put("TrustManagerFactory.SunX509",
                 "com.tencent.kona.sun.security.ssl.TrustManagerFactoryImpl$SimpleFactory");
         provider.put("TrustManagerFactory.PKIX",
                 "com.tencent.kona.sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory");
-        provider.put("Alg.Alias.TrustManagerFactory.SunPKIX", "PKIX");
+        provider.put("Alg.Alias.TrustManagerFactory.TencentPKIX", "PKIX");
         provider.put("Alg.Alias.TrustManagerFactory.X509", "PKIX");
         provider.put("Alg.Alias.TrustManagerFactory.X.509", "PKIX");
 

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPAuthenticator.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPAuthenticator.java
@@ -32,6 +32,7 @@ import java.security.NoSuchAlgorithmException;
 
 import com.tencent.kona.sun.security.ssl.Authenticator.SSLAuthenticator;
 import com.tencent.kona.sun.security.ssl.Authenticator.MAC;
+import com.tencent.kona.sun.security.ssl.CipherSuite.MacAlg;
 
 final class TLCPAuthenticator {
 
@@ -76,14 +77,14 @@ final class TLCPAuthenticator {
         private final MacImpl macImpl;
 
         TLCP11Mac(ProtocolVersion protocolVersion,
-                  CipherSuite.MacAlg macAlg, SecretKey key) throws NoSuchAlgorithmException,
+                MacAlg macAlg, SecretKey key) throws NoSuchAlgorithmException,
                 InvalidKeyException {
             super(protocolVersion);
             this.macImpl = new MacImpl(protocolVersion, macAlg, key);
         }
 
         @Override
-        public CipherSuite.MacAlg macAlg() {
+        public MacAlg macAlg() {
             return macImpl.macAlg;
         }
 
@@ -92,20 +93,5 @@ final class TLCPAuthenticator {
                 byte[] sequence, boolean isSimulated) {
             return macImpl.compute(type, bb, sequence, isSimulated);
         }
-    }
-
-    static final long toLong(byte[] recordEnS) {
-        if (recordEnS != null && recordEnS.length == 8) {
-            return ((recordEnS[0] & 0xFFL) << 56) |
-                   ((recordEnS[1] & 0xFFL) << 48) |
-                   ((recordEnS[2] & 0xFFL) << 40) |
-                   ((recordEnS[3] & 0xFFL) << 32) |
-                   ((recordEnS[4] & 0xFFL) << 24) |
-                   ((recordEnS[5] & 0xFFL) << 16) |
-                   ((recordEnS[6] & 0xFFL) <<  8) |
-                    (recordEnS[7] & 0xFFL);
-        }
-
-        return -1L;
     }
 }

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPContextImpl.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPContextImpl.java
@@ -53,7 +53,7 @@ public final class TLCPContextImpl {
             });
 
             serverDefaultCipherSuites = getApplicableEnabledCipherSuites(
-                    clientDefaultProtocols, true);
+                    serverDefaultProtocols, false);
             clientDefaultCipherSuites = getApplicableEnabledCipherSuites(
                     clientDefaultProtocols, true);
         }

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/SSLSocketTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/SSLSocketTest.java
@@ -176,7 +176,7 @@ public class SSLSocketTest {
      * Get the client side parameters of SSLContext.
      */
     protected ContextParameters getClientContextParameters() {
-        return new ContextParameters("TLCP", "PKIX", "NewSunX509");
+        return new ContextParameters("TLCP", "TencentPKIX", "PKIX");
     }
 
     /*

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/SSLSocketOnTLS13Test.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/SSLSocketOnTLS13Test.java
@@ -179,7 +179,7 @@ public class SSLSocketOnTLS13Test {
      * Get the client side parameters of SSLContext.
      */
     protected ContextParameters getClientContextParameters() {
-        return new ContextParameters("TLS", "PKIX", "NewSunX509");
+        return new ContextParameters("TLS", "TencentPKIX", "PKIX");
     }
 
     /*


### PR DESCRIPTION
OpenJDK has some aliases for PKIX trust manager and NewSunX509 key manager, so TKSS also needs to align to OpenJDK.

This PR will resolves #627.