### PR TITLE
TKSS-946: The pointer of the closed NativeRef should be 0

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeRef.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeRef.java
@@ -50,6 +50,6 @@ abstract class NativeRef implements Closeable {
 
     @Override
     public void close() {
-        pointer = -1;
+        pointer = 0;
     }
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2KeyPairGen.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2KeyPairGen.java
@@ -29,9 +29,9 @@ import static com.tencent.kona.crypto.util.Constants.*;
 /**
  * The SM2 key pair generation native implementation.
  */
-final class NativeSM2KeyGen extends NativeRef {
+final class NativeSM2KeyPairGen extends NativeRef {
 
-    NativeSM2KeyGen() {
+    NativeSM2KeyPairGen() {
         super(createCtx());
     }
 
@@ -44,6 +44,9 @@ final class NativeSM2KeyGen extends NativeRef {
     // X and Y are the coordinates of the public key, 32-bytes
     public byte[] genKeyPair() {
         byte[] keyPair = nativeCrypto().sm2KeyGenGenKeyPair(pointer);
+        if (keyPair == null) {
+            throw new IllegalStateException("Generate key pair failed");
+        }
 
         if (keyPair.length == SM2_PRIKEY_LEN + SM2_PUBKEY_LEN) {
             return keyPair;

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2KeyPairGenerator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2KeyPairGenerator.java
@@ -41,11 +41,11 @@ public final class SM2KeyPairGenerator extends KeyPairGenerator {
 
     private static final Sweeper SWEEPER = Sweeper.instance();
 
-    private final NativeSM2KeyGen sm2;
+    private final NativeSM2KeyPairGen sm2;
 
     public SM2KeyPairGenerator() {
         super("SM2");
-        sm2 = new NativeSM2KeyGen();
+        sm2 = new NativeSM2KeyPairGen();
 
         SWEEPER.register(this, new SweepNativeRef(sm2));
     }

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3HMacTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3HMacTest.java
@@ -127,4 +127,14 @@ public class NativeSM3HMacTest {
                     () -> sm3hmac.doFinal(null));
         }
     }
+
+    @Test
+    public void testUseClosedRef() {
+        NativeSM3HMac sm3hmac = new NativeSM3HMac(KEY);
+        sm3hmac.close();
+
+        Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> sm3hmac.doFinal(MESSAGE));
+    }
 }

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3Test.java
@@ -123,4 +123,14 @@ public class NativeSM3Test {
                     () -> sm3.doFinal(null));
         }
     }
+
+    @Test
+    public void testUseClosedRef() {
+        NativeSM3 sm3 = new NativeSM3();
+        sm3.close();
+
+        Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> sm3.doFinal(MESSAGE_SHORT));
+    }
 }

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4Test.java
@@ -477,4 +477,14 @@ public class NativeSM4Test {
                 IllegalStateException.class,
                 ()-> new SM4GCM(true, KEY, IV).close());
     }
+
+    @Test
+    public void testUseClosedRef() {
+        SM4ECB sm4 = new SM4ECB(true, false, KEY);
+        sm4.close();
+
+        Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> sm4.doFinal(MESSAGE_32));
+    }
 }


### PR DESCRIPTION
After closing `NativeRef` objects, the pointers should be reset to 0 rather than -1.

This PR will resolves #946.