### PR TITLE
TKSS-796: Backport JDK-8332524: Instead of printing "TLSv1.3," it is showing "TLS13"

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ClientHello.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ClientHello.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -906,8 +906,8 @@ final class ClientHello {
             throw context.conContext.fatal(Alert.PROTOCOL_VERSION,
                 "The client supported protocol versions " + Arrays.toString(
                     ProtocolVersion.toStringArray(clientSupportedVersions)) +
-                " are not accepted by server preferences " +
-                context.activeProtocols);
+                " are not accepted by server preferences " + Arrays.toString(
+                ProtocolVersion.toStringArray(context.activeProtocols)));
         }
     }
 


### PR DESCRIPTION
This is a backport of [JDK-8332524]: Instead of printing "TLSv1.3," it is showing "TLS13".

[JDK-8332524]:
https://bugs.openjdk.org/browse/JDK-8332524