### PR TITLE
TKSS-741: Remove redundant semicolons from DerValue and PKCS7

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerValue.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerValue.java
@@ -290,7 +290,7 @@ public class DerValue {
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported DER string type");
-        };
+        }
         return value.getBytes(charset);
     }
 

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS7.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS7.java
@@ -243,7 +243,7 @@ public class PKCS7 {
 
         CertificateFactory certfac = null;
         try {
-            certfac = PKIXInsts.getCertificateFactory("X.509");;
+            certfac = PKIXInsts.getCertificateFactory("X.509");
         } catch (CertificateException ce) {
             // do nothing
         }


### PR DESCRIPTION
`DerValue` and `PKCS7` have redundant semicolons.

This PR will resolves #741.