### PR TITLE
TKSSp-965: Update READMEs for OpenSSL-based SM2 implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ English | **[中文]**
 ## Overview
 Tencent Kona SM Suite is a set of Java security providers, which service the ShangMi applications in Java ecosystem. This suite contains four providers:
 
-- [KonaCrypto]，which implements SM2, SM3 and SM4 algorithms based on Java Cryptography Architecture.
-  - Provides pure Java-based SM2, SM3 and SM4 implementations. These implementations are enabled on runtime by default.
-  - Provides JNI and OpenSSL-based SM3 and SM4 implementations (SM2 is on the way). Currently, these implementations support only Linux x86_64/aarch64 platforms.
+- [KonaCrypto]，which implements SM2, SM3 and SM4 algorithms based on Java Cryptography Architecture. There are two implementations: based on pure Java; based on JNI/OpenSSL. The former is enabled by default, however the latter supports only `Linux x86_64/aarch64` platforms.
 - [KonaPKIX]，which supports ShangMi algorithms on loading certificate and certificate chain verification. It also can load and write keystores containing ShangMi certificates. Additionally, this component provides two utility classes:
   - KeyTool, which is the same as `keytool` in JDK, can generate private keys, and create certificates and keystores. It can use `PBEWithHmacSM3AndSM4` to encrypt private keys and keystores, and use `HmacPBESM3` to validate the integrity of keystores.
   - KeyStoreTool, which can import the existing [PEM]-encoded private keys and certificates to keystores.

--- a/README_cn.md
+++ b/README_cn.md
@@ -8,9 +8,7 @@
 ## 概览
 腾讯Kona国密套件是一组Java安全特性的Provider实现，主要服务于Java生态中的国密应用场景。具体地，该套件包含有四个Provider：
 
-- [KonaCrypto]，它遵循标准的[JCA]框架实现了国密密码学算法SM2，SM3和SM4。
-  - 使用纯Java实现了SM2，SM3和SM4。默认地，在运行时启用该类实现。
-  - 使用JNI与OpenSSL实现了SM3和SM4，未来还将实现SM2。目前仅支持`Linux x86_64/aarch64`平台。
+- [KonaCrypto]，它遵循标准的[JCA]框架实现了国密密码学算法SM2，SM3和SM4。在实现方式上，分为基于纯Java的实现和基于JNI/OpenSSL的实现。默认启用前者，而后者仅支持`Linux x86_64/aarch64`平台。
 - [KonaPKIX]，它实现了国密证书的解析与验证，并可加载和创建包含国密证书的密钥库。它需要依赖`KonaCrypto`。另外，该组件还提供了两个工具类：
   - KeyTool，它的功能与JDK中的`keytool`相同，可以生成密钥对，创建证书以及密钥库。它支持使用`PBEWithHmacSM3AndSM4`算法对私钥和密钥库进行加密，也可使用`HmacPBESM3`算法验证密钥库的完整性。
   - KeyStoreTool，它可以将已有的[PEM]格式的私钥和证书导入密钥库。

--- a/kona-crypto/README.md
+++ b/kona-crypto/README.md
@@ -20,7 +20,7 @@ For providing the above features, `KonaCrypto` implements the JDK-specified Serv
 
 ## Implementations
 
-Tencent Kona Crypto provides pure Java-based SM2, SM3 and SM4, and also JNI and OpenSSL-based SM3 and SM4 (SM2 implementation is on the way). The latter supports Linux x86_64/aarch64 platforms. OpenSSL version 3.4.0 is used by default, but versions 3.0 and later can be supported.
+Tencent Kona Crypto provides pure Java-based and JNI/OpenSSL-based SM2, SM3 and SM4. The latter supports `Linux x86_64/aarch64` platforms. OpenSSL version 3.4.0 is used by default, but versions 3.0 and later can be supported.
 
 The pure Java-based implementations is enabled. The java system property `com.tencent.kona.useNativeCrypto` can be used to enable the OpenSSL-based implementation. The additional system property `com.tencent.kona.openssl.crypto.lib.path` is used to specify an alternative local OpenSSL crypto lib file (`libcrypto.so`). The value of this property is a local absolute path.
 

--- a/kona-crypto/README_cn.md
+++ b/kona-crypto/README_cn.md
@@ -20,7 +20,7 @@
 
 ## 实现方式
 
-目前既提供了纯Java语言实现的SM2，SM3和SM4算法，也提供了基于JNI与OpenSSL实现的SM3和SM4算法（未来也将实现SM2）。后者仅支持Linux x86_64/aarch64平台。本项目默认使用的OpenSSL版本为3.4.0，但可以支持3.0及之后的版本。
+目前既提供了基于纯Java语言和基于JNI与OpenSSL实现的SM2，SM3和SM4算法。后者仅支持`Linux x86_64/aarch64`平台。本项目默认使用的OpenSSL版本为3.4.0，但可以支持3.0及之后的版本。
 
 默认地，启用纯Java的实现。若要启用基于OpenSSL的实现，需要设置系统属性`com.tencent.kona.useNativeCrypto`的值为`true`。另外，还提供了系统属性`com.tencent.kona.openssl.crypto.lib.path`以指定使用本地的其他OpenSSL crypto库文件（`libcrypto.so`），该系统属性的值是一个本地绝对路径。
 


### PR DESCRIPTION
Now that provides OpenSSL-based SM2 implementations, the READMEs should be updated accordingly.

This PR will resolves #965.