### PR TITLE
TKSS-738: Constants should not depend on CryptoUtils

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoUtils.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify
@@ -32,6 +32,12 @@ import com.tencent.kona.sun.security.util.ArrayUtil;
 
 public final class CryptoUtils {
 
+    private static final String JDK_VERSION = privilegedGetProperty(
+            "java.specification.version");
+
+    private static final String JDK_VENDOR = privilegedGetProperty(
+            "java.specification.vendor");
+
     public static String privilegedGetProperty(String key, String def) {
         return AccessController.doPrivileged(
                 (PrivilegedAction<String>) () -> System.getProperty(key, def));
@@ -52,23 +58,23 @@ public final class CryptoUtils {
     }
 
     public static boolean isJdk8() {
-        return Constants.JDK_VERSION.equals("1.8");
+        return JDK_VERSION.equals("1.8");
     }
 
     public static boolean isJdk11() {
-        return Constants.JDK_VERSION.equals("11");
+        return JDK_VERSION.equals("11");
     }
 
     public static boolean isJdk17() {
-        return Constants.JDK_VERSION.equals("17");
+        return JDK_VERSION.equals("17");
     }
 
     public static boolean isJdk21() {
-        return Constants.JDK_VERSION.equals("21");
+        return JDK_VERSION.equals("21");
     }
 
     public static boolean isAndroid() {
-        return Constants.JDK_VENDOR.contains("Android");
+        return JDK_VENDOR.contains("Android");
     }
 
     private static final HexFormat HEX = HexFormat.of();

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/util/Constants.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/util/Constants.java
@@ -20,20 +20,12 @@
 
 package com.tencent.kona.crypto.util;
 
-import com.tencent.kona.crypto.CryptoUtils;
-
 import java.math.BigInteger;
 
 public final class Constants {
 
     public static final BigInteger TWO = BigInteger.valueOf(2);
     public static final BigInteger THREE = BigInteger.valueOf(3);
-
-    public static final String JDK_VERSION = CryptoUtils.privilegedGetProperty(
-            "java.specification.version");
-
-    public static final String JDK_VENDOR = CryptoUtils.privilegedGetProperty(
-            "java.specification.vendor");
 
     // The length of uncompressed SM2 public key,
     // exactly an EC point's coordinates (x, y).


### PR DESCRIPTION
`Constants` and `CryptoUtils` depend on in mutual. The former could not depend on the latter.

This PR will resolves #738.