### PR TITLE
TKSS-881: Backport JDK-8339347: keytool -importpass insists prompting the user even if there is no terminal

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/tools/keytool/Main.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/tools/keytool/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1816,7 +1816,8 @@ public final class Main {
      */
     private char[] promptForCredential() throws Exception {
         // Handle password supplied via stdin
-        if (System.console() == null) {
+        Console console = System.console();
+        if (console == null) { // || !console.isTerminal()
             char[] importPass = Password.readPassword(System.in);
             passwords.add(importPass);
             return importPass;


### PR DESCRIPTION
This is a backport of [JDK-8339347]: keytool -importpass insists prompting the user even if there is no terminal.

This PR will resolves #881.

[JDK-8339347]:
https://bugs.openjdk.org/browse/JDK-8339347