### PR TITLE
TKSS-867: NativeCrypto::loadLibs should be private

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeCrypto.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeCrypto.java
@@ -48,9 +48,7 @@ final class NativeCrypto {
     private static class InstanceHolder {
 
         static {
-            if (CryptoUtils.useNativeCrypto()) {
-                loadLibs();
-            }
+            loadLibs();
         }
 
         private static final NativeCrypto INSTANCE = new NativeCrypto();
@@ -60,7 +58,7 @@ final class NativeCrypto {
         return InstanceHolder.INSTANCE;
     }
 
-    static void loadLibs() {
+    private static void loadLibs() {
         loadLib("OpenSSLCrypto", OPENSSL_CRYPTO_LIB);
         loadLib("KonaCrypto", KONA_CRYPTO_LIB);
     }

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3HMacTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3HMacTest.java
@@ -39,10 +39,6 @@ public class NativeSM3HMacTest {
     private static final byte[] MESSAGE = toBytes("616263");
     private static final byte[] MAC = toBytes("4d2e8eefcfaa97b2bea04cda000823a4f2e6e264cf7a819d67117ad12cc9a8af");
 
-    static {
-        NativeCrypto.loadLibs();
-    }
-
     @Test
     public void testMac() {
         try(NativeSM3HMac sm3hmac = new NativeSM3HMac(KEY)) {

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3Test.java
@@ -44,10 +44,6 @@ public class NativeSM3Test {
     private static final byte[] DIGEST_LONG = toBytes(
             "debe9ff92275b8a138604889c18e5a4d6fdb70e5387e5765293dcba39c0c5732");
 
-    static {
-        NativeCrypto.loadLibs();
-    }
-
     @Test
     public void testKAT() {
         checkDigest(MESSAGE_SHORT, DIGEST_SHORT);

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4EngineTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4EngineTest.java
@@ -58,10 +58,6 @@ public class NativeSM4EngineTest {
             (byte)0xc3, (byte)0x3d, (byte)0x3f, (byte)0x66
     };
 
-    static {
-        NativeCrypto.loadLibs();
-    }
-
     @Test
     public void testEncryption() {
         NativeSM4Engine engine = new NativeSM4Engine(KEY, true);

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4Test.java
@@ -53,10 +53,6 @@ public class NativeSM4Test {
     private static final byte[] MESSAGE_32 = toBytes(
             "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
 
-    static {
-        NativeCrypto.loadLibs();
-    }
-
     @Test
     public void testCBCNoPadding() {
         try(SM4CBC encrypter = new SM4CBC(true, false, KEY, IV)) {


### PR DESCRIPTION
The method `NativeCrypto::loadLibs` should be private, and the tests don't call it anymore.

This PR will resolves #867.