### PR TITLE
TKSS-883: Backport JDK-8319332: Security properties files inclusion

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/PropertyExpander.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/PropertyExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import com.tencent.kona.sun.net.www.ParseUtil;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
+import java.util.function.UnaryOperator;
 
 /**
  * A utility class to expand properties embedded in a string.
@@ -52,15 +53,31 @@ public class PropertyExpander {
         }
     }
 
-    public static String expand(String value)
-        throws ExpandException
-    {
+    public static String expand(String value) throws ExpandException {
         return expand(value, false);
     }
 
-     public static String expand(String value, boolean encodeURL)
-         throws ExpandException
-     {
+    public static String expand(String value, boolean encodeURL)
+            throws ExpandException {
+        return expand(value, encodeURL, System::getProperty);
+    }
+
+    /*
+     * In non-strict mode an undefined property is replaced by an empty string.
+     */
+    public static String expandNonStrict(String value) {
+        try {
+            return expand(value, false, key -> System.getProperty(key, ""));
+        } catch (ExpandException e) {
+            // should not happen
+            throw new AssertionError("unexpected expansion error: when " +
+                    "expansion is non-strict, undefined properties should " +
+                    "be replaced by an empty string", e);
+        }
+    }
+
+    private static String expand(String value, boolean encodeURL,
+            UnaryOperator<String> propertiesGetter) throws ExpandException {
         if (value == null)
             return null;
 
@@ -106,7 +123,7 @@ public class PropertyExpander {
                 if (prop.equals("/")) {
                     sb.append(java.io.File.separatorChar);
                 } else {
-                    String val = System.getProperty(prop);
+                    String val = propertiesGetter.apply(prop);
                     if (val != null) {
                         if (encodeURL) {
                             // encode 'val' unless it's an absolute URI


### PR DESCRIPTION
This is a backport of [JDK-8319332]: Security properties files inclusion.

This PR will resolves #883.

[JDK-8319332]:
https://bugs.openjdk.org/browse/JDK-8319332