### PR TITLE
TKSS-856: Update README for Kona JDK 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Tencent Kona SM Suite supports all the JDK long-term supported (LTS) releases, n
 
 Please note Tencent Kona SM Suite is already signed by Oracle-issued JCE code signing [certificate], so it also can run on Oracle JDK.
 
-We are pleased to recommend Tencent's OpenJDK distributions, namely Tencent Kona JDKs, which provide versions [8], [11] and [17]. They support Linux, macOS and Windows operating systems, and x86_64 and aarch64 CPUs. **The latest Tencent Kona JDK 8 already supports ShangMi algorithms, TLCP and RFC 8998 specification natively.**
+We are pleased to recommend Tencent's OpenJDK distributions, namely Tencent Kona JDKs, which provide 4 long term supported (LTS) versions [8], [11], [17] and [21]. They support Linux, macOS and Windows operating systems, and x86_64 and aarch64 CPUs. **The latest Tencent Kona JDK 8 and 17 already supports ShangMi algorithms, TLCP and RFC 8998 specification natively.**
 
 ### Android
 By default, Tencent Kona SM Suite does not depend on any JDK internal API implementations, so it also can run on Android platform.
@@ -141,6 +141,9 @@ In addition, your problems may be already raised by others. Before open a new is
 
 [17]:
 <https://github.com/Tencent/TencentKona-17>
+
+[21]:
+<https://github.com/Tencent/TencentKona-21>
 
 [Maven Central]:
 <https://repo1.maven.org/maven2/com/tencent/kona/>

--- a/README_cn.md
+++ b/README_cn.md
@@ -28,7 +28,7 @@
 
 注意：已经使用Oracle颁发的JCE代码签名[证书]对本套组件的jar文件签名，所以它们也可以运行在Oracle JDK上。
 
-欢迎使用腾讯的OpenJDK发行版，即Tencent Kona JDK，提供[8]，[11]和[17]三大版本，支持Linux，macOS和Windows等主流操作系统以及x86_64和aarch64等主流CPU架构。**最新的Tencent Kona JDK 8已经原生地支持了国密密码学算法，国密SSL/TLCP协议和RFC 8998规范。**
+欢迎使用腾讯的OpenJDK发行版，即Tencent Kona JDK，它提供四个长期支持（LTS）版本[8]，[11]，[17]和[21]，支持Linux，macOS和Windows等主流操作系统以及x86_64和aarch64等主流CPU架构。**最新的Tencent Kona JDK 8和17已经原生地支持了国密密码学算法，国密SSL/TLCP协议和RFC 8998规范。**
 
 ### Android
 默认情况下，腾讯Kona国密套件并不需要依赖JDK的任何内部API实现，所以它也可以运行Android平台上。
@@ -141,6 +141,9 @@ dependencies {
 
 [17]:
 <https://github.com/Tencent/TencentKona-17>
+
+[21]:
+<https://github.com/Tencent/TencentKona-21>
 
 [Maven中央仓库]:
 <https://repo1.maven.org/maven2/com/tencent/kona/>


### PR DESCRIPTION
Kona JDK 21 has been published, so the README should be updated for this change.

This PR will resolves #856.