### PR TITLE
TKSS-710: Backport JDK-8312383: Log X509ExtendedKeyManager implementation class name in TLS/SSL connection

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPAuthentication.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPAuthentication.java
@@ -217,6 +217,10 @@ enum TLCPAuthentication implements SSLAuthentication {
     private static SSLPossession createClientPossession(
             ClientHandshakeContext chc, String[] keyTypes) {
         X509ExtendedKeyManager km = chc.sslContext.getX509KeyManager();
+        if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
+            SSLLogger.finest("X509KeyManager class: " +
+                    km.getClass().getName());
+        }
         for (String keyType : keyTypes) {
             String[] clientAliases = km.getClientAliases(
                         keyType,
@@ -315,6 +319,10 @@ enum TLCPAuthentication implements SSLAuthentication {
     private static SSLPossession createServerPossession(
             ServerHandshakeContext shc, String[] keyTypes) {
         X509ExtendedKeyManager km = shc.sslContext.getX509KeyManager();
+        if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
+            SSLLogger.finest("X509KeyManager class: " +
+                    km.getClass().getName());
+        }
         for (String keyType : keyTypes) {
             String[] serverAliases = km.getServerAliases(keyType,
                         shc.peerSupportedAuthorities == null ? null :

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/X509Authentication.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/X509Authentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,6 +170,10 @@ enum X509Authentication implements SSLAuthentication {
     private static SSLPossession createClientPossession(
             ClientHandshakeContext chc, String[] keyTypes) {
         X509ExtendedKeyManager km = chc.sslContext.getX509KeyManager();
+        if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
+            SSLLogger.finest("X509KeyManager class: " +
+                    km.getClass().getName());
+        }
         String clientAlias = null;
         if (chc.conContext.transport instanceof SSLSocketImpl) {
             SSLSocketImpl socket = (SSLSocketImpl) chc.conContext.transport;
@@ -241,6 +245,10 @@ enum X509Authentication implements SSLAuthentication {
     private static SSLPossession createServerPossession(
             ServerHandshakeContext shc, String[] keyTypes) {
         X509ExtendedKeyManager km = shc.sslContext.getX509KeyManager();
+        if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
+            SSLLogger.finest("X509KeyManager class: " +
+                    km.getClass().getName());
+        }
         String serverAlias = null;
         for (String keyType : keyTypes) {
             if (shc.conContext.transport instanceof SSLSocketImpl) {


### PR DESCRIPTION
This is a backport of [JDK-8312383]: Log X509ExtendedKeyManager implementation class name in TLS/SSL connection.

This PR will resolves #710.

[JDK-8312383]:
https://bugs.openjdk.org/browse/JDK-8312383