### PR TITLE
TKSS-789: Backport JDK-8333364: Minor cleanup could be done in com.sun.crypto.provider

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/com/sun/crypto/provider/HmacCore.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/com/sun/crypto/provider/HmacCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,8 +87,7 @@ public abstract class HmacCore extends MacSpi implements Cloneable {
                                 break;
                             }
                         }
-                    } catch (NoSuchAlgorithmException nsae) {
-                        continue;
+                    } catch (NoSuchAlgorithmException ignored) {
                     }
                 }
                 if (md == null) {
@@ -169,7 +168,7 @@ public abstract class HmacCore extends MacSpi implements Cloneable {
      * @param input the input byte to be processed.
      */
     protected void engineUpdate(byte input) {
-        if (first == true) {
+        if (first) {
             // compute digest for 1st pass; start with inner pad
             md.update(k_ipad);
             first = false;
@@ -187,8 +186,8 @@ public abstract class HmacCore extends MacSpi implements Cloneable {
      * @param offset the offset in <code>input</code> where the input starts.
      * @param len the number of bytes to process.
      */
-    protected void engineUpdate(byte input[], int offset, int len) {
-        if (first == true) {
+    protected void engineUpdate(byte[] input, int offset, int len) {
+        if (first) {
             // compute digest for 1st pass; start with inner pad
             md.update(k_ipad);
             first = false;
@@ -205,7 +204,7 @@ public abstract class HmacCore extends MacSpi implements Cloneable {
      * @param input the input byte buffer.
      */
     protected void engineUpdate(ByteBuffer input) {
-        if (first == true) {
+        if (first) {
             // compute digest for 1st pass; start with inner pad
             md.update(k_ipad);
             first = false;
@@ -221,7 +220,7 @@ public abstract class HmacCore extends MacSpi implements Cloneable {
      * @return the HMAC result.
      */
     protected byte[] engineDoFinal() {
-        if (first == true) {
+        if (first) {
             // compute digest for 1st pass; start with inner pad
             md.update(k_ipad);
         } else {
@@ -250,7 +249,7 @@ public abstract class HmacCore extends MacSpi implements Cloneable {
      * HMAC was initialized with.
      */
     protected void engineReset() {
-        if (first == false) {
+        if (!first) {
             md.reset();
             first = true;
         }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/CipherBlockChaining.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/CipherBlockChaining.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -178,7 +178,7 @@ class CipherBlockChaining extends FeedbackCipher  {
      *
      * <p>It is also the application's responsibility to make sure that
      * <code>init</code> has been called before this method is called.
-     * (This check is omitted here, to avoid double checking.)
+     * (This check is omitted here, to avoid double-checking.)
      *
      * @param cipher the buffer with the input data to be decrypted
      * @param cipherOffset the offset in <code>cipherOffset</code>

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/CipherCore.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/CipherCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ final class CipherCore {
     /*
      * unit size (number of input bytes that can be processed at a time)
      */
-    private int unitBytes = 0;
+    private int unitBytes;
 
     /*
      * index of the content size left in the buffer
@@ -93,17 +93,17 @@ final class CipherCore {
      * input bytes that are processed at a time is different from the block
      * size)
      */
-    private int diffBlocksize = 0;
+    private int diffBlocksize;
 
     /*
      * padding class
      */
-    private Padding padding = null;
+    private Padding padding;
 
     /*
      * internal cipher engine
      */
-    private FeedbackCipher cipher = null;
+    private FeedbackCipher cipher;
 
     /*
      * the cipher mode
@@ -138,7 +138,7 @@ final class CipherCore {
         /*
          * The buffer should be usable for all cipher mode and padding
          * schemes. Thus, it has to be at least (blockSize+1) for CTS.
-         * In decryption mode, it also hold the possible padding block.
+         * In decryption mode, it also holds the possible padding block.
          */
         buffer = new byte[blockSize*2];
 
@@ -318,7 +318,7 @@ final class CipherCore {
         if (cipherMode == ECB_MODE) {
             return null;
         }
-        AlgorithmParameters params = null;
+        AlgorithmParameters params;
         AlgorithmParameterSpec spec;
         byte[] iv = getIV();
         if (iv == null) {
@@ -522,7 +522,7 @@ final class CipherCore {
      */
     byte[] update(byte[] input, int inputOffset, int inputLen) {
 
-        byte[] output = null;
+        byte[] output;
         try {
             output = new byte[getOutputSizeByOperation(inputLen, false)];
             int len = update(input, inputOffset, inputLen, output, 0);
@@ -906,8 +906,7 @@ final class CipherCore {
 
     private int fillOutputBuffer(byte[] finalBuf, int finalOffset,
         byte[] output, int outOfs, int finalBufLen, byte[] input)
-        throws ShortBufferException, BadPaddingException,
-        IllegalBlockSizeException {
+        throws BadPaddingException, IllegalBlockSizeException {
 
         int len;
         try {
@@ -943,7 +942,7 @@ final class CipherCore {
 
     private int finalNoPadding(byte[] in, int inOfs, byte[] out, int outOfs,
                                int len)
-        throws IllegalBlockSizeException, ShortBufferException {
+        throws IllegalBlockSizeException {
 
         if (in == null || len == 0) {
             return 0;

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/CipherTextStealing.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/CipherTextStealing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package com.tencent.kona.crypto.provider;
 
 import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.ShortBufferException;
 
 /**
  * This class represents ciphers in cipher text stealing (CTS) mode.
@@ -153,7 +152,7 @@ final class CipherTextStealing extends CipherBlockChaining {
      *
      * <p>It is also the application's responsibility to make sure that
      * <code>init</code> has been called before this method is called.
-     * (This check is omitted here, to avoid double checking.)
+     * (This check is omitted here, to avoid double-checking.)
      *
      * @param cipher the buffer with the input data to be decrypted
      * @param cipherOffset the offset in <code>cipherOffset</code>

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/ConstructKeys.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/ConstructKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/ElectronicCodeBook.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/ElectronicCodeBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/FeedbackCipher.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/FeedbackCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,7 +156,7 @@ abstract class FeedbackCipher {
      */
      int encryptFinal(byte[] plain, int plainOffset, int plainLen,
                       byte[] cipher, int cipherOffset)
-         throws IllegalBlockSizeException, ShortBufferException {
+         throws IllegalBlockSizeException {
          return encrypt(plain, plainOffset, plainLen, cipher, cipherOffset);
     }
     /**
@@ -198,7 +198,7 @@ abstract class FeedbackCipher {
      */
      int decryptFinal(byte[] cipher, int cipherOffset, int cipherLen,
                       byte[] plain, int plainOffset)
-         throws IllegalBlockSizeException, ShortBufferException {
+         throws IllegalBlockSizeException {
          return decrypt(cipher, cipherOffset, cipherLen, plain, plainOffset);
      }
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GCTR.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GCTR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,8 +75,7 @@ final class GCTR extends CounterMode implements GCM {
         ByteBuffer buf = ByteBuffer.wrap(counter, counter.length - 4, 4);
         buf.order(ByteOrder.BIG_ENDIAN);
         long ctr32 = 0xFFFFFFFFL & buf.getInt();
-        long blocksLeft = (1L << 32) - ctr32;
-        return blocksLeft;
+        return (1L << 32) - ctr32;
     }
 
     private void checkBlock() {

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GHASH.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GHASH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -191,9 +191,8 @@ final class GHASH implements Cloneable, GCM {
 
         // If ct is a direct bytebuffer, send it directly to the intrinsic
         if (ct.isDirect()) {
-            int processed = inLen;
             processBlocksDirect(ct, inLen);
-            return processed;
+            return inLen;
         } else if (!ct.isReadOnly()) {
             // If a non-read only heap bytebuffer, use the array update method
             int processed = update(ct.array(),
@@ -274,7 +273,7 @@ final class GHASH implements Cloneable, GCM {
     /*
      * This is an intrinsified method.  The method's argument list must match
      * the hotspot signature.  This method and methods called by it, cannot
-     * throw exceptions or allocate arrays as it will breaking intrinsics
+     * throw exceptions or allocate arrays as it will break intrinsics
      */
     private void processBlocks(byte[] data, int inOfs, int blocks, long[] st) {
         int offset = inOfs;

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GaloisCounterMode.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GaloisCounterMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,23 +32,10 @@ import com.tencent.kona.jdk.internal.misc.UnsafeUtil;
 import com.tencent.kona.sun.security.jca.JCAUtil;
 import com.tencent.kona.sun.security.util.ArrayUtil;
 
-import javax.crypto.AEADBadTagException;
-import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
-import javax.crypto.CipherSpi;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
-import javax.crypto.ShortBufferException;
+import javax.crypto.*;
 import javax.crypto.spec.GCMParameterSpec;
 import java.nio.ByteBuffer;
-import java.security.AlgorithmParameters;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.Key;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.ProviderException;
-import java.security.SecureRandom;
+import java.security.*;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidParameterSpecException;
 import java.util.Arrays;

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/OutputFeedback.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/OutputFeedback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ final class OutputFeedback extends FeedbackCipher {
     private final byte[] register;
 
     /*
-     * number of bytes for each stream unit, defaults to the blocksize
+     * number of bytes for each stream unit, defaults to the block size
      * of the embedded cipher
      */
     private final int numBytes;

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBEKeyFactory.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBEKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,7 +104,7 @@ abstract class PBEKeyFactory extends SecretKeyFactorySpi {
      */
     protected KeySpec engineGetKeySpec(SecretKey key, Class<?> keySpecCl)
         throws InvalidKeySpecException {
-        if ((key instanceof SecretKey)
+        if ((key != null)
             && (validTypes.contains(key.getAlgorithm().toUpperCase(Locale.ENGLISH)))
             && (key.getFormat().equalsIgnoreCase("RAW"))) {
 

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBES2Parameters.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBES2Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,8 +135,8 @@ abstract class PBES2Parameters extends AlgorithmParametersSpi {
 
     PBES2Parameters(String pbes2AlgorithmName) throws NoSuchAlgorithmException {
         int and;
-        String kdfAlgo = null;
-        String cipherAlgo = null;
+        String kdfAlgo;
+        String cipherAlgo;
 
         // Extract the KDF and encryption algorithm names
         this.pbes2AlgorithmName = pbes2AlgorithmName;
@@ -207,9 +207,6 @@ abstract class PBES2Parameters extends AlgorithmParametersSpi {
     protected void engineInit(byte[] encoded)
         throws IOException
     {
-        String kdfAlgo = null;
-        String cipherAlgo = null;
-
         DerValue pBES2_params = new DerValue(encoded);
         if (pBES2_params.tag != DerValue.tag_Sequence) {
             throw new IOException("PBE parameter parsing error: "
@@ -228,16 +225,15 @@ abstract class PBES2Parameters extends AlgorithmParametersSpi {
             kdf = pBES2_params.data.getDerValue();
         }
 
-        kdfAlgo = parseKDF(kdf);
+        String kdfAlgo = parseKDF(kdf);
 
         if (pBES2_params.tag != DerValue.tag_Sequence) {
             throw new IOException("PBE parameter parsing error: "
                 + "not an ASN.1 SEQUENCE tag");
         }
-        cipherAlgo = parseES(pBES2_params.data.getDerValue());
+        String cipherAlgo = parseES(pBES2_params.data.getDerValue());
 
-        this.pbes2AlgorithmName = new StringBuilder().append("PBEWith")
-            .append(kdfAlgo).append("And").append(cipherAlgo).toString();
+        this.pbes2AlgorithmName = "PBEWith" + kdfAlgo + "And" + cipherAlgo;
     }
 
     @SuppressWarnings("deprecation")
@@ -303,7 +299,7 @@ abstract class PBES2Parameters extends AlgorithmParametersSpi {
 
     @SuppressWarnings("deprecation")
     private String parseES(DerValue encryptionScheme) throws IOException {
-        String cipherAlgo = null;
+        String cipherAlgo;
 
         cipherAlgo_OID = encryptionScheme.data.getOID();
         if (sm4128CBC_OID.equals(cipherAlgo_OID)) {
@@ -403,7 +399,7 @@ abstract class PBES2Parameters extends AlgorithmParametersSpi {
     /*
      * Returns a formatted string describing the parameters.
      *
-     * The algorithn name pattern is: "PBEWith<prf>And<encryption>"
+     * The algorithm name pattern is: "PBEWith<prf>And<encryption>"
      * where <prf> is one of: HmacSHA1, HmacSHA224, HmacSHA256, HmacSHA384,
      * HmacSHA512, HmacSHA512/224, or HmacSHA512/256 and <encryption> is
      * AES with a keysize suffix.

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBKDF2KeyImpl.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBKDF2KeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,13 +29,13 @@ import java.io.*;
 //import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-import java.util.Arrays;
-import java.util.Locale;
 import java.security.MessageDigest;
 import java.security.KeyRep;
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+import java.util.Locale;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.PBEKeySpec;

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PKCS5Padding.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PKCS5Padding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,7 +120,6 @@ final class PKCS5Padding implements Padding {
      * @return the length of the padding
      */
     public int padLength(int len) {
-        int paddingOctet = blockSize - (len % blockSize);
-        return paddingOctet;
+        return blockSize - (len % blockSize);
     }
 }

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/provider/TlsKeyMaterialGenerator.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/provider/TlsKeyMaterialGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,11 +64,11 @@ public final class TlsKeyMaterialGenerator extends KeyGeneratorSpi {
     @SuppressWarnings("deprecation")
     protected void engineInit(AlgorithmParameterSpec params,
             SecureRandom random) throws InvalidAlgorithmParameterException {
-        if (params instanceof TlsKeyMaterialParameterSpec == false) {
+        if (!(params instanceof TlsKeyMaterialParameterSpec)) {
             throw new InvalidAlgorithmParameterException(MSG);
         }
         this.spec = (TlsKeyMaterialParameterSpec)params;
-        if ("RAW".equals(spec.getMasterSecret().getFormat()) == false) {
+        if (!"RAW".equals(spec.getMasterSecret().getFormat())) {
             throw new InvalidAlgorithmParameterException(
                 "Key format must be RAW");
         }
@@ -108,8 +108,6 @@ public final class TlsKeyMaterialGenerator extends KeyGeneratorSpi {
 
         SecretKey clientMacKey = null;
         SecretKey serverMacKey = null;
-        SecretKey clientCipherKey = null;
-        SecretKey serverCipherKey = null;
         IvParameterSpec clientIv = null;
         IvParameterSpec serverIv = null;
 
@@ -197,8 +195,10 @@ public final class TlsKeyMaterialGenerator extends KeyGeneratorSpi {
         System.arraycopy(keyBlock, ofs, serverKeyBytes, 0, keyLength);
         ofs += keyLength;
 
+        SecretKey clientCipherKey;
+        SecretKey serverCipherKey;
         try {
-            if (isExportable == false) {
+            if (!isExportable) {
                 // cipher keys
                 clientCipherKey = new SecretKeySpec(clientKeyBytes, alg);
                 serverCipherKey = new SecretKeySpec(serverKeyBytes, alg);

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/provider/TlsPrfGenerator.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/provider/TlsPrfGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,12 +133,12 @@ abstract class TlsPrfGenerator extends KeyGeneratorSpi {
     @SuppressWarnings("deprecation")
     protected void engineInit(AlgorithmParameterSpec params,
             SecureRandom random) throws InvalidAlgorithmParameterException {
-        if (params instanceof TlsPrfParameterSpec == false) {
+        if (!(params instanceof TlsPrfParameterSpec)) {
             throw new InvalidAlgorithmParameterException(MSG);
         }
         this.spec = (TlsPrfParameterSpec)params;
         SecretKey key = spec.getSecret();
-        if ((key != null) && ("RAW".equals(key.getFormat()) == false)) {
+        if ((key != null) && (!"RAW".equals(key.getFormat()))) {
             throw new InvalidAlgorithmParameterException(
                 "Key encoding format must be RAW");
         }
@@ -379,7 +379,7 @@ abstract class TlsPrfGenerator extends KeyGeneratorSpi {
      * TLS 1.2 uses a different hash algorithm than 1.0/1.1 for the PRF
      * calculations.  As of 2010, there is no PKCS11-level support for TLS
      * 1.2 PRF calculations, and no known OS's have an internal variant
-     * we could use.  Therefore for TLS 1.2, we are updating JSSE to request
+     * we could use.  Therefore, for TLS 1.2, we are updating JSSE to request
      * a different provider algorithm:  "SunTls12Prf".  If we reused the
      * name "SunTlsPrf", the PKCS11 provider would need be updated to
      * fail correctly when presented with the wrong version number


### PR DESCRIPTION
This is a backport of [JDK-8333364]: Minor cleanup could be done in com.sun.crypto.provider.

This PR will resolves #789.

[JDK-8333364]:
https://bugs.openjdk.org/browse/JDK-8333364