### PR TITLE
TKSS-777: SSL tests use Tongsuo rather than BabaSSL

### DIFF
--- a/buildSrc/src/main/kotlin/CommonTest.kt
+++ b/buildSrc/src/main/kotlin/CommonTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,14 +43,14 @@ abstract class CommonTest : Test() {
                 excludeTestsMatching("com.tencent.kona.ssl.misc.*")
             }
 
-            val babasslPathProp = "test.babassl.path"
-            val babasslPath = System.getProperty(babasslPathProp, "babassl")
+            val tongsuoPathProp = "test.tongsuo.path"
+            val tongsuoPath = System.getProperty(tongsuoPathProp, "tongsuo")
 
-            if (!isBabaSSLAvailable(babasslPath)) {
-                // Ignore BabaSSL-related tests if no BabaSSL is available
-                excludeTestsMatching("*BabaSSL*Test")
+            if (!isTongsuoAvailable(tongsuoPath)) {
+                // Ignore Tongsuo-related tests if no Tongsuo is available
+                excludeTestsMatching("*Tongsuo*Test")
             } else {
-                systemProperty(babasslPathProp, babasslPath)
+                systemProperty(tongsuoPathProp, tongsuoPath)
             }
         }
 
@@ -88,12 +88,12 @@ abstract class CommonTest : Test() {
     }
 }
 
