### PR TITLE
TKSS-779: Use any JDK 8 distro for compiling source

### DIFF
--- a/buildSrc/src/main/kotlin/kona-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/kona-common.gradle.kts
@@ -51,7 +51,6 @@ tasks {
         if (!passedTasks.contains("test") && !passedTasks.contains("testOnCurrent")) {
             javaCompiler = javaToolchains.compilerFor {
                 languageVersion = JavaLanguageVersion.of(8)
-                vendor = JvmVendorSpec.ADOPTIUM
             }
         }
 


### PR DESCRIPTION
Adoptium Temurin JDK doesn't provide version 8 on macOS aarch64, so Gradle toolchain cannot use this JDK 8 on this platform.

This PR will resolves #779.