### PR TITLE
TKSS-773: Upgrade BouncyCastle to 1.78

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -18,7 +18,7 @@
 #
 
 [versions]
-bouncycastle = "1.77"
+bouncycastle = "1.78"
 
 grpc = "1.58.0"
 tomcat = "9.0.78"


### PR DESCRIPTION
BouncyCastle 1.78 just was released.
It would be better to use this version for testing.

This PR will resolves #773.