-// Determine if BabaSSL is available
-fun isBabaSSLAvailable(babasslPath : String): Boolean {
+// Determine if Tongsuo is available
+fun isTongsuoAvailable(tongsuoPath : String): Boolean {
     var exitCode : Int = -1
     try {
         val process = ProcessBuilder()
-            .command(babasslPath, "version")
+            .command(tongsuoPath, "version")
             .start()
         process.waitFor(3, TimeUnit.SECONDS)
         exitCode = process.exitValue()
@@ -103,7 +103,7 @@ fun isBabaSSLAvailable(babasslPath : String): Boolean {
         }
         System.out.print(versionInfo)
     } catch (e: Exception) {
-        println("BabaSSL is unavailable: " + e.cause)
+        println("Tongsuo is unavailable: " + e.cause)
     }
 
     return exitCode == 0

--- a/kona-pkix/src/test/resources/gen_certs.sh
+++ b/kona-pkix/src/test/resources/gen_certs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ EOF
 
 echo password > password
 
-OPENSSL=babassl
+OPENSSL=tongsuo
 
 ##### CAs
 echo "RSA key CA, signed by SHA256withRSA"

--- a/kona-pkix/src/test/resources/gen_hybrid_certs.sh
+++ b/kona-pkix/src/test/resources/gen_hybrid_certs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ basicConstraints=critical,CA:FALSE
 keyUsage=critical,keyEncipherment,dataEncipherment,keyAgreement
 EOF
 
-OPENSSL=babassl
+OPENSSL=tongsuo
 
 ########## RSA START ##########
 

--- a/kona-pkix/src/test/resources/gen_tlcp_certs.sh
+++ b/kona-pkix/src/test/resources/gen_tlcp_certs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ basicConstraints=critical,CA:FALSE
 keyUsage=critical,keyEncipherment,dataEncipherment,keyAgreement
 EOF
 
-OPENSSL=babassl
+OPENSSL=tongsuo
 
 ##### CA
 $OPENSSL genpkey -algorithm ec -pkeyopt ec_paramgen_curve:SM2 -pkeyopt ec_param_enc:named_curve -out tlcp-ca.key

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPCertificate.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPCertificate.java
@@ -63,7 +63,7 @@ final class TLCPCertificate {
     enum CertListFormat {
 
         // sign_cert | enc_cert | ca_list
-        SIGN_ENC_CA("SIGN|ENC|CA"),  // BabaSSL preference, default
+        SIGN_ENC_CA("SIGN|ENC|CA"),  // Tongsuo preference, default
 
         // sign_cert | ca_list | enc_cert
         SIGN_CA_ENC("SIGN|CA|ENC");  // TASSL preference
@@ -508,7 +508,7 @@ final class TLCPCertificate {
 
         // Assume the cert list contains at least one certificate,
         // and the structure is either of:
-        // 1. sign_cert | enc_cert | sign_cert_CA_list (BabaSSL's preference)
+        // 1. sign_cert | enc_cert | sign_cert_CA_list (Tongsuo's preference)
         // 2. sign_cert | sign_cert_CA_list | enc_cert (TASSL's preference)
         //
         // sign_cert and enc_cert are issued by the same CA.

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/OpenSSL.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/OpenSSL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ public class OpenSSL extends AbstractProduct {
 
     public static final OpenSSL DEFAULT = new OpenSSL(
             "OpenSSL",
-            System.getProperty("test.openssl.path", "babassl"));
+            System.getProperty("test.openssl.path", "tongsuo"));
 
     private final String name;
     private final Path path;

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/Tongsuo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/Tongsuo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,27 +19,38 @@
 
 package com.tencent.kona.ssl.interop;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 /*
- * Utilities for OpenSSL/BabaSSL peers.
+ * OpenSSL/Tongsuo product.
+ * This product is used for testing TLCP/NTLS/GMTLS.
  */
-public class BabaSSLUtils {
+public class Tongsuo extends AbstractProduct {
 
-    public static String cipherSuite(CipherSuite cipherSuite) {
-        switch (cipherSuite) {
-            case TLCP_ECC_SM4_CBC_SM3:
-                return "ECC-SM2-SM4-CBC-SM3";
+    public static final Tongsuo DEFAULT = new Tongsuo(
+            "Tongsuo",
+            System.getProperty("test.tongsuo.path", "tongsuo"));
 
-            case TLCP_ECDHE_SM4_CBC_SM3:
-                return "ECDHE-SM2-SM4-CBC-SM3";
+    private final String name;
+    private final Path path;
 
-            case TLCP_ECC_SM4_GCM_SM3:
-                return "ECC-SM2-SM4-GCM-SM3";
+    public Tongsuo(String name, Path path) {
+        this.name = name;
+        this.path = path;
+    }
 
-            case TLCP_ECDHE_SM4_GCM_SM3:
-                return "ECDHE-SM2-SM4-GCM-SM3";
+    public Tongsuo(String name, String path) {
+        this(name, Paths.get(path));
+    }
 
-            default:
-                return null;
-        }
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Path getPath() {
+        return path;
     }
 }

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/TongsuoClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/TongsuoClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,22 +19,17 @@
 
 package com.tencent.kona.ssl.interop;
 
-import com.tencent.kona.ssl.TestUtils;
-
 import java.io.IOException;
 import java.util.Collections;
 
 /*
- * The OpenSSL/BabaSSL server.
+ * The OpenSSL/Tongsuo client.
  */
-public class BabaSSLServer extends AbstractServer {
+public class TongsuoClient extends AbstractClient {
 
-    private final int port;
     private final String command;
 
-    private Process process;
-
-    public BabaSSLServer(Builder builder) throws IOException {
+    public TongsuoClient(Builder builder) {
         CertTuple certTuple = builder.getCertTuple();
         FileCert caCert = (FileCert) certTuple.trustedCert();
         FileCert signEeCert = (FileCert) certTuple.signEndEntityCert();
@@ -45,69 +40,82 @@ public class BabaSSLServer extends AbstractServer {
 
         String serverName = builder.getServerName();
         String alpn = Utilities.join(builder.getAppProtocols());
-
-        port = builder.getPort() == 0
-                ? TestUtils.getFreePort()
-                : builder.getPort();
+        String sessIn = builder.sessIn();
+        String sessOut = builder.sessOut();
 
         command = Utilities.join(" ",
+                "echo " + builder.getMessage(),
+                // Wait for the server response, e.g. session ticket.
+                "|", "sleep 1", "|",
                 getProduct().getPath().toString(),
-                "s_server",
-                Utilities.DEBUG ? "-state -debug -trace" : "",
+                "s_client",
+                Utilities.DEBUG ? "-state -debug -trace" : "-quiet",
                 "-enable_ntls", "-ntls",
                 Utilities.joinOptValue("-CAfile",
                         caCert == null ? null : caCert.certPath()),
                 "-sign_cert " + signEeCert.certPath(),
-                "-sign_key " + signEeCert.keyPath(),
+                "-sign_key " +  signEeCert.keyPath(),
                 "-enc_cert " + encEeCert.certPath(),
-                "-enc_key " + encEeCert.keyPath(),
-                builder.getClientAuth() == ClientAuth.REQUIRED ? "-Verify 2" : "",
-                builder.isUseSessTicket() ? "" : "-no_ticket",
+                "-enc_key " +  encEeCert.keyPath(),
+                Utilities.joinOptValue("-cipher",
+                        TongsuoUtils.cipherSuite(builder.getCipherSuite())),
                 Utilities.joinOptValue("-servername", serverName),
                 Utilities.joinOptValue("-alpn", alpn),
-                "-WWW",
-                "-accept " + port);
+                builder.isUseSessTicket() ? "" : "-no_ticket",
+                Utilities.joinOptValue("-sess_in", sessIn),
+                Utilities.joinOptValue("-sess_out", sessOut),
+                "-no_ign_eof");
     }
 
-    public static class Builder extends AbstractServer.Builder {
+    public static class Builder extends AbstractClient.Builder {
+
+        private String sessIn;
+        private String sessOut;
+
+        public String sessIn() {
+            return sessIn;
+        }
+
+        public Builder sessIn(String sessIn) {
+            this.sessIn = sessIn;
+            return this;
+        }
+
+        public String sessOut() {
+            return sessOut;
+        }
+
+        public Builder sessOut(String sessOut) {
+            this.sessOut = sessOut;
+            return this;
+        }
 
         @Override
-        public BabaSSLServer build() throws IOException {
-            return new BabaSSLServer(this);
+        public TongsuoClient build() {
+            return new TongsuoClient(this);
         }
     }
 
     @Override
     public Product getProduct() {
-        return BabaSSL.DEFAULT;
+        return Tongsuo.DEFAULT;
     }
 
     @Override
-    public int getPort() {
-        System.out.println("Waiting for port...");
-        if (!Utilities.waitFor(BabaSSLServer::isAlive, this)) {
-            throw new RuntimeException("Server doesn't start in time.");
-        }
-
-        return port;
-    }
-
-    @Override
-    public boolean isAlive() {
-        return process != null && process.isAlive();
-    }
-
-    @Override
-    public void accept() throws IOException {
-        process = ProcUtils.shellProc(command, getLogPath(), Collections.emptyMap());
+    public void connect(String host, int port) throws IOException {
+        String server = host + ":" + port;
+        Process process = ProcUtils.shellProc(
+                String.join(" ", command, "-connect", server),
+                getLogPath(),
+                Collections.emptyMap());
         try {
             process.waitFor();
         } catch (InterruptedException e) {
-            throw new RuntimeException("Server is interrupted!", e);
+            throw new RuntimeException("Client is interrupted!", e);
         }
 
         if (process.exitValue() != 0) {
-            throw new SSLTestException("Server exited abnormally!");
+            throw new SSLTestException("Client exited abnormally!");
         }
     }
 
@@ -115,9 +123,5 @@ public class BabaSSLServer extends AbstractServer {
     public void close() throws IOException {
         printLog();
         deleteLog();
-
-        if (isAlive()) {
-            Utilities.destroyProcess(process);
-        }
     }
 }

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/TongsuoServer.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/TongsuoServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,17 +19,22 @@
 
 package com.tencent.kona.ssl.interop;
 
+import com.tencent.kona.ssl.TestUtils;
+
 import java.io.IOException;
 import java.util.Collections;
 
 /*
- * The OpenSSL/BabaSSL client.
+ * The OpenSSL/Tongsuo server.
  */
-public class BabaSSLClient extends AbstractClient {
+public class TongsuoServer extends AbstractServer {
 
+    private final int port;
     private final String command;
 
-    public BabaSSLClient(Builder builder) {
+    private Process process;
+
+    public TongsuoServer(Builder builder) throws IOException {
         CertTuple certTuple = builder.getCertTuple();
         FileCert caCert = (FileCert) certTuple.trustedCert();
         FileCert signEeCert = (FileCert) certTuple.signEndEntityCert();
@@ -40,82 +45,69 @@ public class BabaSSLClient extends AbstractClient {
 
         String serverName = builder.getServerName();
         String alpn = Utilities.join(builder.getAppProtocols());
-        String sessIn = builder.sessIn();
-        String sessOut = builder.sessOut();
+
+        port = builder.getPort() == 0
+                ? TestUtils.getFreePort()
+                : builder.getPort();
 
         command = Utilities.join(" ",
-                "echo " + builder.getMessage(),
-                // Wait for the server response, e.g. session ticket.
-                "|", "sleep 1", "|",
                 getProduct().getPath().toString(),
-                "s_client",
-                Utilities.DEBUG ? "-state -debug -trace" : "-quiet",
+                "s_server",
+                Utilities.DEBUG ? "-state -debug -trace" : "",
                 "-enable_ntls", "-ntls",
                 Utilities.joinOptValue("-CAfile",
                         caCert == null ? null : caCert.certPath()),
                 "-sign_cert " + signEeCert.certPath(),
-                "-sign_key " +  signEeCert.keyPath(),
+                "-sign_key " + signEeCert.keyPath(),
                 "-enc_cert " + encEeCert.certPath(),
-                "-enc_key " +  encEeCert.keyPath(),
-                Utilities.joinOptValue("-cipher",
-                        BabaSSLUtils.cipherSuite(builder.getCipherSuite())),
+                "-enc_key " + encEeCert.keyPath(),
+                builder.getClientAuth() == ClientAuth.REQUIRED ? "-Verify 2" : "",
+                builder.isUseSessTicket() ? "" : "-no_ticket",
                 Utilities.joinOptValue("-servername", serverName),
                 Utilities.joinOptValue("-alpn", alpn),
-                builder.isUseSessTicket() ? "" : "-no_ticket",
-                Utilities.joinOptValue("-sess_in", sessIn),
-                Utilities.joinOptValue("-sess_out", sessOut),
-                "-no_ign_eof");
+                "-WWW",
+                "-accept " + port);
     }
 
-    public static class Builder extends AbstractClient.Builder {
-
-        private String sessIn;
-        private String sessOut;
-
-        public String sessIn() {
-            return sessIn;
-        }
-
-        public Builder sessIn(String sessIn) {
-            this.sessIn = sessIn;
-            return this;
-        }
-
-        public String sessOut() {
-            return sessOut;
-        }
-
-        public Builder sessOut(String sessOut) {
-            this.sessOut = sessOut;
-            return this;
-        }
+    public static class Builder extends AbstractServer.Builder {
 
         @Override
-        public BabaSSLClient build() {
-            return new BabaSSLClient(this);
+        public TongsuoServer build() throws IOException {
+            return new TongsuoServer(this);
         }
     }
 
     @Override
     public Product getProduct() {
-        return BabaSSL.DEFAULT;
+        return Tongsuo.DEFAULT;
     }
 
     @Override
-    public void connect(String host, int port) throws IOException {
-        String server = host + ":" + port;
-        Process process = ProcUtils.shellProc(
-                String.join(" ", command, "-connect", server),
-                getLogPath(),
-                Collections.emptyMap());
+    public int getPort() {
+        System.out.println("Waiting for port...");
+        if (!Utilities.waitFor(TongsuoServer::isAlive, this)) {
+            throw new RuntimeException("Server doesn't start in time.");
+        }
+
+        return port;
+    }
+
+    @Override
+    public boolean isAlive() {
+        return process != null && process.isAlive();
+    }
+
+    @Override
+    public void accept() throws IOException {
+        process = ProcUtils.shellProc(command, getLogPath(), Collections.emptyMap());
         try {
             process.waitFor();
         } catch (InterruptedException e) {
-            throw new RuntimeException("Client is interrupted!", e);
+            throw new RuntimeException("Server is interrupted!", e);
         }
 
         if (process.exitValue() != 0) {
-            throw new SSLTestException("Client exited abnormally!");
+            throw new SSLTestException("Server exited abnormally!");
         }
     }
 
@@ -123,5 +115,9 @@ public class BabaSSLClient extends AbstractClient {
     public void close() throws IOException {
         printLog();
         deleteLog();
+
+        if (isAlive()) {
+            Utilities.destroyProcess(process);
+        }
     }
 }

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/TongsuoUtils.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/TongsuoUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,38 +19,27 @@
 
 package com.tencent.kona.ssl.interop;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 /*
- * OpenSSL/BabaSSL product.
- * This product is used for testing TLCP/NTLS/GMTLS.
+ * Utilities for OpenSSL/Tongsuo peers.
  */
-public class BabaSSL extends AbstractProduct {
+public class TongsuoUtils {
 
-    public static final BabaSSL DEFAULT = new BabaSSL(
-            "BabaSSL",
-            System.getProperty("test.babassl.path", "babassl"));
+    public static String cipherSuite(CipherSuite cipherSuite) {
+        switch (cipherSuite) {
+            case TLCP_ECC_SM4_CBC_SM3:
+                return "ECC-SM2-SM4-CBC-SM3";
 
-    private final String name;
-    private final Path path;
+            case TLCP_ECDHE_SM4_CBC_SM3:
+                return "ECDHE-SM2-SM4-CBC-SM3";
 
-    public BabaSSL(String name, Path path) {
-        this.name = name;
-        this.path = path;
-    }
+            case TLCP_ECC_SM4_GCM_SM3:
+                return "ECC-SM2-SM4-GCM-SM3";
 
-    public BabaSSL(String name, String path) {
-        this(name, Paths.get(path));
-    }
+            case TLCP_ECDHE_SM4_GCM_SM3:
+                return "ECDHE-SM2-SM4-GCM-SM3";
 
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public Path getPath() {
-        return path;
+            default:
+                return null;
+        }
     }
 }

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/JdkServerTongsuoClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/JdkServerTongsuoClientTest.java
@@ -15,11 +15,12 @@
  * You should have received a copy of the GNU General Public License version
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 package com.tencent.kona.ssl.tlcp;
 
-import com.tencent.kona.ssl.interop.BabaSSLClient;
+import com.tencent.kona.ssl.interop.TongsuoClient;
 import com.tencent.kona.ssl.interop.CertTuple;
 import com.tencent.kona.ssl.interop.CipherSuite;
 import com.tencent.kona.ssl.interop.Client;
@@ -46,9 +47,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 /**
- * The interop test between JDK server and BabaSSL(OpenSSL) client.
+ * The interop test between JDK server and Tongsuo(OpenSSL) client.
  */
-public class JdkServerBabaSSLClientTest {
+public class JdkServerTongsuoClientTest {
 
     private static final Path SESS_FILE = Paths.get("build", "openssl.sess");
 
@@ -143,7 +144,7 @@ public class JdkServerBabaSSLClientTest {
             executor.submit(new ServerCaller(server));
             Utilities.waitFor(Server::isAlive, server);
 
-            BabaSSLClient.Builder clientBuilder = new BabaSSLClient.Builder();
+            TongsuoClient.Builder clientBuilder = new TongsuoClient.Builder();
             clientBuilder.setCertTuple(clientCertTuple);
             clientBuilder.setProtocols(Protocol.TLCPV1_1);
             clientBuilder.setCipherSuites(clientCipherSuite);
@@ -187,10 +188,10 @@ public class JdkServerBabaSSLClientTest {
             executor.submit(new ServerCaller(server));
             Utilities.waitFor(Server::isAlive, server);
 
-            BabaSSLClient.Builder clientBuilder = createClientBuilder(
+            TongsuoClient.Builder clientBuilder = createClientBuilder(
                     clientCertTuple, clientCipherSuite);
             clientBuilder.setAppProtocols("h2");
-            try (BabaSSLClient client = clientBuilder.build()) {
+            try (TongsuoClient client = clientBuilder.build()) {
                 client.connect("127.0.0.1", server.getPort());
                 Assertions.assertEquals("h2", server.getNegoAppProtocol());
             }
@@ -229,10 +230,10 @@ public class JdkServerBabaSSLClientTest {
             executor.submit(new ServerCaller(server));
             Utilities.waitFor(Server::isAlive, server);
 
-            BabaSSLClient.Builder clientBuilder = createClientBuilder(
+            TongsuoClient.Builder clientBuilder = createClientBuilder(
                     clientCertTuple, clientCipherSuite);
             clientBuilder.setServerNames("www.example.com");
-            try (BabaSSLClient client = clientBuilder.build()) {
+            try (TongsuoClient client = clientBuilder.build()) {
                 client.connect("127.0.0.1", server.getPort());
             }
         } finally {
@@ -292,7 +293,7 @@ public class JdkServerBabaSSLClientTest {
             Utilities.waitFor(Server::isAlive, server);
 
             long firstCreationTime = 0;
-            try (BabaSSLClient client = createClientBuilder(
+            try (TongsuoClient client = createClientBuilder(
                     clientCertTuple, clientCipherSuite,
                     useSessionTicket,
                     SESS_FILE, true).build()) {
@@ -300,7 +301,7 @@ public class JdkServerBabaSSLClientTest {
                 firstCreationTime = server.getSession().getCreationTime();
             }
 
-            try (BabaSSLClient client = createClientBuilder(
+            try (TongsuoClient client = createClientBuilder(
                     clientCertTuple, clientCipherSuite,
                     useSessionTicket,
                     SESS_FILE, false).build()) {
@@ -314,10 +315,10 @@ public class JdkServerBabaSSLClientTest {
         }
     }
 
-    private BabaSSLClient.Builder createClientBuilder(CertTuple certTuple,
-            CipherSuite cipherSuite, boolean useSessionTicket,
-            Path sessFile, boolean saveSess) {
-        BabaSSLClient.Builder builder = new BabaSSLClient.Builder();
+    private TongsuoClient.Builder createClientBuilder(CertTuple certTuple,
+                                                      CipherSuite cipherSuite, boolean useSessionTicket,
+                                                      Path sessFile, boolean saveSess) {
+        TongsuoClient.Builder builder = new TongsuoClient.Builder();
         builder.setCertTuple(certTuple);
         builder.setProtocols(Protocol.TLCPV1_1);
         builder.setCipherSuites(cipherSuite);
@@ -337,8 +338,8 @@ public class JdkServerBabaSSLClientTest {
         return builder;
     }
 
-    private BabaSSLClient.Builder createClientBuilder(CertTuple certTuple,
-            CipherSuite cipherSuite) {
+    private TongsuoClient.Builder createClientBuilder(CertTuple certTuple,
+                                                      CipherSuite cipherSuite) {
         return createClientBuilder(certTuple, cipherSuite, false, null, false);
     }
 }

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/TongsuoServerJdkClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/TongsuoServerJdkClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,7 +19,7 @@
 
 package com.tencent.kona.ssl.tlcp;
 
-import com.tencent.kona.ssl.interop.BabaSSLServer;
+import com.tencent.kona.ssl.interop.TongsuoServer;
 import com.tencent.kona.ssl.interop.CertTuple;
 import com.tencent.kona.ssl.interop.CipherSuite;
 import com.tencent.kona.ssl.interop.Client;
@@ -56,9 +56,9 @@ import static com.tencent.kona.ssl.tlcp.TlcpUtils.SERVER_ENC_CERT;
 import static com.tencent.kona.ssl.tlcp.TlcpUtils.SERVER_SIGN_CERT;
 
 /**
- * The interop test between BabaSSL(OpenSSL) server and JDK client.
+ * The interop test between Tongsuo(OpenSSL) server and JDK client.
  */
-public class BabaSSLServerJdkClientTest {
+public class TongsuoServerJdkClientTest {
 
     private static final Path PAGE_FILE = Paths.get("build", "tlcp-page");
 
@@ -71,7 +71,7 @@ public class BabaSSLServerJdkClientTest {
 
     private static void createWebPage() throws IOException {
         Files.write(PAGE_FILE,
-                "BabaSSL server".getBytes(Utilities.CHARSET),
+                "Tongsuo server".getBytes(Utilities.CHARSET),
                 StandardOpenOption.CREATE);
     }
 
@@ -151,7 +151,7 @@ public class BabaSSLServerJdkClientTest {
 
         ExecutorService executor = Executors.newFixedThreadPool(1);
 
-        BabaSSLServer.Builder serverBuilder = new BabaSSLServer.Builder();
+        TongsuoServer.Builder serverBuilder = new TongsuoServer.Builder();
         serverBuilder.setCertTuple(serverCertTuple);
         serverBuilder.setCipherSuites(
                 CipherSuite.TLCP_ECC_SM4_CBC_SM3,
@@ -188,7 +188,7 @@ public class BabaSSLServerJdkClientTest {
 
         ExecutorService executor = Executors.newFixedThreadPool(1);
 
-        BabaSSLServer.Builder serverBuilder = new BabaSSLServer.Builder();
+        TongsuoServer.Builder serverBuilder = new TongsuoServer.Builder();
         serverBuilder.setContextProtocol(ContextProtocol.TLCP11);
         serverBuilder.setCertTuple(certTuple);
         serverBuilder.setAppProtocols("HTTP/1.1", "h2");
@@ -211,7 +211,7 @@ public class BabaSSLServerJdkClientTest {
     }
 
 //    @Test
-    // TODO BabaSSL s_server doesn't support the testing for SNI on TLCP yet.
+    // TODO Tongsuo s_server doesn't support the testing for SNI on TLCP yet.
     public void testSNI() throws Exception {
         testSNI(CipherSuite.TLCP_ECC_SM4_CBC_SM3, ClientAuth.NONE);
         testSNI(CipherSuite.TLCP_ECC_SM4_CBC_SM3, ClientAuth.REQUIRED);
@@ -226,7 +226,7 @@ public class BabaSSLServerJdkClientTest {
 
         ExecutorService executor = Executors.newFixedThreadPool(1);
 
-        BabaSSLServer.Builder serverBuilder = new BabaSSLServer.Builder();
+        TongsuoServer.Builder serverBuilder = new TongsuoServer.Builder();
         serverBuilder.setContextProtocol(ContextProtocol.TLCP11);
         serverBuilder.setCertTuple(certTuple);
         serverBuilder.setServerNames("www.example.com");
@@ -288,7 +288,7 @@ public class BabaSSLServerJdkClientTest {
 
         ExecutorService executor = Executors.newFixedThreadPool(1);
 
-        BabaSSLServer.Builder serverBuilder = new BabaSSLServer.Builder();
+        TongsuoServer.Builder serverBuilder = new TongsuoServer.Builder();
         serverBuilder.setCertTuple(certTuple);
         serverBuilder.setCipherSuites(
                 CipherSuite.TLCP_ECC_SM4_CBC_SM3,

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/JdkServerTongsuoClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/JdkServerTongsuoClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,10 @@ import com.tencent.kona.ssl.interop.Client;
 import com.tencent.kona.ssl.interop.ClientAuth;
 import com.tencent.kona.ssl.interop.FileCert;
 import com.tencent.kona.ssl.interop.HashAlgorithm;
-import com.tencent.kona.ssl.interop.JdkClient;
-import com.tencent.kona.ssl.interop.JdkProcClient;
+import com.tencent.kona.ssl.interop.JdkServer;
 import com.tencent.kona.ssl.interop.KeyAlgorithm;
 import com.tencent.kona.ssl.interop.NamedGroup;
-import com.tencent.kona.ssl.interop.OpenSSLServer;
+import com.tencent.kona.ssl.interop.OpenSSLClient;
 import com.tencent.kona.ssl.interop.Protocol;
 import com.tencent.kona.ssl.interop.Server;
 import com.tencent.kona.ssl.interop.ServerCaller;
@@ -42,19 +41,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 /**
- * The interop testing between BabaSSL(OpenSSL) server and JDK client.
+ * The interop testing between JDK server and OpenSSL client.
  */
-public class BabaSSLServerJdkClientTest {
+public class JdkServerTongsuoClientTest {
 
     private static final FileCert ECDSA_INTCA_CERT = new FileCert(
             KeyAlgorithm.EC, SignatureAlgorithm.ECDSA, HashAlgorithm.SHA256,
@@ -74,28 +71,21 @@ public class BabaSSLServerJdkClientTest {
             "ee-sm2sm2-sm2sm2-sm2sm2.crt",
             "ee-sm2sm2-sm2sm2-sm2sm2.key");
 
-    private static final Path PAGE_FILE = Paths.get("build", "page");
+    private static final Path SESS_FILE = Paths.get("build", "openssl.sess");
 
     @BeforeAll
     public static void setup() throws IOException {
+        deleteSessFile();
         TestUtils.addProviders();
-        deleteWebPage();
-        createWebPage();
-    }
-
-    private static void createWebPage() throws IOException {
-        Files.write(PAGE_FILE,
-                "OpenSSL server".getBytes(Utilities.CHARSET),
-                StandardOpenOption.CREATE);
     }
 
     @AfterAll
     public static void clean() throws IOException {
-        deleteWebPage();
+        deleteSessFile();
     }
 
-    private static void deleteWebPage() throws IOException {
-        Files.deleteIfExists(PAGE_FILE);
+    private static void deleteSessFile() throws IOException {
+        Files.deleteIfExists(SESS_FILE);
     }
 
     @Test
@@ -233,19 +223,45 @@ public class BabaSSLServerJdkClientTest {
                 clientAuth);
     }
 
+    @Test
+    public void testCertSelectionWithSignatureSchemeOnTLS13()
+            throws Exception {
+        // The JDK server selects ECDSA_EE_CERT due to
+        // the OpenSSL client prefers to ECDSA_SECP256R1_SHA256.
+        connect(
+                new FileCert[] { ECDSA_INTCA_CERT },
+                new FileCert[] { SM_EE_CERT, ECDSA_EE_CERT },
+                Protocol.TLSV1_3,
+                CipherSuite.TLS_AES_128_GCM_SHA256,
+                NamedGroup.SECP256R1,
+                SignatureScheme.ECDSA_SECP256R1_SHA256,
+                ClientAuth.NONE);
+
+        // The JDK server selects SM_EE_CERT due to
+        // the OpenSSL client prefers to SM2SIG_SM3.
+        connect(
+                new FileCert[] { SM_INTCA_CERT },
+                new FileCert[] { ECDSA_EE_CERT, SM_EE_CERT },
+                Protocol.TLSV1_3,
+                CipherSuite.TLS_AES_128_GCM_SHA256,
+                NamedGroup.SECP256R1,
+                SignatureScheme.SM2SIG_SM3,
+                ClientAuth.NONE);
+    }
+
     private void connect(
             FileCert[] trustedCerts,
             FileCert[] eeCerts,
             Protocol clientProtocol,
             CipherSuite clientCipherSuite,
             NamedGroup clientNamedGroup,
-            SignatureScheme signatureScheme,
+            SignatureScheme clientSignatureScheme,
             ClientAuth clientAuth) throws Exception {
         CertTuple certTuple = new CertTuple(trustedCerts, eeCerts);
 
         ExecutorService executor = Executors.newFixedThreadPool(1);
 
-        OpenSSLServer.Builder serverBuilder = new OpenSSLServer.Builder();
+        JdkServer.Builder serverBuilder = new JdkServer.Builder();
         serverBuilder.setCertTuple(certTuple);
         serverBuilder.setProtocols(Protocol.TLSV1_3, Protocol.TLSV1_2);
         serverBuilder.setCipherSuites(
@@ -259,32 +275,15 @@ public class BabaSSLServerJdkClientTest {
             executor.submit(new ServerCaller(server));
             Utilities.waitFor(Server::isAlive, server);
 
-            try (Client client = createProcClient(
+            try (Client client = createClient(
                     certTuple, clientProtocol,
                     clientCipherSuite, clientNamedGroup,
-                    signatureScheme)) {
+                    clientSignatureScheme)) {
                 client.connect("127.0.0.1", server.getPort());
             }
         } finally {
             executor.shutdown();
         }
-    }
-
-    private JdkProcClient createProcClient(
-            CertTuple certTuple, Protocol protocol,
-            CipherSuite cipherSuite, NamedGroup namedGroup,
-            SignatureScheme signatureScheme) throws Exception {
-        JdkProcClient.Builder builder = new JdkProcClient.Builder();
-        builder.setCertTuple(certTuple);
-        builder.setProtocols(protocol);
-        builder.setCipherSuites(cipherSuite);
-        builder.setNamedGroups(namedGroup);
-        builder.setSignatureSchemes(signatureScheme);
-        builder.setMessage(
-                // An HTTP request asks to access the page.
-                String.format("GET /%s HTTP/1.1\r\n", PAGE_FILE));
-        builder.setReadResponse(true);
-        return builder.build();
     }
 
     @Test
@@ -389,7 +388,7 @@ public class BabaSSLServerJdkClientTest {
 
         ExecutorService executor = Executors.newFixedThreadPool(1);
 
-        OpenSSLServer.Builder serverBuilder = new OpenSSLServer.Builder();
+        JdkServer.Builder serverBuilder = new JdkServer.Builder();
         serverBuilder.setCertTuple(certTuple);
         serverBuilder.setProtocols(Protocol.TLSV1_3, Protocol.TLSV1_2);
         serverBuilder.setCipherSuites(
@@ -397,33 +396,30 @@ public class BabaSSLServerJdkClientTest {
                 CipherSuite.TLS_SM4_GCM_SM3,
                 CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
                 CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256);
-        serverBuilder.setUseSessTicket(isUseSessTicket);
         serverBuilder.setClientAuth(clientAuth);
 
-        try (Server server = serverBuilder.build()) {
+        try (JdkServer server = serverBuilder.build()) {
             executor.submit(new ServerCaller(server));
             Utilities.waitFor(Server::isAlive, server);
 
-            SSLContext context = null;
             long firstCreationTime = 0;
-            try (JdkClient client = createClient(
-                    certTuple, clientProtocol,
-                    clientCipherSuite, clientNamedGroup,
-                    clientSignatureScheme,
-                    null)) {
+            try (OpenSSLClient client = createClient(
+                    certTuple, clientProtocol, clientCipherSuite,
+                    clientNamedGroup, clientSignatureScheme,
+                    isUseSessTicket,
+                    SESS_FILE, true)) {
                 client.connect("127.0.0.1", server.getPort());
-                context = client.context;
-                firstCreationTime = client.getSession().getCreationTime();
+                firstCreationTime = server.getSession().getCreationTime();
             }
 
-            try (JdkClient client = createClient(
-                    certTuple, clientProtocol,
-                    clientCipherSuite, clientNamedGroup,
-                    clientSignatureScheme,
-                    context)) {
+            try (OpenSSLClient client = createClient(
+                    certTuple, clientProtocol, clientCipherSuite,
+                    clientNamedGroup, clientSignatureScheme,
+                    isUseSessTicket,
+                    SESS_FILE, false)) {
                 client.connect("127.0.0.1", server.getPort());
 
-                long secondCreationTime = client.getSession().getCreationTime();
+                long secondCreationTime = server.getSession().getCreationTime();
                 Assertions.assertEquals(firstCreationTime, secondCreationTime);
             }
         } finally {
@@ -431,22 +427,37 @@ public class BabaSSLServerJdkClientTest {
         }
     }
 
-    private JdkClient createClient(
-            CertTuple certTuple, Protocol protocol,
+    private OpenSSLClient createClient(CertTuple certTuple, Protocol protocol,
             CipherSuite cipherSuite, NamedGroup namedGroup,
             SignatureScheme signatureScheme,
-            SSLContext context) throws Exception {
-        JdkClient.Builder builder = new JdkClient.Builder();
+            boolean isUseSessTicket,
+            Path sessFile, boolean saveSess) {
+        OpenSSLClient.Builder builder = new OpenSSLClient.Builder();
         builder.setCertTuple(certTuple);
         builder.setProtocols(protocol);
         builder.setCipherSuites(cipherSuite);
-//        builder.setNamedGroups(namedGroup);
-//        builder.setSignatureSchemes(signatureScheme);
-        builder.setMessage(
-                // An HTTP request asks to access the page.
-                String.format("GET /%s HTTP/1.1\r\n", PAGE_FILE));
-        builder.setReadResponse(true);
-        builder.setContext(context);
+        builder.setNamedGroups(namedGroup);
+        builder.setSignatureSchemes(signatureScheme);
+        builder.setMessage("Q");  // quit s_client
+        builder.setReadResponse(false);
+        builder.setUseSessTicket(isUseSessTicket);
+
+        if (sessFile != null) {
+            String sessFilePath = sessFile.toAbsolutePath().toString();
+            if (saveSess) {
+                builder.sessOut(sessFilePath);
+            } else {
+                builder.sessIn(sessFilePath);
+            }
+        }
+
         return builder.build();
+    }
+
+    private OpenSSLClient createClient(CertTuple certTuple, Protocol protocol,
+            CipherSuite cipherSuite, NamedGroup namedGroup,
+            SignatureScheme signatureScheme) {
+        return createClient(certTuple, protocol, cipherSuite, namedGroup,
+                signatureScheme, true, null, false);
     }
 }

--- a/kona-ssl/src/test/resources/gen_certs.sh
+++ b/kona-ssl/src/test/resources/gen_certs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ EOF
 
 echo password > password
 
-OPENSSL=babassl
+OPENSSL=tongsuo
 
 ##### CAs
 echo "RSA key CA, signed by SHA256withRSA"

--- a/kona-ssl/src/test/resources/gen_hybrid_certs.sh
+++ b/kona-ssl/src/test/resources/gen_hybrid_certs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ basicConstraints=critical,CA:FALSE
 keyUsage=critical,keyEncipherment,dataEncipherment,keyAgreement
 EOF
 
-OPENSSL=babassl
+OPENSSL=tongsuo
 
 ########## RSA START ##########
 

--- a/kona-ssl/src/test/resources/gen_tlcp_certs.sh
+++ b/kona-ssl/src/test/resources/gen_tlcp_certs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ basicConstraints=critical,CA:FALSE
 keyUsage=critical,keyEncipherment,dataEncipherment,keyAgreement
 EOF
 
-OPENSSL=babassl
+OPENSSL=tongsuo
 
 ##### CA
 $OPENSSL genpkey -algorithm ec -pkeyopt ec_paramgen_curve:SM2 -pkeyopt ec_param_enc:named_curve -out tlcp-ca.key


### PR DESCRIPTION
BabaSSL is already deprecated, so it would be better to use Tongsuo.

This PR will resolves #777.