### PR TITLE
TKSS-785: Tests should prioritize TKSS providers

### DIFF
--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/KonaCryptoProviderTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/KonaCryptoProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,6 @@ public class KonaCryptoProviderTest {
     public void testAddProvider() {
         Provider[] providers = Security.getProviders();
         Assertions.assertEquals(
-                TestUtils.PROVIDER, providers[providers.length - 1].getName());
+                TestUtils.PROVIDER, providers[0].getName());
     }
 }

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/TestUtils.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class TestUtils {
     public static final byte[] EMPTY = new byte[0];
 
     public static void addProviders() {
-        Security.addProvider(new KonaCryptoProvider());
+        Security.insertProviderAt(new KonaCryptoProvider(), 1);
     }
 
     public static void repeatTaskParallelly(Callable<Void> task, int count)

--- a/kona-demo/src/main/java/com/tencent/kona/demo/JettyServer.java
+++ b/kona-demo/src/main/java/com/tencent/kona/demo/JettyServer.java
@@ -49,7 +49,7 @@ import java.security.Security;
 public class JettyServer {
 
     static {
-        Security.addProvider(new KonaProvider());
+        Security.insertProviderAt(new KonaProvider(), 1);
     }
 
     public static void main(String[] args) {

--- a/kona-demo/src/main/java/com/tencent/kona/demo/TomcatServer.java
+++ b/kona-demo/src/main/java/com/tencent/kona/demo/TomcatServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ import java.util.Set;
 public class TomcatServer {
 
     static {
-        Security.addProvider(new KonaProvider());
+        Security.insertProviderAt(new KonaProvider(), 1);
     }
 
     public static void main(String[] args) {

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,8 +91,8 @@ public class TestUtils {
             "--add-exports", "java.base/jdk.internal.access=ALL-UNNAMED");
 
     public static void addProviders() {
-        Security.addProvider(new KonaCryptoProvider());
-        Security.addProvider(new KonaPKIXProvider());
+        Security.insertProviderAt(new KonaCryptoProvider(), 1);
+        Security.insertProviderAt(new KonaPKIXProvider(), 2);
     }
 
     public static Path resFilePath(String resource) {

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/TestUtils.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,9 +94,9 @@ public class TestUtils {
     }
 
     public static void addProviders() {
-        Security.addProvider(new KonaCryptoProvider());
-        Security.addProvider(new KonaPKIXProvider());
-        Security.addProvider(new KonaSSLProvider());
+        Security.insertProviderAt(new KonaCryptoProvider(), 1);
+        Security.insertProviderAt(new KonaPKIXProvider(), 2);
+        Security.insertProviderAt(new KonaSSLProvider(), 3);
     }
 
     public static Path resFilePath(String resource) {


### PR DESCRIPTION
The recent Tencent Kona JDKs, say [8.0.18/8u412](https://github.com/Tencent/TencentKona-8/releases/tag/8.0.18-GA),  already support ShangMi algorithms and protocol.
When using such JDKs, the tests may invoke the implementations from the JDKs, but not TKSS providers.
So, it has to put TKSS providers to the highest positions in the provider list.

This PR will resolves #785.