### PR TITLE
TKSS-680: Backport JDK-8311644: Server should not send bad_certificate alert when the client does not send any certificates

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/Alert.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/Alert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,13 +124,13 @@ enum Alert {
 
         SSLException ssle;
         if (cause instanceof IOException) {
-            ssle = new SSLException(reason);
+            ssle = new SSLException("(" + description + ") " + reason);
         } else if ((this == UNEXPECTED_MESSAGE)) {
-            ssle = new SSLProtocolException(reason);
+            ssle = new SSLProtocolException("(" + description + ") " + reason);
         } else if (handshakeOnly) {
-            ssle = new SSLHandshakeException(reason);
+            ssle = new SSLHandshakeException("(" + description + ") " + reason);
         } else {
-            ssle = new SSLException(reason);
+            ssle = new SSLException("(" + description + ") " + reason);
         }
 
         if (cause != null) {

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateMessage.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateMessage.java
@@ -390,7 +390,7 @@ final class CertificateMessage {
                 if (shc.sslConfig.clientAuthType !=
                         ClientAuthType.CLIENT_AUTH_REQUESTED) {
                     // unexpected or require client authentication
-                    throw shc.conContext.fatal(Alert.BAD_CERTIFICATE,
+                    throw shc.conContext.fatal(Alert.HANDSHAKE_FAILURE,
                         "Empty client certificate chain");
                 } else {
                     return;
@@ -1168,7 +1168,7 @@ final class CertificateMessage {
                 shc.handshakeConsumers.remove(
                         SSLHandshake.CERTIFICATE_VERIFY.id);
                 if (shc.sslConfig.clientAuthType == ClientAuthType.CLIENT_AUTH_REQUIRED) {
-                    throw shc.conContext.fatal(Alert.BAD_CERTIFICATE,
+                    throw shc.conContext.fatal(Alert.CERTIFICATE_REQUIRED,
                         "Empty client certificate chain");
                 } else {
                     // optional client authentication
@@ -1192,7 +1192,7 @@ final class CertificateMessage {
                 T13CertificateMessage certificateMessage )throws IOException {
             if (certificateMessage.certEntries == null ||
                     certificateMessage.certEntries.isEmpty()) {
-                throw chc.conContext.fatal(Alert.BAD_CERTIFICATE,
+                throw chc.conContext.fatal(Alert.DECODE_ERROR,
                     "Empty server certificate chain");
             }
 


### PR DESCRIPTION
This is a backport of [JDK-8311644]: Server should not send bad_certificate alert when the client does not send any certificates.

This PR will resolves #680.

[JDK-8311644]:
https://bugs.openjdk.org/browse/JDK-8311644