### PR TITLE
TKSS-698: kona-demo should allow not to specify providers

### DIFF
--- a/kona-demo/src/main/java/com/tencent/kona/demo/AppConfig.java
+++ b/kona-demo/src/main/java/com/tencent/kona/demo/AppConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,10 @@ public class AppConfig {
     @Value("${server.ssl.enabled}")
     private boolean sslEnabled;
 
-    @Value("${server.ssl.provider}")
+    @Value("${server.ssl.provider:#{null}}")
     private String provider;
 
-    @Value("${server.ssl.trust-store-provider}")
+    @Value("${server.ssl.trust-store-provider:#{null}}")
     private String trustStoreProvider;
 
     @Value("${server.ssl.trust-store-type}")
@@ -46,7 +46,7 @@ public class AppConfig {
     @Value("${server.ssl.trust-store-password}")
     private String trustStorePassword;
 
-    @Value("${server.ssl.key-store-provider}")
+    @Value("${server.ssl.key-store-provider:#{null}}")
     private String keyStoreProvider;
 
     @Value("${server.ssl.key-store-type}")

--- a/kona-demo/src/main/java/com/tencent/kona/demo/JettyServer.java
+++ b/kona-demo/src/main/java/com/tencent/kona/demo/JettyServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,14 +97,20 @@ public class JettyServer {
                 }
             };
 
-            contextFactory.setProvider(appConfig.getProvider());
+            if (!isEmpty(appConfig.getProvider())) {
+                contextFactory.setProvider(appConfig.getProvider());
+            }
 
-            contextFactory.setTrustStoreProvider(appConfig.getTrustStoreProvider());
+            if (!isEmpty(appConfig.getTrustStoreProvider())) {
+                contextFactory.setTrustStoreProvider(appConfig.getTrustStoreProvider());
+            }
             contextFactory.setTrustStoreType(appConfig.getTrustStoreType());
             contextFactory.setTrustStorePath(getAbsolutePath(appConfig.getTrustStorePath()));
             contextFactory.setTrustStorePassword(appConfig.getTrustStorePassword());
 
-            contextFactory.setKeyStoreProvider(appConfig.getKeyStoreProvider());
+            if (!isEmpty(appConfig.getKeyStoreProvider())) {
+                contextFactory.setKeyStoreProvider(appConfig.getKeyStoreProvider());
+            }
             contextFactory.setKeyStoreType(appConfig.getKeyStoreType());
             contextFactory.setKeyStorePath(getAbsolutePath(appConfig.getKeyStorePath()));
             contextFactory.setKeyStorePassword(appConfig.getKeyStorePassword());
@@ -143,6 +149,10 @@ public class JettyServer {
 
             server.setConnectors(new Connector[] { httpsConnector });
             server.setStopAtShutdown(true);
+        }
+
+        private static boolean isEmpty(String str) {
+            return str == null || str.isEmpty();
         }
 
         private static String getAbsolutePath(String resourcePath) {


### PR DESCRIPTION
The providers can be null, then kona-demo just uses the default providers.
Generally, the default providers comes from JDK.

This PR will resolves #698.