### PR TITLE
TKSS-798: Backport JDK-8334670: SSLSocketOutputRecord buffer miscalculation

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLSocketOutputRecord.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLSocketOutputRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,12 +168,12 @@ final class SSLSocketOutputRecord extends OutputRecord implements SSLRecord {
 
             for (int limit = (offset + length); offset < limit;) {
 
-                int remains = (limit - offset) + (count - position);
-                int fragLen = Math.min(fragLimit, remains);
+                int remains = (limit - offset);
+                int fragLen = Math.min(fragLimit - count + position, remains);
 
                 // use the buf of ByteArrayOutputStream
                 write(source, offset, fragLen);
-                if (remains < fragLimit) {
+                if (remains < fragLen) {
                     return;
                 }
 


### PR DESCRIPTION
This a backport of [JDK-8334670]: SSLSocketOutputRecord buffer miscalculation.

This PR will resolves #798.

[JDK-8334670]:
https://bugs.openjdk.org/browse/JDK-8334670