### PR TITLE
TKSS-973: No need to care thread-safe on native crypto

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/ByteArrayWriter.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/ByteArrayWriter.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation. THL A29 Limited designates
+ * this particular file as subject to the "Classpath" exception as provided
+ * in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License version 2 for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.tencent.kona.crypto.provider.nativeImpl;
+
+import java.util.Arrays;
+
+/**
+ * A simplified clone for ByteArrayOutputStream, however the methods
+ * are not synchronized. Especially, clear() method resets not only the size,
+ * but also the values in the buffer due to security concern.
+ */
+public class ByteArrayWriter {
+
+    static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+    private byte[] buf;
+    private int size;
+
+    public ByteArrayWriter(int size) {
+        if (size < 0) {
+            throw new IllegalArgumentException("Negative initial size: " + size);
+        }
+
+        buf = new byte[size];
+    }
+
+    public ByteArrayWriter() {
+        this(128);
+    }
+
+    public ByteArrayWriter(byte[] initData) {
+        if (initData == null || initData.length == 0) {
+            throw new IllegalArgumentException("Null or empty byte array");
+        }
+
+        buf = initData.clone();
+        size = initData.length;
+    }
+
+    public void write(int b) {
+        ensureCapacity(size + 1);
+        buf[size] = (byte) b;
+        size += 1;
+    }
+
+    public void write(byte[] src) {
+        write(src, 0, src.length);
+    }
+
+    public void write(byte[] src, int off, int len) {
+        if (off < 0 || off > src.length || len < 0 ||
+                (off + len) - src.length > 0) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        ensureCapacity(size + len);
+        System.arraycopy(src, off, buf, size, len);
+        size += len;
+    }
+
+    private void ensureCapacity(int minCapacity) {
+        // overflow-conscious code
+        if (minCapacity - buf.length > 0) {
+            grow(minCapacity);
+        }
+    }
+
+    private void grow(int minCapacity) {
+        // overflow-conscious code
+        int oldCapacity = buf.length;
+        int newCapacity = oldCapacity << 1;
+        if (newCapacity - minCapacity < 0) {
+            newCapacity = minCapacity;
+        }
+        if (newCapacity - MAX_ARRAY_SIZE > 0) {
+            newCapacity = hugeCapacity(minCapacity);
+        }
+        buf = Arrays.copyOf(buf, newCapacity);
+    }
+
+    private static int hugeCapacity(int minCapacity) {
+        if (minCapacity < 0) { // overflow
+            throw new OutOfMemoryError();
+        }
+
+        return minCapacity > MAX_ARRAY_SIZE ? Integer.MAX_VALUE : MAX_ARRAY_SIZE;
+    }
+
+    public void reset() {
+        Arrays.fill(buf, (byte) 0x00);
+        size = 0;
+    }
+
+    public byte[] toByteArray() {
+        return Arrays.copyOf(buf, size);
+    }
+
+    public int size() {
+        return size;
+    }
+
+    byte[] buf() {
+        return Arrays.copyOf(buf, buf.length);
+    }
+
+    int capacity() {
+        return buf.length;
+    }
+}

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2Cipher.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2Cipher.java
@@ -30,7 +30,6 @@ import javax.crypto.CipherSpi;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.ShortBufferException;
-import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
 import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
@@ -54,8 +53,8 @@ public final class SM2Cipher extends CipherSpi {
 
     private static final byte[] B0 = new byte[0];
 
-    private NativeSM2Cipher sm2;
-    private final Buffer buffer = new Buffer();
+    private volatile NativeSM2Cipher sm2;
+    private final ByteArrayWriter buffer = new ByteArrayWriter();
 
     private boolean encrypted = true;
 
@@ -245,13 +244,5 @@ public final class SM2Cipher extends CipherSpi {
     @Override
     public int engineGetKeySize(Key key) {
         return SM2_CURVE_FIELD_SIZE << 3;
-    }
-
-    private static final class Buffer extends ByteArrayOutputStream {
-
-        public void reset() {
-            Arrays.fill(buf, (byte)0);
-            super.reset();
-        }
     }
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2Signature.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2Signature.java
@@ -26,7 +26,6 @@ import com.tencent.kona.crypto.spec.SM2SignatureParameterSpec;
 import com.tencent.kona.crypto.util.Sweeper;
 
 import javax.crypto.BadPaddingException;
-import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -39,7 +38,6 @@ import java.security.SignatureSpi;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
-import java.util.Arrays;
 
 import static com.tencent.kona.crypto.spec.SM2ParameterSpec.ORDER;
 import static java.math.BigInteger.ONE;
@@ -54,13 +52,13 @@ public final class SM2Signature extends SignatureSpi {
 
     private static final Sweeper SWEEPER = Sweeper.instance();
 
-    private NativeSM2Signature sm2;
+    private volatile NativeSM2Signature sm2;
 
     private SM2PrivateKey privateKey;
     private SM2PublicKey publicKey;
     private byte[] id;
 
-    private final Buffer buffer = new Buffer();
+    private final ByteArrayWriter buffer = new ByteArrayWriter();
 
     @Override
     protected void engineInitSign(PrivateKey privateKey, SecureRandom random)
@@ -193,13 +191,5 @@ public final class SM2Signature extends SignatureSpi {
     private void reset() {
         sm2 = null;
         buffer.reset();
-    }
-
-    private static final class Buffer extends ByteArrayOutputStream {
-
-        public void reset() {
-            Arrays.fill(buf, (byte)0);
-            super.reset();
-        }
     }
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3HMac.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3HMac.java
@@ -34,7 +34,7 @@ public final class SM3HMac extends MacSpi implements Cloneable {
 
     private static final Sweeper SWEEPER = Sweeper.instance();
 
-    private volatile NativeSM3HMac sm3HMac;
+    private NativeSM3HMac sm3HMac;
 
     @Override
     protected int engineGetMacLength() {
@@ -45,8 +45,7 @@ public final class SM3HMac extends MacSpi implements Cloneable {
     protected void engineInit(Key key, AlgorithmParameterSpec params)
             throws InvalidKeyException, InvalidAlgorithmParameterException {
         if (params != null) {
-            throw new InvalidAlgorithmParameterException(
-                    "No need parameters");
+            throw new InvalidAlgorithmParameterException("No need parameters");
         }
 
         if (!(key instanceof SecretKey)) {

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3MessageDigest.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3MessageDigest.java
@@ -31,7 +31,7 @@ public final class SM3MessageDigest extends MessageDigest implements Cloneable {
 
     private static final Sweeper SWEEPER = Sweeper.instance();
 
-    private volatile NativeSM3 sm3;
+    private NativeSM3 sm3;
 
     public SM3MessageDigest() {
         super("SM3");

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4Crypt.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4Crypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify
@@ -37,7 +37,7 @@ class SM4Crypt extends SymmetricCipher {
     private SM4Params paramSpec;
     private byte[] key;
 
-    private volatile NativeSM4 sm4;
+    private NativeSM4 sm4;
 
     private DataWindow gcmLastCipherBlock;
 


### PR DESCRIPTION
The native crypto implementations just be not thread-safe, so it's unnecessary to use `volatile` and `synchronized`.

This PR will resolves #973.