### PR TITLE
TKSS-639: Backport JDK-8320449: ECDHKeyAgreement should validate parameters before using them

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECDHKeyAgreement.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECDHKeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,11 @@
 
 package com.tencent.kona.sun.security.ec;
 
-import com.tencent.kona.sun.security.ec.point.AffinePoint;
 import com.tencent.kona.sun.security.ec.point.Point;
 import com.tencent.kona.sun.security.util.ArrayUtil;
 import com.tencent.kona.sun.security.util.CurveDB;
 import com.tencent.kona.sun.security.util.ECUtil;
 import com.tencent.kona.sun.security.util.NamedCurve;
-import com.tencent.kona.sun.security.util.math.ImmutableIntegerModuloP;
 import com.tencent.kona.sun.security.util.math.IntegerFieldModuloP;
 import com.tencent.kona.sun.security.util.math.MutableIntegerModuloP;
 import com.tencent.kona.sun.security.util.math.SmallValue;
@@ -81,22 +79,27 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
     // Generic init
     private void init(Key key) throws
         InvalidKeyException, InvalidAlgorithmParameterException {
+        privateKey = null;
+        privateKeyOps = null;
+        publicKey = null;
+
         if (!(key instanceof PrivateKey)) {
             throw new InvalidKeyException("Key must be instance of PrivateKey");
         }
-        privateKey = (ECPrivateKey)ECKeyFactory.toECKey(key);
-        publicKey = null;
 
-        namedCurve = CurveDB.lookup(privateKey.getParams());
+        ECPrivateKey ecPrivateKey = (ECPrivateKey)ECKeyFactory.toECKey(key);
         Optional<ECOperations> opsOpt =
-                ECOperations.forParameters(privateKey.getParams());
+            ECOperations.forParameters(ecPrivateKey.getParams());
         if (!opsOpt.isPresent()) {
+            NamedCurve nc = CurveDB.lookup(ecPrivateKey.getParams());
             throw new InvalidAlgorithmParameterException(
-                    "Curve not supported: " + (namedCurve != null ? namedCurve.toString() :
-                            "unknown"));
+                "Curve not supported: " + (nc != null ? nc.toString() :
+                    "unknown"));
         }
+        ECUtil.checkPrivateKey(ecPrivateKey);
+
+        privateKey = ecPrivateKey;
         privateKeyOps = opsOpt.get();
-        ECUtil.checkPrivateKey(privateKey);
     }
 
     // see JCE spec
@@ -141,14 +144,14 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
                 ("Key must be a PublicKey with algorithm EC");
         }
 
+        // Validate public key
+        validate(privateKeyOps, (ECPublicKey) key);
+
         this.publicKey = (ECPublicKey) key;
 
         int keyLenBits =
             publicKey.getParams().getCurve().getField().getFieldSize();
         secretLen = (keyLenBits + 7) >> 3;
-
-        // Validate public key
-        validate(privateKeyOps, publicKey);
 
         return null;
     }
@@ -156,11 +159,7 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
     // Verify that x and y are integers in the interval [0, p - 1].
     private static void validateCoordinate(BigInteger c, BigInteger mod)
         throws InvalidKeyException{
-        if (c.compareTo(BigInteger.ZERO) < 0) {
-            throw new InvalidKeyException("Invalid coordinate");
-        }
-
-        if (c.compareTo(mod) >= 0) {
+        if (c.compareTo(BigInteger.ZERO) < 0 || c.compareTo(mod) >= 0) {
             throw new InvalidKeyException("Invalid coordinate");
         }
     }


### PR DESCRIPTION
This is a backport of [JDK-8320449]: ECDHKeyAgreement should validate parameters before using them.

This PR will resolves #639.

[JDK-8320449]:
https://bugs.openjdk.org/browse/JDK-8320449