### PR TITLE
TKSS-714: Remove unused TlcpKeyMaterial, TlcpMasterSecret and TlcpPrf

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/ssl/SSLInsts.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/ssl/SSLInsts.java
@@ -96,8 +96,7 @@ public class SSLInsts {
             = new HashSet<>(Arrays.asList(
                     "SunTlsPrf", "SunTls12Prf",
                     "SunTlsMasterSecret", "SunTlsKeyMaterial",
-                    "TlcpKeyMaterial", "TlcpSM2PremasterSecret",
-                    "TlcpMasterSecret", "TlcpPrf"));
+                    "TlcpSM2PremasterSecret"));
 
     public static KeyGenerator getKeyGenerator(String protocol)
             throws NoSuchAlgorithmException {

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/internal/spec/TlsKeyMaterialParameterSpec.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/internal/spec/TlsKeyMaterialParameterSpec.java
@@ -94,9 +94,8 @@ public class TlsKeyMaterialParameterSpec implements AlgorithmParameterSpec {
             byte[] serverRandom, String cipherAlgorithm, int cipherKeyLength,
             int expandedCipherKeyLength, int ivLength, int macKeyLength,
             String prfHashAlg, int prfHashLength, int prfBlockSize) {
-        if (!masterSecret.getAlgorithm().equals("TlcpMasterSecret")
-                && !masterSecret.getAlgorithm().equals("TlsMasterSecret")) {
-            throw new IllegalArgumentException("Not a TLCP/TLS master secret");
+        if (!masterSecret.getAlgorithm().equals("TlsMasterSecret")) {
+            throw new IllegalArgumentException("Not a TLS master secret");
         }
         if (cipherAlgorithm == null) {
             throw new NullPointerException();


### PR DESCRIPTION
Classes `TlcpKeyMaterial`, `TlcpMasterSecret` and `TlcpPrf` are already removed, but the names still present in classes `SSLInsts` and `TlsKeyMaterialParameterSpec`.

This PR will resolves #714.