### PR TITLE
TKSS-846: SM3HMacWithBCTest uses Kona SM3HMac twice

### DIFF
--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacWithBCTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacWithBCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ public class SM3HMacWithBCTest {
         sm3HMacBC.init(secretKey);
 
         byte[] mac = sm3HMac.doFinal(message);
-        byte[] macBC = sm3HMac.doFinal(message);
+        byte[] macBC = sm3HMacBC.doFinal(message);
 
         Assertions.assertArrayEquals(macBC, mac);
     }


### PR DESCRIPTION
`SM3HMacWithBCTest` unexpectedly uses SM3HMac from Kona provider to generate mac for BC provider.