### PR TITLE
TKSS-730: SharedSecretsUtil should support JDK 21

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoUtils.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoUtils.java
@@ -63,6 +63,10 @@ public final class CryptoUtils {
         return Constants.JDK_VERSION.equals("17");
     }
 
+    public static boolean isJdk21() {
+        return Constants.JDK_VERSION.equals("21");
+    }
+
     public static boolean isAndroid() {
         return Constants.JDK_VENDOR.contains("Android");
     }

--- a/kona-crypto/src/main/java/com/tencent/kona/jdk/internal/misc/SharedSecretsUtil.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/jdk/internal/misc/SharedSecretsUtil.java
@@ -104,7 +104,7 @@ public class SharedSecretsUtil {
                     javaIOAccessClass = Class.forName("jdk.internal.misc.JavaIOAccess");
                     inetAddressAccessClass = Class.forName("jdk.internal.misc.JavaNetInetAddressAccess");
                     secSignatureAccessClass = Class.forName("jdk.internal.misc.JavaSecuritySignatureAccess");
-                } else if (isJdk17()) {
+                } else if (isJdk17() || isJdk21()) {
                     sharedSecretsClass = Class.forName("jdk.internal.access.SharedSecrets");
 
                     javaLangAccessClass = Class.forName("jdk.internal.access.JavaLangAccess");
@@ -124,11 +124,11 @@ public class SharedSecretsUtil {
                 langNewStringNoRepl = isJdk8()
                         ? null : javaLangAccessClass.getMethod(
                                 "newStringNoRepl", byte[].class, Charset.class);
-                initialSystemIn = isJdk8()
+                initialSystemIn = isJdk8() || isJdk11() || isJdk17()
                         ? null : javaLangAccessClass.getMethod("initialSystemIn");
 
                 console = javaIOAccessClass.getMethod("console");
-                charset = javaIOAccessClass.getMethod("charset");
+                charset = isJdk21() ? null : javaIOAccessClass.getMethod("charset");
 
                 cryptoSpecClearSecretKeySpec = javaxCryptoSpecAccessClass != null
                         ? javaxCryptoSpecAccessClass.getMethod(

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
@@ -400,7 +400,7 @@ public class TestUtils {
 
         if (CryptoUtils.isJdk11()) {
             allJVMOptions.addAll(JDK11_OPTIONS);
-        } else if (CryptoUtils.isJdk17()) {
+        } else if (CryptoUtils.isJdk17() || CryptoUtils.isJdk21()) {
             allJVMOptions.addAll(JDK17_OPTIONS);
         }
 


### PR DESCRIPTION
SharedSecretsUtil doesn't support JDK 21 currently, however this JDK version should be supported.

This PR will resolves #730.