### PR TITLE
TKSS-808: Remove SSLUtils::getECKeyPairGenerator

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/ssl/SSLUtils.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/ssl/SSLUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify
@@ -20,10 +20,6 @@
 
 package com.tencent.kona.ssl;
 
-import com.tencent.kona.crypto.CryptoInsts;
-
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.util.Locale;
 
 /**
@@ -45,11 +41,4 @@ public class SSLUtils {
     }
 
     /* ***** System properties end ***** */
-
-    public static KeyPairGenerator getECKeyPairGenerator(String namedGroup)
-            throws NoSuchAlgorithmException {
-        String algorithm = "curvesm2".equalsIgnoreCase(namedGroup)
-                ? "SM2" : "EC";
-        return CryptoInsts.getKeyPairGenerator(algorithm);
-    }
 }

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ECDHKeyExchange.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ECDHKeyExchange.java
@@ -45,7 +45,6 @@ import javax.crypto.SecretKey;
 import javax.net.ssl.SSLHandshakeException;
 
 import com.tencent.kona.crypto.CryptoInsts;
-import com.tencent.kona.ssl.SSLUtils;
 import com.tencent.kona.sun.security.util.ECUtil;
 import com.tencent.kona.sun.security.ssl.NamedGroup.NamedGroupSpec;
 import com.tencent.kona.sun.security.ssl.X509Authentication.X509Credentials;
@@ -114,8 +113,7 @@ final class ECDHKeyExchange {
 
         ECDHEPossession(NamedGroup namedGroup, SecureRandom random) {
             try {
-                KeyPairGenerator kpg = SSLUtils.getECKeyPairGenerator(
-                        namedGroup.name);
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
                 kpg.initialize(namedGroup.keAlgParamSpec, random);
                 KeyPair kp = kpg.generateKeyPair();
                 privateKey = kp.getPrivate();
@@ -131,8 +129,7 @@ final class ECDHKeyExchange {
         ECDHEPossession(ECDHECredentials credentials, SecureRandom random) {
             ECParameterSpec params = credentials.popPublicKey.getParams();
             try {
-                KeyPairGenerator kpg = SSLUtils.getECKeyPairGenerator(
-                        credentials.namedGroup.name);
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
                 kpg.initialize(params, random);
                 KeyPair kp = kpg.generateKeyPair();
                 privateKey = kp.getPrivate();

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2EKeyExchange.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SM2EKeyExchange.java
@@ -27,7 +27,6 @@ package com.tencent.kona.sun.security.ssl;
 
 import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.crypto.spec.SM2KeyAgreementParamSpec;
-import com.tencent.kona.ssl.SSLUtils;
 import com.tencent.kona.sun.security.ssl.TLCPAuthentication.TLCPPossession;
 import com.tencent.kona.sun.security.util.ECUtil;
 
@@ -116,8 +115,7 @@ public class SM2EKeyExchange {
         SM2EPossession(TLCPPossession tlcpPossession,
                        NamedGroup namedGroup, SecureRandom random) {
             try {
-                KeyPairGenerator kpg
-                        = SSLUtils.getECKeyPairGenerator(namedGroup.name);
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
                 kpg.initialize(namedGroup.keAlgParamSpec, random);
                 KeyPair kp = kpg.generateKeyPair();
                 ephemeralPrivateKey = (ECPrivateKey) kp.getPrivate();
@@ -133,10 +131,9 @@ public class SM2EKeyExchange {
 
         @Override
         public byte[] encode() {
-            byte[] encodedPoint = ECUtil.encodePoint(
+            return ECUtil.encodePoint(
                     ephemeralPublicKey.getW(),
                     ephemeralPublicKey.getParams().getCurve());
-            return encodedPoint;
         }
 
         // called by ClientHandshaker with either the server's static or


### PR DESCRIPTION
`KeyPairGenerator.getInstance("SM2")` is unnecessary due to `KeyPairGenerator.getInstance("EC")` with curve `curveSM` is already supported.
So, the method `SSLUtils::getECKeyPairGenerator` could be removed.

This PR will resolves #808.