### PR TITLE
TKSS-761: Backport JDK-8200566: DistributionPointFetcher fails to fetch CRLs if the DistributionPoints field contains more than one DistributionPoint and the first one fails

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/DistributionPointFetcher.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/DistributionPointFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,16 +113,28 @@ public class DistributionPointFetcher {
                 }
                 return Collections.emptySet();
             }
-            List<DistributionPoint> points =
-                    ext.getDistributionPoints();
+            List<DistributionPoint> points = ext.getDistributionPoints();
             Set<X509CRL> results = new HashSet<>();
+            CertStoreException savedCSE = null;
             for (Iterator<DistributionPoint> t = points.iterator();
                  t.hasNext() && !Arrays.equals(reasonsMask, ALL_REASONS); ) {
-                DistributionPoint point = t.next();
-                Collection<X509CRL> crls = getCRLs(selector, certImpl,
+                try {
+                    DistributionPoint point = t.next();
+                    Collection<X509CRL> crls = getCRLs(selector, certImpl,
                         point, reasonsMask, signFlag, prevKey, prevCert, provider,
                         certStores, trustAnchors, validity, variant, anchor);
-                results.addAll(crls);
+                    results.addAll(crls);
+                } catch (CertStoreException cse) {
+                    if (savedCSE == null) {
+                        savedCSE = cse;
+                    } else {
+                        savedCSE.addSuppressed(cse);
+                    }
+                }
+            }
+            // only throw CertStoreException if no CRLs are retrieved
+            if (results.isEmpty() && savedCSE != null) {
+                throw savedCSE;
             }
             if (debug != null) {
                 debug.println("Returning " + results.size() + " CRLs");
@@ -194,7 +206,11 @@ public class DistributionPointFetcher {
                     }
                 }
             } catch (CertStoreException cse) {
-                savedCSE = cse;
+                if (savedCSE == null) {
+                    savedCSE = cse;
+                } else {
+                    savedCSE.addSuppressed(cse);
+                }
             }
         }
         // only throw CertStoreException if no CRLs are retrieved


### PR DESCRIPTION
This is a backport of [JDK-8200566]: DistributionPointFetcher fails to fetch CRLs if the DistributionPoints field contains more than one DistributionPoint and the first one fails.

This PR will resolves #761.

[JDK-8200566]:
https://bugs.openjdk.org/browse/JDK-8200566