### PR TITLE
TKSS-719: Remove TLCPAuthentication SM2E

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLKeyExchange.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLKeyExchange.java
@@ -280,7 +280,7 @@ final class SSLKeyExchange implements SSLKeyAgreementGenerator,
 
     private static class TLCPKeyExSM2E {
         private static final SSLKeyExchange KE = new SSLKeyExchange(
-                Arrays.asList(TLCPAuthentication.SM2E), TLCPKeyAgreement.SM2E);
+                Arrays.asList(TLCPAuthentication.SM2), TLCPKeyAgreement.SM2E);
     }
 
     private static class SSLKeyExRSA {

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPAuthentication.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPAuthentication.java
@@ -38,10 +38,9 @@ import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Map;
 
-final class TLCPAuthentication implements SSLAuthentication {
+enum TLCPAuthentication implements SSLAuthentication {
 
-    static final TLCPAuthentication SM2 = new TLCPAuthentication("EC", "EC");
-    static final TLCPAuthentication SM2E = new TLCPAuthentication("EC", "EC");
+    SM2("EC", "EC");
 
     final String keyAlgorithm;
     final String[] keyTypes;


### PR DESCRIPTION
`SM2` and `SM2E` in `TLCPAuthentication` are the same, so it could remove one.

This PR will resolves #719.