### PR TITLE
TKSS-637: JettyServer supports client authentication

### DIFF
--- a/kona-demo/src/main/java/com/tencent/kona/demo/AppConfig.java
+++ b/kona-demo/src/main/java/com/tencent/kona/demo/AppConfig.java
@@ -31,6 +31,9 @@ public class AppConfig {
     @Value("${server.ssl.enabled}")
     private boolean sslEnabled;
 
+    @Value("${server.ssl.provider}")
+    private String provider;
+
     @Value("${server.ssl.trust-store-provider}")
     private String trustStoreProvider;
 
@@ -58,6 +61,9 @@ public class AppConfig {
     @Value("${server.ssl.protocol}")
     private String contextProtocol;
 
+    @Value("${server.ssl.client-auth-enabled}")
+    private boolean clientAuthEnabled;
+
     @Value("${server.http2.enabled}")
     private boolean http2Enabled;
 
@@ -75,6 +81,14 @@ public class AppConfig {
 
     public void setSslEnabled(String sslEnabled) {
         this.sslEnabled = Boolean.parseBoolean(sslEnabled);
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
     }
 
     public String getTrustStoreProvider() {
@@ -147,6 +161,14 @@ public class AppConfig {
 
     public void setContextProtocol(String contextProtocol) {
         this.contextProtocol = contextProtocol;
+    }
+
+    public boolean isClientAuthEnabled() {
+        return clientAuthEnabled;
+    }
+
+    public void setClientAuthEnabled(boolean clientAuthEnabled) {
+        this.clientAuthEnabled = clientAuthEnabled;
     }
 
     public boolean isHttp2Enabled() {

--- a/kona-demo/src/main/java/com/tencent/kona/demo/JettyServer.java
+++ b/kona-demo/src/main/java/com/tencent/kona/demo/JettyServer.java
@@ -97,6 +97,8 @@ public class JettyServer {
                 }
             };
 
+            contextFactory.setProvider(appConfig.getProvider());
+
             contextFactory.setTrustStoreProvider(appConfig.getTrustStoreProvider());
             contextFactory.setTrustStoreType(appConfig.getTrustStoreType());
             contextFactory.setTrustStorePath(getAbsolutePath(appConfig.getTrustStorePath()));
@@ -109,6 +111,7 @@ public class JettyServer {
             contextFactory.setKeyManagerPassword(appConfig.getKeyStorePassword());
 
             contextFactory.setProtocol(appConfig.getContextProtocol());
+            contextFactory.setNeedClientAuth(appConfig.isClientAuthEnabled());
 
             HttpConfiguration httpsConfig = new HttpConfiguration();
             httpsConfig.setSecureScheme("https");

--- a/kona-demo/src/main/resources/application.yml
+++ b/kona-demo/src/main/resources/application.yml
@@ -23,6 +23,8 @@ server:
   ssl:
     enabled: true
 
+    provider: Kona
+
     trust-store-provider: Kona
     trust-store-type: PKCS12
     trust-store: classpath:ssl/truststore.p12
@@ -36,6 +38,8 @@ server:
     # This context protocol supports TLCPv1.1, TLSv1.3 and TLSv1.2,
     # and will take the providers from TencentKonaSMSuite to work.
     protocol: TLCP
+
+    client-auth-enabled: false
 
   http2:
     enabled: true


### PR DESCRIPTION
It allows to config `JettyServer` to support client authentication.

This PR will resolves #637.