### PR TITLE
TKSS-926: Backport JDK-8331682: Slow networks/Impatient clients can potentially send unencrypted TLSv1.3 alerts that won't parse on the server

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLCipher.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1900,10 +1900,20 @@ enum SSLCipher {
                 }
 
                 if (bb.remaining() <= tagSize) {
-                    throw new BadPaddingException(
-                        "Insufficient buffer remaining for AEAD cipher " +
-                        "fragment (" + bb.remaining() + "). Needs to be " +
-                        "more than tag size (" + tagSize + ")");
+                    // Check for unexpected plaintext alert.
+                    if (contentType == ContentType.ALERT.id
+                            && bb.remaining() == 2) {
+                        throw new GeneralSecurityException(String.format(
+                                "Unexpected plaintext alert received: " +
+                                "Level: %s; Alert: %s",
+                                Alert.Level.nameOf(bb.get(bb.position())),
+                                Alert.nameOf(bb.get(bb.position() + 1))));
+                    } else {
+                        throw new BadPaddingException(
+                                "Insufficient buffer remaining for AEAD cipher " +
+                                "fragment (" + bb.remaining() + "). Needs to be " +
+                                "more than tag size (" + tagSize + ")");
+                    }
                 }
 
                 byte[] sn = sequence;


### PR DESCRIPTION
This is a backport of [JDK-8331682]: Slow networks/Impatient clients can potentially send unencrypted TLSv1.3 alerts that won't parse on the server.

This PR will resolves #926.

[JDK-8331682]:
https://bugs.openjdk.org/browse/JDK-8331682