### PR TITLE
TKSS-736: Redundant semicolon in SM2ServerKeyExchange::messageLength

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2ServerKeyExchange.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2ServerKeyExchange.java
@@ -214,7 +214,7 @@ final class SM2ServerKeyExchange {
 
         @Override
         public int messageLength() {
-            int sigLen = 2 + paramsSignature.length;;
+            int sigLen = 2 + paramsSignature.length;
             if (useExplicitSigAlgorithm) {
                 sigLen += SignatureScheme.sizeInRecord();
             }


### PR DESCRIPTION
The method `SM2ServerKeyExchange::messageLength` contains a redundant semicolon.

This PR will resolves #736.