### PR TITLE
TKSS-739: Backport JDK-8326643: JDK server does not send a dummy change_cipher_spec record after HelloRetryRequest message

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ServerHello.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ServerHello.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -802,6 +802,15 @@ final class ServerHello {
             // Output the handshake message.
             hhrm.write(shc.handshakeOutput);
             shc.handshakeOutput.flush();
+
+            // In TLS1.3 middlebox compatibility mode the server sends a
+            // dummy change_cipher_spec record immediately after its
+            // first handshake message. This may either be after
+            // a ServerHello or a HelloRetryRequest.
+            // (RFC 8446, Appendix D.4)
+            shc.conContext.outputRecord.changeWriteCiphers(
+                SSLWriteCipher.nullTlsWriteCipher(),
+                    (clientHello.sessionId.length() != 0));
 
             // Stateless, shall we clean up the handshake context as well?
             shc.handshakeHash.finish();     // forgot about the handshake hash


### PR DESCRIPTION
This is a backport of [JDK-8326643]: JDK server does not send a dummy change_cipher_spec record after HelloRetryRequest message.

[JDK-8326643]:
https://bugs.openjdk.org/browse/JDK-8326643