### PR TITLE
TKSS-854: Supports Kona JDKs

### DIFF
--- a/buildSrc/src/main/kotlin/kona-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/kona-common.gradle.kts
@@ -125,6 +125,58 @@ tasks {
         }
     }
 
+    register("testOnKona8", CommonTest::class) {
+        systemProperty("test.classpath", classpath.joinToString(separator = ":"))
+
+        javaLauncher.set(javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(8))
+            vendor.set(JvmVendorSpec.TENCENT)
+        })
+
+        doFirst {
+            println("Testing JDK: " + javaLauncher.get().metadata.installationPath)
+        }
+    }
+
+    register("testOnKona11", CommonTest::class) {
+        systemProperty("test.classpath", classpath.joinToString(separator = ":"))
+
+        javaLauncher.set(javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(11))
+            vendor.set(JvmVendorSpec.TENCENT)
+        })
+
+        doFirst {
+            println("Testing JDK: " + javaLauncher.get().metadata.installationPath)
+        }
+    }
+
+    register("testOnKona17", CommonTest::class) {
+        systemProperty("test.classpath", classpath.joinToString(separator = ":"))
+
+        javaLauncher.set(javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(17))
+            vendor.set(JvmVendorSpec.TENCENT)
+        })
+
+        doFirst {
+            println("Testing JDK: " + javaLauncher.get().metadata.installationPath)
+        }
+    }
+
+    register("testOnKona21", CommonTest::class) {
+        systemProperty("test.classpath", classpath.joinToString(separator = ":"))
+
+        javaLauncher.set(javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(21))
+            vendor.set(JvmVendorSpec.TENCENT)
+        })
+
+        doFirst {
+            println("Testing JDK: " + javaLauncher.get().metadata.installationPath)
+        }
+    }
+
     test {
         dependsOn(testOnCurrent)
     }


### PR DESCRIPTION
Since version 8.6, Gradle has support Kona JDKs.
It should add Kona releases for testing.

This PR will resolves #854.