### PR TITLE
TKSS-650: Backport JDK-8325022: Incorrect error message on client authentication

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateMessage.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -391,7 +391,7 @@ final class CertificateMessage {
                         ClientAuthType.CLIENT_AUTH_REQUESTED) {
                     // unexpected or require client authentication
                     throw shc.conContext.fatal(Alert.BAD_CERTIFICATE,
-                        "Empty server certificate chain");
+                        "Empty client certificate chain");
                 } else {
                     return;
                 }
@@ -408,7 +408,7 @@ final class CertificateMessage {
                 }
             } catch (CertificateException ce) {
                 throw shc.conContext.fatal(Alert.BAD_CERTIFICATE,
-                    "Failed to parse server certificates", ce);
+                    "Failed to parse client certificates", ce);
             }
 
             checkClientCerts(shc, x509Certs);
@@ -1230,7 +1230,7 @@ final class CertificateMessage {
                 }
             } catch (CertificateException ce) {
                 throw shc.conContext.fatal(Alert.BAD_CERTIFICATE,
-                    "Failed to parse server certificates", ce);
+                    "Failed to parse client certificates", ce);
             }
 
             // find out the types of client authentication used

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPCertificate.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPCertificate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -408,7 +408,7 @@ final class TLCPCertificate {
                         ClientAuthType.CLIENT_AUTH_REQUESTED) {
                     // unexpected or require client authentication
                     throw shc.conContext.fatal(Alert.BAD_CERTIFICATE,
-                            "Empty server certificate chain");
+                            "Empty client certificate chain");
                 } else {
                     return;
                 }
@@ -425,7 +425,7 @@ final class TLCPCertificate {
                 }
             } catch (CertificateException ce) {
                 throw shc.conContext.fatal(Alert.BAD_CERTIFICATE,
-                        "Failed to parse server certificates", ce);
+                        "Failed to parse client certificates", ce);
             }
 
             checkClientCerts(shc, x509Certs);


### PR DESCRIPTION
This is a backport of [JDK-8325022]: Incorrect error message on client authentication.

This PR will resolves #650.

[JDK-8325022]:
https://bugs.openjdk.org/browse/JDK-8325022