### PR TITLE
TKSS-629: PKCS12KeyStore should clear storeEntryCache

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/util/Constants.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/util/Constants.java
@@ -36,7 +36,7 @@ public final class Constants {
             "java.specification.vendor");
 
     // The length of uncompressed SM2 public key,
-    // exactly a EC point's coordinates (x, y).
+    // exactly an EC point's coordinates (x, y).
     // The hex format is 04||x||y
     public static final int SM2_PUBKEY_LEN = 65;
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs12/PKCS12KeyStore.java
@@ -989,7 +989,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
      * for some other reason.
      */
     public synchronized void engineSetCertificateEntry(String alias,
-                                                       Certificate cert) throws KeyStoreException
+            Certificate cert) throws KeyStoreException
     {
         setCertEntry(alias, cert, null);
     }
@@ -998,7 +998,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
      * Sets a trusted cert entry (with attributes, when present)
      */
     private void setCertEntry(String alias, Certificate cert,
-                              Set<KeyStore.Entry.Attribute> attributes) throws KeyStoreException {
+            Set<KeyStore.Entry.Attribute> attributes) throws KeyStoreException {
 
         // Check that the cert is an X.509 cert
         if (cert != null && (!(cert instanceof X509Certificate))) {
@@ -2007,6 +2007,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
         }
 
         entries.clear();
+        storeEntryCache.clear();
 
         /*
          * Read the authSafe.


### PR DESCRIPTION
When load a new keystore, storeEntryCache should be cleared.