### PR TITLE
TKSS-791: Tests use the default key store type, trust and key manager algorithms

### DIFF
--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkClient.java
@@ -76,6 +76,7 @@ public class JdkClient extends AbstractClient {
     protected SSLContext getContext(Builder builder) throws Exception {
         return builder.getContext() == null
                 ? Utilities.createSSLContext(builder.getProvider(),
+                        builder.getKeystoreType(),
                         builder.getTrustManagerAlgo(), builder.getKeyManagerAlgo(),
                         builder.getContextProtocol(), builder.getCertTuple())
                 : builder.getContext();

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkClient.java
@@ -26,15 +26,11 @@ package com.tencent.kona.ssl.interop;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
+import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.net.ssl.SNIHostName;
-import javax.net.ssl.SNIServerName;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLParameters;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.SSLSocket;
+import javax.net.ssl.*;
 
 /*
  * A JDK client based on SSLSocket.
@@ -80,6 +76,7 @@ public class JdkClient extends AbstractClient {
     protected SSLContext getContext(Builder builder) throws Exception {
         return builder.getContext() == null
                 ? Utilities.createSSLContext(builder.getProvider(),
+                        builder.getTrustManagerAlgo(), builder.getKeyManagerAlgo(),
                         builder.getContextProtocol(), builder.getCertTuple())
                 : builder.getContext();
     }
@@ -113,6 +110,10 @@ public class JdkClient extends AbstractClient {
 
         private Provider provider = Provider.KONA;
 
+        private String keystoreType = KeyStore.getDefaultType();
+        private String trustManagerAlgo = TrustManagerFactory.getDefaultAlgorithm();
+        private String keyManagerAlgo = KeyManagerFactory.getDefaultAlgorithm();
+
         private ConnectionInterceptor interceptor;
         private SSLContext context;
 
@@ -120,8 +121,35 @@ public class JdkClient extends AbstractClient {
             return provider;
         }
 
-        public AbstractPeer.Builder setProvider(Provider provider) {
+        public Builder setProvider(Provider provider) {
             this.provider = provider;
+            return this;
+        }
+
+        public String getKeystoreType() {
+            return keystoreType;
+        }
+
+        public Builder setKeystoreType(String keystoreType) {
+            this.keystoreType = keystoreType;
+            return this;
+        }
+
+        public String getTrustManagerAlgo() {
+            return trustManagerAlgo;
+        }
+
+        public Builder setTrustManagerAlgo(String trustManagerAlgo) {
+            this.trustManagerAlgo = trustManagerAlgo;
+            return this;
+        }
+
+        public String getKeyManagerAlgo() {
+            return keyManagerAlgo;
+        }
+
+        public Builder setKeyManagerAlgo(String keyManagerAlgo) {
+            this.keyManagerAlgo = keyManagerAlgo;
             return this;
         }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkHttpsClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkHttpsClient.java
@@ -25,9 +25,12 @@ package com.tencent.kona.ssl.interop;
 
 import java.io.IOException;
 import java.net.URL;
+import java.security.KeyStore;
 
 import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 
 /*
  * A JDK client based on HttpsURLConnection.
@@ -49,6 +52,7 @@ public class JdkHttpsClient extends AbstractClient {
     protected SSLContext getContext(Builder builder) throws Exception {
         return builder.getContext() == null
                 ? Utilities.createSSLContext(builder.getProvider(),
+                        builder.getTrustManagerAlgo(), builder.getKeyManagerAlgo(),
                         builder.getContextProtocol(), builder.getCertTuple())
                 : builder.getContext();
     }
@@ -58,6 +62,10 @@ public class JdkHttpsClient extends AbstractClient {
         private String path = "";
 
         private Provider provider = Provider.KONA;
+
+        private String keystoreType = KeyStore.getDefaultType();
+        private String trustManagerAlgo = TrustManagerFactory.getDefaultAlgorithm();
+        private String keyManagerAlgo = KeyManagerFactory.getDefaultAlgorithm();
 
         private SSLContext context;
 
@@ -74,8 +82,35 @@ public class JdkHttpsClient extends AbstractClient {
             return provider;
         }
 
-        public AbstractPeer.Builder setProvider(Provider provider) {
+        public Builder setProvider(Provider provider) {
             this.provider = provider;
+            return this;
+        }
+
+        public String getKeystoreType() {
+            return keystoreType;
+        }
+
+        public Builder setKeystoreType(String keystoreType) {
+            this.keystoreType = keystoreType;
+            return this;
+        }
+
+        public String getTrustManagerAlgo() {
+            return trustManagerAlgo;
+        }
+
+        public Builder setTrustManagerAlgo(String trustManagerAlgo) {
+            this.trustManagerAlgo = trustManagerAlgo;
+            return this;
+        }
+
+        public String getKeyManagerAlgo() {
+            return keyManagerAlgo;
+        }
+
+        public Builder setKeyManagerAlgo(String keyManagerAlgo) {
+            this.keyManagerAlgo = keyManagerAlgo;
             return this;
         }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkHttpsClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkHttpsClient.java
@@ -52,6 +52,7 @@ public class JdkHttpsClient extends AbstractClient {
     protected SSLContext getContext(Builder builder) throws Exception {
         return builder.getContext() == null
                 ? Utilities.createSSLContext(builder.getProvider(),
+                        builder.getKeystoreType(),
                         builder.getTrustManagerAlgo(), builder.getKeyManagerAlgo(),
                         builder.getContextProtocol(), builder.getCertTuple())
                 : builder.getContext();

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcClient.java
@@ -25,8 +25,11 @@ package com.tencent.kona.ssl.interop;
 
 import com.tencent.kona.ssl.TestUtils;
 
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.security.KeyStore;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -50,6 +53,10 @@ public class JdkProcClient extends AbstractClient {
         }
 
         props.put(JdkProcUtils.PROP_PROVIDER, builder.getProvider().name);
+
+        props.put(JdkProcUtils.PROP_KEYSTORE_TYPE, builder.getKeystoreType());
+        props.put(JdkProcUtils.PROP_TRUST_MANAGER_ALGO, builder.getTrustManagerAlgo());
+        props.put(JdkProcUtils.PROP_KEY_MANAGER_ALGO, builder.getKeyManagerAlgo());
 
         if (builder.getCertTuple() != null) {
             props.put(JdkProcUtils.PROP_TRUSTED_CERTS,
@@ -116,6 +123,10 @@ public class JdkProcClient extends AbstractClient {
 
         private Provider provider = Provider.KONA;
 
+        private String keystoreType = KeyStore.getDefaultType();
+        private String trustManagerAlgo = TrustManagerFactory.getDefaultAlgorithm();
+        private String keyManagerAlgo = KeyManagerFactory.getDefaultAlgorithm();
+
         private Path secPropsFile;
 
         public Jdk getJdk() {
@@ -140,11 +151,37 @@ public class JdkProcClient extends AbstractClient {
             return provider;
         }
 
-        public AbstractPeer.Builder setProvider(Provider provider) {
+        public Builder setProvider(Provider provider) {
             this.provider = provider;
             return this;
         }
 
+        public String getKeystoreType() {
+            return keystoreType;
+        }
+
+        public Builder setKeystoreType(String keystoreType) {
+            this.keystoreType = keystoreType;
+            return this;
+        }
+
+        public String getTrustManagerAlgo() {
+            return trustManagerAlgo;
+        }
+
+        public Builder setTrustManagerAlgo(String trustManagerAlgo) {
+            this.trustManagerAlgo = trustManagerAlgo;
+            return this;
+        }
+
+        public String getKeyManagerAlgo() {
+            return keyManagerAlgo;
+        }
+
+        public Builder setKeyManagerAlgo(String keyManagerAlgo) {
+            this.keyManagerAlgo = keyManagerAlgo;
+            return this;
+        }
 
         @Override
         public JdkProcClient build() {
@@ -188,6 +225,10 @@ public class JdkProcClient extends AbstractClient {
             TestUtils.addProviders();
         }
 
+        String keystoreStr = System.getProperty(JdkProcUtils.PROP_KEYSTORE_TYPE);
+        String trustManagerAlgoStr = System.getProperty(JdkProcUtils.PROP_TRUST_MANAGER_ALGO);
+        String keyManagerAlgoStr = System.getProperty(JdkProcUtils.PROP_KEY_MANAGER_ALGO);
+
         String trustedCertsStr = System.getProperty(JdkProcUtils.PROP_TRUSTED_CERTS);
         String eeCertsStr = System.getProperty(JdkProcUtils.PROP_EE_CERTS);
 
@@ -206,6 +247,11 @@ public class JdkProcClient extends AbstractClient {
 
         JdkClient.Builder builder = new JdkClient.Builder();
         builder.setProvider(Provider.provider(providerStr));
+
+        builder.setKeystoreType(keystoreStr);
+        builder.setTrustManagerAlgo(trustManagerAlgoStr);
+        builder.setKeyManagerAlgo(keyManagerAlgoStr);
+
         builder.setCertTuple(JdkProcUtils.createCertTuple(
                 trustedCertsStr, eeCertsStr));
         builder.setContextProtocol(

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcServer.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcServer.java
@@ -25,10 +25,13 @@ package com.tencent.kona.ssl.interop;
 
 import com.tencent.kona.ssl.TestUtils;
 
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.KeyStore;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -54,6 +57,10 @@ public class JdkProcServer extends AbstractServer {
         }
 
         props.put(JdkProcUtils.PROP_PROVIDER, builder.getProvider().name);
+
+        props.put(JdkProcUtils.PROP_KEYSTORE_TYPE, builder.getKeystoreType());
+        props.put(JdkProcUtils.PROP_TRUST_MANAGER_ALGO, builder.getTrustManagerAlgo());
+        props.put(JdkProcUtils.PROP_KEY_MANAGER_ALGO, builder.getKeyManagerAlgo());
 
         if (builder.getCertTuple() != null) {
             props.put(JdkProcUtils.PROP_TRUSTED_CERTS,
@@ -120,6 +127,10 @@ public class JdkProcServer extends AbstractServer {
 
         private Provider provider = Provider.KONA;
 
+        private String keystoreType = KeyStore.getDefaultType();
+        private String trustManagerAlgo = TrustManagerFactory.getDefaultAlgorithm();
+        private String keyManagerAlgo = KeyManagerFactory.getDefaultAlgorithm();
+
         public Jdk getJdk() {
             return jdk;
         }
@@ -142,8 +153,35 @@ public class JdkProcServer extends AbstractServer {
             return provider;
         }
 
-        public AbstractPeer.Builder setProvider(Provider provider) {
+        public Builder setProvider(Provider provider) {
             this.provider = provider;
+            return this;
+        }
+
+        public String getKeystoreType() {
+            return keystoreType;
+        }
+
+        public Builder setKeystoreType(String keystoreType) {
+            this.keystoreType = keystoreType;
+            return this;
+        }
+
+        public String getTrustManagerAlgo() {
+            return trustManagerAlgo;
+        }
+
+        public Builder setTrustManagerAlgo(String trustManagerAlgo) {
+            this.trustManagerAlgo = trustManagerAlgo;
+            return this;
+        }
+
+        public String getKeyManagerAlgo() {
+            return keyManagerAlgo;
+        }
+
+        public Builder setKeyManagerAlgo(String keyManagerAlgo) {
+            this.keyManagerAlgo = keyManagerAlgo;
             return this;
         }
 
@@ -225,6 +263,10 @@ public class JdkProcServer extends AbstractServer {
             TestUtils.addProviders();
         }
 
+        String keystoreStr = System.getProperty(JdkProcUtils.PROP_KEYSTORE_TYPE);
+        String trustManagerAlgoStr = System.getProperty(JdkProcUtils.PROP_TRUST_MANAGER_ALGO);
+        String keyManagerAlgoStr = System.getProperty(JdkProcUtils.PROP_KEY_MANAGER_ALGO);
+
         String trustedCertsStr = System.getProperty(JdkProcUtils.PROP_TRUSTED_CERTS);
         String eeCertsStr = System.getProperty(JdkProcUtils.PROP_EE_CERTS);
 
@@ -243,6 +285,11 @@ public class JdkProcServer extends AbstractServer {
 
         JdkServer.Builder builder = new JdkServer.Builder();
         builder.setProvider(Provider.provider(providerStr));
+
+        builder.setKeystoreType(keystoreStr);
+        builder.setTrustManagerAlgo(trustManagerAlgoStr);
+        builder.setKeyManagerAlgo(keyManagerAlgoStr);
+
         builder.setCertTuple(JdkProcUtils.createCertTuple(
                 trustedCertsStr, eeCertsStr));
         builder.setContextProtocol(

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcUtils.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcUtils.java
@@ -42,6 +42,9 @@ public class JdkProcUtils {
 
     public static final String PROP_SEC_PROPS_FILE = "java.security.properties";
     public static final String PROP_PROVIDER = "test.provider";
+    public static final String PROP_KEYSTORE_TYPE = "test.keystore.type";
+    public static final String PROP_TRUST_MANAGER_ALGO = "test.trust.manager.algo";
+    public static final String PROP_KEY_MANAGER_ALGO = "test.key.manager.algo";
     public static final String PROP_CTX_PROTOCOL = "test.context.protocol";
     public static final String PROP_PROTOCOLS = "test.protocols";
     public static final String PROP_CIPHER_SUITES = "test.cipher.suites";

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkServer.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkServer.java
@@ -25,17 +25,11 @@ package com.tencent.kona.ssl.interop;
 
 import java.io.IOException;
 import java.net.SocketException;
+import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.net.ssl.SNIHostName;
-import javax.net.ssl.SNIMatcher;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLParameters;
-import javax.net.ssl.SSLServerSocket;
-import javax.net.ssl.SSLServerSocketFactory;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.SSLSocket;
+import javax.net.ssl.*;
 
 /*
  * A JDK server based on SSLServerSocket.
@@ -69,6 +63,7 @@ public class JdkServer extends AbstractServer {
         response = builder.getMessage();
 
         context = Utilities.createSSLContext(builder.getProvider(),
+                builder.getTrustManagerAlgo(), builder.getKeyManagerAlgo(),
                 builder.getContextProtocol(), builder.getCertTuple());
         SSLServerSocketFactory serverFactory = context.getServerSocketFactory();
         serverSocket
@@ -117,12 +112,43 @@ public class JdkServer extends AbstractServer {
 
         private Provider provider = Provider.KONA;
 
+        private String keystoreType = KeyStore.getDefaultType();
+        private String trustManagerAlgo = TrustManagerFactory.getDefaultAlgorithm();
+        private String keyManagerAlgo = KeyManagerFactory.getDefaultAlgorithm();
+
         public Provider getProvider() {
             return provider;
         }
 
         public AbstractPeer.Builder setProvider(Provider provider) {
             this.provider = provider;
+            return this;
+        }
+
+        public String getKeystoreType() {
+            return keystoreType;
+        }
+
+        public Builder setKeystoreType(String keystoreType) {
+            this.keystoreType = keystoreType;
+            return this;
+        }
+
+        public String getTrustManagerAlgo() {
+            return trustManagerAlgo;
+        }
+
+        public Builder setTrustManagerAlgo(String trustManagerAlgo) {
+            this.trustManagerAlgo = trustManagerAlgo;
+            return this;
+        }
+
+        public String getKeyManagerAlgo() {
+            return keyManagerAlgo;
+        }
+
+        public Builder setKeyManagerAlgo(String keyManagerAlgo) {
+            this.keyManagerAlgo = keyManagerAlgo;
             return this;
         }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkServer.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkServer.java
@@ -63,6 +63,7 @@ public class JdkServer extends AbstractServer {
         response = builder.getMessage();
 
         context = Utilities.createSSLContext(builder.getProvider(),
+                builder.getKeystoreType(),
                 builder.getTrustManagerAlgo(), builder.getKeyManagerAlgo(),
                 builder.getContextProtocol(), builder.getCertTuple());
         SSLServerSocketFactory serverFactory = context.getServerSocketFactory();

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/Utilities.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/Utilities.java
@@ -112,6 +112,7 @@ public class Utilities {
     }
 
     public static SSLContext createSSLContext(Provider provider,
+            String trustManagerAlgorithm, String keyManagerAlgorithm,
             ContextProtocol contextProtocol, CertTuple certTuple) throws Exception {
         String sslProvider = provider == Provider.JDK ? "SunJSSE" : "KonaSSL";
         String keystoreProvider = provider == Provider.JDK ? "SunJSSE" : "KonaPKIX";
@@ -119,17 +120,26 @@ public class Utilities {
 
         KeyStore trustStore = createTrustStore(
                 keystoreProvider, pkixProvider, certTuple.trustedCerts);
-        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PKIX", sslProvider);
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(
+                trustManagerAlgorithm, sslProvider);
         tmf.init(trustStore);
 
         KeyStore keyStore = createKeyStore(
                 keystoreProvider, pkixProvider, certTuple.endEntityCerts);
-        KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509", sslProvider);
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(
+                keyManagerAlgorithm, sslProvider);
         kmf.init(keyStore, null);
 
         SSLContext context = SSLContext.getInstance(contextProtocol.name, sslProvider);
         context.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
         return context;
+    }
+
+    public static SSLContext createSSLContext(Provider provider,
+            ContextProtocol contextProtocol, CertTuple certTuple) throws Exception {
+        return createSSLContext(provider,
+                TrustManagerFactory.getDefaultAlgorithm(), KeyManagerFactory.getDefaultAlgorithm(),
+                contextProtocol, certTuple);
     }
 
     /*
@@ -139,7 +149,7 @@ public class Utilities {
             String keystoreProvider, String pkixProvider, Cert... certs)
             throws KeyStoreException, IOException, NoSuchAlgorithmException,
             CertificateException, NoSuchProviderException {
-        KeyStore trustStore = KeyStore.getInstance("PKCS12", keystoreProvider);
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType(), keystoreProvider);
         trustStore.load(null, null);
 
         if (certs != null && certs.length > 0) {
@@ -162,7 +172,7 @@ public class Utilities {
             throws KeyStoreException, IOException, NoSuchAlgorithmException,
             CertificateException, InvalidKeySpecException,
             NoSuchProviderException {
-        KeyStore keyStore = KeyStore.getInstance("PKCS12", keystoreProvider);
+        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType(), keystoreProvider);
         keyStore.load(null, null);
 
         if (certs != null && certs.length > 0) {

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/JdkServerJdkClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/JdkServerJdkClientTest.java
@@ -263,6 +263,7 @@ public class JdkServerJdkClientTest {
         ExecutorService executor = Executors.newFixedThreadPool(1);
 
         JdkServer.Builder serverBuilder = new JdkServer.Builder();
+        serverBuilder.setKeyManagerAlgo("NewSunX509");
         serverBuilder.setCertTuple(serverCertTuple);
         serverBuilder.setProtocols(Protocol.TLSV1_3, Protocol.TLSV1_2);
         serverBuilder.setCipherSuites(

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/JdkServerTongsuoClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/JdkServerTongsuoClientTest.java
@@ -262,6 +262,7 @@ public class JdkServerTongsuoClientTest {
         ExecutorService executor = Executors.newFixedThreadPool(1);
 
         JdkServer.Builder serverBuilder = new JdkServer.Builder();
+        serverBuilder.setKeyManagerAlgo("NewSunX509");
         serverBuilder.setCertTuple(certTuple);
         serverBuilder.setProtocols(Protocol.TLSV1_3, Protocol.TLSV1_2);
         serverBuilder.setCipherSuites(


### PR DESCRIPTION
It would not hard-code the key store type, trust and key manager algorithms.
Instead, just use the defaults.

This PR will resolves #791.