### PR TITLE
TKSS-835: Backport JDK-8336667: IAE in DerInputStream.toByteArray

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerInputStream.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/DerInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,7 +114,7 @@ public class DerInputStream {
             // to the end of return value by DerIndefLenConverter::convertBytes
             // and stay inside result.buffer.
             int unused = result.buffer.length - result.end;
-            this.pos = this.data.length - unused;
+            this.pos = this.end - unused;
         } else {
             this.pos = result.end;
         }


### PR DESCRIPTION
This is a backport of [JDK-8336667]: IAE in DerInputStream.toByteArray.

This PR will resolves #835.

[JDK-8336667]:
https://bugs.openjdk.org/browse/JDK-8336667