### PR TITLE
TKSS-722: Remove unused VerifyDataScheme TLCP11

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/Finished.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/Finished.java
@@ -165,7 +165,6 @@ final class Finished {
         SSL30       ("kdf_ssl30", new S30VerifyDataGenerator()),
         TLS10       ("kdf_tls10", new T10VerifyDataGenerator()),
         TLS12       ("kdf_tls12", new T12VerifyDataGenerator()),
-        TLCP11      ("kdf_tlcp11",new T12VerifyDataGenerator()),
         TLS13       ("kdf_tls13", new T13VerifyDataGenerator());
 
         final String name;


### PR DESCRIPTION
`TLCP11` in `VerifyDataScheme` is not used anymore, so just remove it.

This PR will resolves #722.