### PR TITLE
TKSS-882: Backport JDK-8331391: Enhance the keytool code by invoking the buildTrustedCerts method for essential options

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/tools/keytool/Main.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/tools/keytool/Main.java
@@ -1156,7 +1156,6 @@ public final class Main {
             }
         }
 
-        KeyStore cakstore = buildTrustedCerts();
         // -trustcacerts can be specified on -importcert, -printcert or -printcrl.
         // Reset it so that warnings on CA cert will remain for other command.
         if (command != IMPORTCERT && command != PRINTCERT
@@ -1165,6 +1164,7 @@ public final class Main {
         }
 
         if (trustcacerts) {
+            KeyStore cakstore = buildTrustedCerts();
             if (cakstore != null) {
                 caks = cakstore;
             } else {


### PR DESCRIPTION
This is a backport of [JDK-8331391]: Enhance the keytool code by invoking the buildTrustedCerts method for essential options.

This PR will resolves #882.

[JDK-8331391]:
https://bugs.openjdk.org/browse/JDK-8331391