### PR TITLE
TKSS-810: Remove key generator TlsRsaPremasterSecret

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/ssl/KonaSSLProvider.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/ssl/KonaSSLProvider.java
@@ -97,7 +97,8 @@ public class KonaSSLProvider extends Provider {
         provider.put("Alg.Alias.KeyGenerator.SunTls12KeyMaterial",
                 "SunTlsKeyMaterial");
 
-        provider.put("KeyGenerator.TlsRsaPremasterSecret",
+        provider.put("KeyGenerator.SunTlsRsaPremasterSecret",
                 "com.tencent.kona.sun.security.provider.TlsRsaPremasterSecretGenerator");
+        provider.put("Alg.Alias.KeyGenerator.SunTls12RsaPremasterSecret", "SunTlsRsaPremasterSecret");
     }
 }

--- a/kona-ssl/src/main/java/com/tencent/kona/ssl/SSLInsts.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/ssl/SSLInsts.java
@@ -96,7 +96,7 @@ public class SSLInsts {
             = new HashSet<>(Arrays.asList(
                     "SunTlsPrf", "SunTls12Prf",
                     "SunTlsMasterSecret", "SunTlsKeyMaterial",
-                    "TlcpSM2PremasterSecret"));
+                    "SunTlsRsaPremasterSecret", "SunTls12RsaPremasterSecret"));
 
     public static KeyGenerator getKeyGenerator(String protocol)
             throws NoSuchAlgorithmException {


### PR DESCRIPTION
Should define key generator `SunTls12RsaPremasterSecret`/`SunTlsRsaPremasterSecret` instead of `TlsRsaPremasterSecret`.

This PR will resolves #810.