### PR TITLE
TKSS-678: Better certificate key usage checking on TLCP

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLMasterKeyDerivation.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLMasterKeyDerivation.java
@@ -118,7 +118,7 @@ enum SSLMasterKeyDerivation implements SSLKeyDerivationGenerator {
             } else {
                 if (protocolVersion.isTLCP11()) {
                     masterAlg = "TlcpMasterSecret";
-                    hashAlg = HashAlg.H_SM3;
+                    hashAlg = cipherSuite.hashAlg;
                 } else if (protocolVersion.id >= ProtocolVersion.TLS12.id) {
                     masterAlg = "SunTls12MasterSecret";
                     hashAlg = cipherSuite.hashAlg;


### PR DESCRIPTION
TLCP requires two certificates, exactly sign and enc certificates.
The sign certificate should always have `digitalSignature` key usage regardless of key exchange (`SM2` or `SM2E`).
It would be better to improve the checking on this certificate.

This PR will resolves #678.