### PR TITLE
TKSS-911: Not recommend to prioritize the Kona SM Suite providers

### DIFF
--- a/kona-crypto/README.md
+++ b/kona-crypto/README.md
@@ -40,7 +40,7 @@ The above line adds this provider at the bottom of the provider list. That means
 Security.insertProviderAt(new KonaCryptoProvider(), position);
 ```
 
-the less the position is, the higher the priority is. The minimum value is 1.
+the less the position is, the higher the priority is. The minimum value is 1. However, it's not recommended to prioritize this provider. So, `Security.addProvider` is recommended.
 
 ### SM2
 

--- a/kona-crypto/README_cn.md
+++ b/kona-crypto/README_cn.md
@@ -40,7 +40,7 @@ Security.addProvider(new KonaCryptoProvider());
 Security.insertProviderAt(new KonaCryptoProvider(), position);
 ```
 
-position的值越小，代表的优先级越高，最小可为1。
+position的值越小，代表的优先级越高，最小可为1。然而，并不推荐提升该Provider的优先级，故推荐使用`Security.addProvider`。
 
 ### SM2
 

--- a/kona-pkix/README.md
+++ b/kona-pkix/README.md
@@ -25,7 +25,7 @@ Security.insertProviderAt(new KonaCryptoProvider(), position1);
 Security.insertProviderAt(new KonaPKIXProvider(), position2);
 ```
 
-the less the positions are, the higher the priorities are. The minimum value is 1.
+the less the positions are, the higher the priorities are. The minimum value is 1. However, it's not recommended to prioritize this provider. So, `Security.addProvider` is recommended.
 
 ### Certificate
 `KonaPKIX` can parse X.509 certificates, including RSA and EC certificates. Especially, it supports the EC certificates using ShangMi algorithms, like SM2 curve and SM3withSM2 signature.

--- a/kona-pkix/README_cn.md
+++ b/kona-pkix/README_cn.md
@@ -25,7 +25,7 @@ Security.insertProviderAt(new KonaCryptoProvider(), position1);
 Security.insertProviderAt(new KonaPKIXProvider(), position2);
 ```
 
-position的值越小，代表的优先级越高，最小可为1。
+position的值越小，代表的优先级越高，最小可为1。然而，并不推荐提升该Provider的优先级，故推荐使用`Security.addProvider`。
 
 ### 证书
 `KonaPKIX`能够解析标准的X.509证书，支持RSA与EC证书，特别是支持了包含国密算法（SM2曲线和SM3withSM2签名算法）的EC证书。

--- a/kona-provider/README.md
+++ b/kona-provider/README.md
@@ -21,7 +21,7 @@ The above line adds the provider to the last position of the provider list. If n
 Security.insertProviderAt(new KonaProvider(), position);
 ```
 
-the less the position value is, the higher the privilege is. The minimum value is 1.
+the less the position value is, the higher the privilege is. The minimum value is 1. However, it's not recommended to prioritize this provider. So, `Security.addProvider` is recommended.
 
 Please note that is no need to load `KonaCryptoProvider`，`KonaPKIXProvider` or `KonaSSLProvider`. Instead, it just needs to put their jars into the classpath. `Kona` can load all the features in these three providers via reflection.
 

--- a/kona-provider/README_cn.md
+++ b/kona-provider/README_cn.md
@@ -21,7 +21,7 @@ Security.addProvider(new KonaProvider());
 Security.insertProviderAt(new KonaProvider(), position);
 ```
 
-position的值越小，代表的优先级越高，最小可为1。
+position的值越小，代表的优先级越高，最小可为1。然而，并不推荐提升该Provider的优先级，故推荐使用`Security.addProvider`。
 
 注意：在使用`Kona`时，并不需要加载`KonaCryptoProvider`，`KonaPKIXProvider`或`KonaSSLProvider`，而只需要将它们的jar文件放入类路径中。`Kona`会通过反射自动地加载这三个Provider的特性。
 

--- a/kona-ssl/README.md
+++ b/kona-ssl/README.md
@@ -27,7 +27,7 @@ Security.insertProviderAt(new KonaPKIXProvider(), position2);
 Security.insertProviderAt(new KonaSSLProvider(), position3);
 ```
 
-the less the position values are, the higher the priorities are. The minimum value is 1.
+the less the position values are, the higher the priorities are. The minimum value is 1. However, it's not recommended to prioritize this provider. So, `Security.addProvider` is recommended.
 
 ### Create SSLContext
 In order to take advantage of the implementations on TLCP and RFC 8998 in `KonaSSL`, the most important point is taking SSLSocket or SSLEngine to apply the SSLContext implementation from `KonaSSL`.

--- a/kona-ssl/README_cn.md
+++ b/kona-ssl/README_cn.md
@@ -27,7 +27,7 @@ Security.insertProviderAt(new KonaPKIXProvider(), position2);
 Security.insertProviderAt(new KonaSSLProvider(), position3);
 ```
 
-position的值越小，代表的优先级越高，最小可为1。
+position的值越小，代表的优先级越高，最小可为1。然而，并不推荐提升该Provider的优先级，故推荐使用`Security.addProvider`。
 
 ### 创建SSLContext
 为了能利用上`KonaSSL`实现的国标TLCP协议和RFC 8998规范等特性，其关键就是让JDK的SSLSocket或SSLEngine能利用上`KonaSSL`实现的SSLContext实例。


### PR DESCRIPTION
Generally, just need to add the Kona SM Suite providers to the bottom of the provider list.
So, it would not use `Security.insertProviderAt` to add the Kona SM Suite providers.