### PR TITLE
TKSS-729: Backport JDK-8325164: Named groups and signature schemes unavailable with SunPKCS11 in FIPS mode

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECKeyPairGenerator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECKeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ public final class ECKeyPairGenerator extends KeyPairGeneratorSpi {
     public void initialize(int keySize, SecureRandom random) {
 
         checkKeySize(keySize);
-        this.params = ECUtil.getECParameterSpec(null, keySize);
+        this.params = ECUtil.getECParameterSpec(keySize);
         if (params == null) {
             throw new InvalidParameterException(
                 "No EC parameters available for key size " + keySize + " bits");
@@ -96,14 +96,14 @@ public final class ECKeyPairGenerator extends KeyPairGeneratorSpi {
 
         if (params instanceof ECParameterSpec) {
             ECParameterSpec ecParams = (ECParameterSpec) params;
-            ecSpec = ECUtil.getECParameterSpec(null, ecParams);
+            ecSpec = ECUtil.getECParameterSpec(ecParams);
             if (ecSpec == null) {
                 throw new InvalidAlgorithmParameterException(
                     "Curve not supported: " + params);
             }
         } else if (params instanceof ECGenParameterSpec) {
             String name = ((ECGenParameterSpec) params).getName();
-            ecSpec = ECUtil.getECParameterSpec(null, name);
+            ecSpec = ECUtil.getECParameterSpec(name);
             if (ecSpec == null) {
                 throw new InvalidAlgorithmParameterException(
                     "Unknown curve name: " + name);
@@ -125,7 +125,7 @@ public final class ECKeyPairGenerator extends KeyPairGeneratorSpi {
         throws InvalidAlgorithmParameterException {
 
         // Check if ecSpec is a valid curve
-        AlgorithmParameters ecParams = ECUtil.getECParameters(null);
+        AlgorithmParameters ecParams = ECUtil.getECParameters();
         try {
             ecParams.init(ecSpec);
         } catch (InvalidParameterSpecException ex) {

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/ECUtil.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/ECUtil.java
@@ -142,21 +142,16 @@ public final class ECUtil {
         return (ECPrivateKey)keyFactory.generatePrivate(keySpec);
     }
 
-    public static AlgorithmParameters getECParameters(Provider p) {
+    public static AlgorithmParameters getECParameters() {
         try {
-            if (p != null) {
-                return AlgorithmParameters.getInstance("EC", p);
-            }
-
             return CryptoInsts.getAlgorithmParameters("EC");
         } catch (NoSuchAlgorithmException nsae) {
             throw new RuntimeException(nsae);
         }
     }
 
-    public static byte[] encodeECParameterSpec(
-            Provider p, ECParameterSpec spec) {
-        AlgorithmParameters parameters = getECParameters(p);
+    public static byte[] encodeECParameterSpec(ECParameterSpec spec) {
+        AlgorithmParameters parameters = getECParameters();
 
         try {
             parameters.init(spec);
@@ -172,9 +167,8 @@ public final class ECUtil {
         }
     }
 
-    public static ECParameterSpec getECParameterSpec(
-            Provider p, ECParameterSpec spec) {
-        AlgorithmParameters parameters = getECParameters(p);
+    public static ECParameterSpec getECParameterSpec(ECParameterSpec spec) {
+        AlgorithmParameters parameters = getECParameters();
 
         try {
             parameters.init(spec);
@@ -184,9 +178,9 @@ public final class ECUtil {
         }
     }
 
-    public static ECParameterSpec getECParameterSpec(
-            Provider p, byte[] params) throws IOException {
-        AlgorithmParameters parameters = getECParameters(p);
+    public static ECParameterSpec getECParameterSpec(byte[] params)
+            throws IOException {
+        AlgorithmParameters parameters = getECParameters();
 
         parameters.init(params);
 
@@ -197,8 +191,8 @@ public final class ECUtil {
         }
     }
 
-    public static ECParameterSpec getECParameterSpec(Provider p, String name) {
-        AlgorithmParameters parameters = getECParameters(p);
+    public static ECParameterSpec getECParameterSpec(String name) {
+        AlgorithmParameters parameters = getECParameters();
 
         try {
             parameters.init(new ECGenParameterSpec(name));
@@ -208,8 +202,8 @@ public final class ECUtil {
         }
     }
 
-    public static ECParameterSpec getECParameterSpec(Provider p, int keySize) {
-        AlgorithmParameters parameters = getECParameters(p);
+    public static ECParameterSpec getECParameterSpec(int keySize) {
+        AlgorithmParameters parameters = getECParameters();
 
         try {
             parameters.init(new ECKeySizeParameterSpec(keySize));
@@ -219,9 +213,9 @@ public final class ECUtil {
         }
     }
 
-    public static String getCurveName(Provider p, ECParameterSpec spec) {
+    public static String getCurveName(ECParameterSpec spec) {
         ECGenParameterSpec nameSpec;
-        AlgorithmParameters parameters = getECParameters(p);
+        AlgorithmParameters parameters = getECParameters();
 
         try {
             parameters.init(spec);

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/KeyUtil.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/KeyUtil.java
@@ -146,7 +146,7 @@ public final class KeyUtil {
 
                 // Note: the ECGenParameterSpec case should be covered by the
                 // ECParameterSpec case above.
-                // See ECUtil.getECParameterSpec(Provider, String).
+                // See ECUtil.getECParameterSpec(String).
 
                 break;
             case "DiffieHellman":


### PR DESCRIPTION
This is a backport of [JDK-8325164]: Named groups and signature schemes unavailable with SunPKCS11 in FIPS mode.

This PR will resolves #729.

[JDK-8325164]:
https://bugs.openjdk.org/browse/JDK-8325164