### PR TITLE
TKSS-993: Run tests on the native crypto provider

### DIFF
--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2CipherConstantTimeTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2CipherConstantTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,7 @@ public class SM2CipherConstantTimeTest {
     @State(Scope.Thread)
     public static class CipherHolder {
 
-        @Param({"KonaCrypto", "BC"})
+        @Param({"KonaCrypto", "KonaCrypto-Native", "BC"})
         String provider;
 
         @Param({"Small", "Mid", "Big"})

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2KeyPairGenPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2KeyPairGenPerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,6 @@ import java.security.Security;
 import java.security.spec.ECGenParameterSpec;
 import java.util.concurrent.TimeUnit;
 
-import static com.tencent.kona.crypto.TestUtils.PROVIDER;
-
 /**
  * The JMH-based performance test for SM2 key pair generation.
  */
@@ -64,7 +62,18 @@ public class SM2KeyPairGenPerfTest {
 
         @Setup
         public void setup() throws Exception {
-            keyPairGenerator = KeyPairGenerator.getInstance("SM2", PROVIDER);
+            keyPairGenerator = KeyPairGenerator.getInstance("SM2", "KonaCrypto");
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class KeyPairGenHolderNative {
+
+        KeyPairGenerator keyPairGenerator;
+
+        @Setup
+        public void setup() throws Exception {
+            keyPairGenerator = KeyPairGenerator.getInstance("SM2", "KonaCrypto-Native");
         }
     }
 
@@ -82,6 +91,11 @@ public class SM2KeyPairGenPerfTest {
 
     @Benchmark
     public KeyPair genKeyPair(KeyPairGenHolder holder) {
+        return holder.keyPairGenerator.generateKeyPair();
+    }
+
+    @Benchmark
+    public KeyPair genKeyPairNative(KeyPairGenHolderNative holder) {
         return holder.keyPairGenerator.generateKeyPair();
     }
 

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2SignatureConstantTimeTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2SignatureConstantTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,7 @@ public class SM2SignatureConstantTimeTest {
     @State(Scope.Thread)
     public static class SignerHolder {
 
-        @Param({"KonaCrypto", "BC"})
+        @Param({"KonaCrypto", "KonaCrypto-Native", "BC"})
         String provider;
 
         @Param({"Small", "Mid", "Big"})

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM3HMacPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM3HMacPerfTest.java
@@ -41,7 +41,6 @@ import javax.crypto.spec.SecretKeySpec;
 import java.security.Security;
 import java.util.concurrent.TimeUnit;
 
-import static com.tencent.kona.crypto.TestUtils.PROVIDER;
 import static com.tencent.kona.crypto.CryptoUtils.toBytes;
 
 /**
@@ -71,7 +70,19 @@ public class SM3HMacPerfTest {
 
         @Setup(Level.Trial)
         public void setup() throws Exception {
-            mac = Mac.getInstance("HmacSM3", PROVIDER);
+            mac = Mac.getInstance("HmacSM3", "KonaCrypto");
+            mac.init(SECRET_KEY);
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class MacHolderNative {
+
+        Mac mac;
+
+        @Setup(Level.Trial)
+        public void setup() throws Exception {
+            mac = Mac.getInstance("HmacSM3", "KonaCrypto-Native");
             mac.init(SECRET_KEY);
         }
     }
@@ -90,6 +101,11 @@ public class SM3HMacPerfTest {
 
     @Benchmark
     public byte[] mac(MacHolder holder) throws Exception {
+        return holder.mac.doFinal(MESSAGE);
+    }
+
+    @Benchmark
+    public byte[] macNative(MacHolderNative holder) throws Exception {
         return holder.mac.doFinal(MESSAGE);
     }
 

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM3MessageDigestPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM3MessageDigestPerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,8 +38,6 @@ import java.security.MessageDigest;
 import java.security.Security;
 import java.util.concurrent.TimeUnit;
 
-import static com.tencent.kona.crypto.TestUtils.PROVIDER;
-
 /**
  * The JMH-based performance test for SM3 message digest.
  */
@@ -65,7 +63,18 @@ public class SM3MessageDigestPerfTest {
 
         @Setup(Level.Trial)
         public void setup() throws Exception {
-            md = MessageDigest.getInstance("SM3", PROVIDER);
+            md = MessageDigest.getInstance("SM3", "KonaCrypto");
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class MessageDigestHolderNative {
+
+        MessageDigest md;
+
+        @Setup(Level.Trial)
+        public void setup() throws Exception {
+            md = MessageDigest.getInstance("SM3", "KonaCrypto-Native");
         }
     }
 
@@ -82,6 +91,11 @@ public class SM3MessageDigestPerfTest {
 
     @Benchmark
     public byte[] digest(MessageDigestHolder holder) {
+        return holder.md.digest(MESSAGE);
+    }
+
+    @Benchmark
+    public byte[] digestNative(MessageDigestHolderNative holder) {
         return holder.md.digest(MESSAGE);
     }
 

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4ConstantTimeTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4ConstantTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ public class SM4ConstantTimeTest {
     @State(Scope.Benchmark)
     public static class CipherHolder {
 
-        @Param({"KonaCrypto", "BC"})
+        @Param({"KonaCrypto", "KonaCrypto-Native", "BC"})
         String provider;
 
         @Param({"Small", "Mid", "Big"})

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4DecrypterPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4DecrypterPerfTest.java
@@ -44,7 +44,6 @@ import javax.crypto.spec.SecretKeySpec;
 import java.security.Security;
 import java.util.concurrent.TimeUnit;
 
-import static com.tencent.kona.crypto.TestUtils.PROVIDER;
 import static com.tencent.kona.crypto.CryptoUtils.toBytes;
 
 /**
@@ -96,50 +95,121 @@ public class SM4DecrypterPerfTest {
         }
 
         private void setupCiphertexts() throws Exception {
-            Cipher cipher = Cipher.getInstance("SM4/CBC/PKCS7Padding", PROVIDER);
+            Cipher cipher = Cipher.getInstance("SM4/CBC/PKCS7Padding", "KonaCrypto");
             cipher.init(Cipher.ENCRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
             ciphertextCBCPadding = cipher.doFinal(MESSAGE);
 
-            cipher = Cipher.getInstance("SM4/CBC/NoPadding", PROVIDER);
+            cipher = Cipher.getInstance("SM4/CBC/NoPadding", "KonaCrypto");
             cipher.init(Cipher.ENCRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
             ciphertextCBCNoPadding = cipher.doFinal(MESSAGE);
 
-            cipher = Cipher.getInstance("SM4/ECB/NoPadding", PROVIDER);
+            cipher = Cipher.getInstance("SM4/ECB/NoPadding", "KonaCrypto");
             cipher.init(Cipher.ENCRYPT_MODE, SECRET_KEY);
             ciphertextECBNoPadding = cipher.doFinal(MESSAGE);
 
-            cipher = Cipher.getInstance("SM4/CTR/NoPadding", PROVIDER);
+            cipher = Cipher.getInstance("SM4/CTR/NoPadding", "KonaCrypto");
             cipher.init(Cipher.ENCRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
             ciphertextCTRNoPadding = cipher.doFinal(MESSAGE);
 
-            cipher = Cipher.getInstance("SM4/GCM/NoPadding", PROVIDER);
+            cipher = Cipher.getInstance("SM4/GCM/NoPadding", "KonaCrypto");
             cipher.init(Cipher.ENCRYPT_MODE, SECRET_KEY, GCM_PARAM_SPEC);
             ciphertextGCMNoPadding = cipher.doFinal(MESSAGE);
         }
 
         private void setupDecrypters() throws Exception {
             decrypterCBCPadding = Cipher.getInstance(
-                    "SM4/CBC/PKCS7Padding", PROVIDER);
+                    "SM4/CBC/PKCS7Padding", "KonaCrypto");
             decrypterCBCPadding.init(
                     Cipher.DECRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
 
             decrypterCBCNoPadding = Cipher.getInstance(
-                    "SM4/CBC/NoPadding", PROVIDER);
+                    "SM4/CBC/NoPadding", "KonaCrypto");
             decrypterCBCNoPadding.init(
                     Cipher.DECRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
 
             decrypterECBNoPadding = Cipher.getInstance(
-                    "SM4/ECB/NoPadding", PROVIDER);
+                    "SM4/ECB/NoPadding", "KonaCrypto");
             decrypterECBNoPadding.init(
                     Cipher.DECRYPT_MODE, SECRET_KEY);
 
             decrypterCTRNoPadding = Cipher.getInstance(
-                    "SM4/CTR/NoPadding", PROVIDER);
+                    "SM4/CTR/NoPadding", "KonaCrypto");
             decrypterCTRNoPadding.init(
                     Cipher.DECRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
 
             decrypterGCMNoPadding = Cipher.getInstance(
-                    "SM4/GCM/NoPadding", PROVIDER);
+                    "SM4/GCM/NoPadding", "KonaCrypto");
+            decrypterGCMNoPadding.init(
+                    Cipher.DECRYPT_MODE, SECRET_KEY, GCM_PARAM_SPEC);
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class DecrypterHolderNative {
+
+        byte[] ciphertextCBCPadding;
+        byte[] ciphertextCBCNoPadding;
+        byte[] ciphertextCTRNoPadding;
+        byte[] ciphertextECBNoPadding;
+        byte[] ciphertextGCMNoPadding;
+
+        Cipher decrypterCBCPadding;
+        Cipher decrypterCBCNoPadding;
+        Cipher decrypterECBNoPadding;
+        Cipher decrypterCTRNoPadding;
+        Cipher decrypterGCMNoPadding;
+
+        @Setup(Level.Invocation)
+        public void setup() throws Exception {
+            setupCiphertexts();
+            setupDecrypters();
+        }
+
+        private void setupCiphertexts() throws Exception {
+            Cipher cipher = Cipher.getInstance("SM4/CBC/PKCS7Padding", "KonaCrypto-Native");
+            cipher.init(Cipher.ENCRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
+            ciphertextCBCPadding = cipher.doFinal(MESSAGE);
+
+            cipher = Cipher.getInstance("SM4/CBC/NoPadding", "KonaCrypto-Native");
+            cipher.init(Cipher.ENCRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
+            ciphertextCBCNoPadding = cipher.doFinal(MESSAGE);
+
+            cipher = Cipher.getInstance("SM4/ECB/NoPadding", "KonaCrypto-Native");
+            cipher.init(Cipher.ENCRYPT_MODE, SECRET_KEY);
+            ciphertextECBNoPadding = cipher.doFinal(MESSAGE);
+
+            cipher = Cipher.getInstance("SM4/CTR/NoPadding", "KonaCrypto-Native");
+            cipher.init(Cipher.ENCRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
+            ciphertextCTRNoPadding = cipher.doFinal(MESSAGE);
+
+            cipher = Cipher.getInstance("SM4/GCM/NoPadding", "KonaCrypto-Native");
+            cipher.init(Cipher.ENCRYPT_MODE, SECRET_KEY, GCM_PARAM_SPEC);
+            ciphertextGCMNoPadding = cipher.doFinal(MESSAGE);
+        }
+
+        private void setupDecrypters() throws Exception {
+            decrypterCBCPadding = Cipher.getInstance(
+                    "SM4/CBC/PKCS7Padding", "KonaCrypto-Native");
+            decrypterCBCPadding.init(
+                    Cipher.DECRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
+
+            decrypterCBCNoPadding = Cipher.getInstance(
+                    "SM4/CBC/NoPadding", "KonaCrypto-Native");
+            decrypterCBCNoPadding.init(
+                    Cipher.DECRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
+
+            decrypterECBNoPadding = Cipher.getInstance(
+                    "SM4/ECB/NoPadding", "KonaCrypto-Native");
+            decrypterECBNoPadding.init(
+                    Cipher.DECRYPT_MODE, SECRET_KEY);
+
+            decrypterCTRNoPadding = Cipher.getInstance(
+                    "SM4/CTR/NoPadding", "KonaCrypto-Native");
+            decrypterCTRNoPadding.init(
+                    Cipher.DECRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
+
+            decrypterGCMNoPadding = Cipher.getInstance(
+                    "SM4/GCM/NoPadding", "KonaCrypto-Native");
             decrypterGCMNoPadding.init(
                     Cipher.DECRYPT_MODE, SECRET_KEY, GCM_PARAM_SPEC);
         }

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4EncrypterPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4EncrypterPerfTest.java
@@ -44,7 +44,6 @@ import javax.crypto.spec.SecretKeySpec;
 import java.security.Security;
 import java.util.concurrent.TimeUnit;
 
-import static com.tencent.kona.crypto.TestUtils.PROVIDER;
 import static com.tencent.kona.crypto.CryptoUtils.toBytes;
 
 /**
@@ -85,27 +84,64 @@ public class SM4EncrypterPerfTest {
         @Setup(Level.Invocation)
         public void setup() throws Exception {
             encrypterCBCPadding = Cipher.getInstance(
-                    "SM4/CBC/PKCS7Padding", PROVIDER);
+                    "SM4/CBC/PKCS7Padding", "KonaCrypto");
             encrypterCBCPadding.init(
                     Cipher.ENCRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
 
             encrypterCBCNoPadding = Cipher.getInstance(
-                    "SM4/CBC/NoPadding", PROVIDER);
+                    "SM4/CBC/NoPadding", "KonaCrypto");
             encrypterCBCNoPadding.init(
                     Cipher.ENCRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
 
             encrypterECBNoPadding = Cipher.getInstance(
-                    "SM4/ECB/NoPadding", PROVIDER);
+                    "SM4/ECB/NoPadding", "KonaCrypto");
             encrypterECBNoPadding.init(
                     Cipher.ENCRYPT_MODE, SECRET_KEY);
 
             encrypterCTRNoPadding = Cipher.getInstance(
-                    "SM4/CTR/NoPadding", PROVIDER);
+                    "SM4/CTR/NoPadding", "KonaCrypto");
             encrypterCTRNoPadding.init(
                     Cipher.ENCRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
 
             encrypterGCMNoPadding = Cipher.getInstance(
-                    "SM4/GCM/NoPadding", PROVIDER);
+                    "SM4/GCM/NoPadding", "KonaCrypto");
+            encrypterGCMNoPadding.init(
+                    Cipher.ENCRYPT_MODE, SECRET_KEY, GCM_PARAM_SPEC);
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class EncrypterHolderNative {
+        Cipher encrypterCBCPadding;
+        Cipher encrypterCBCNoPadding;
+        Cipher encrypterECBNoPadding;
+        Cipher encrypterCTRNoPadding;
+        Cipher encrypterGCMNoPadding;
+
+        @Setup(Level.Invocation)
+        public void setup() throws Exception {
+            encrypterCBCPadding = Cipher.getInstance(
+                    "SM4/CBC/PKCS7Padding", "KonaCrypto-Native");
+            encrypterCBCPadding.init(
+                    Cipher.ENCRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
+
+            encrypterCBCNoPadding = Cipher.getInstance(
+                    "SM4/CBC/NoPadding", "KonaCrypto-Native");
+            encrypterCBCNoPadding.init(
+                    Cipher.ENCRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
+
+            encrypterECBNoPadding = Cipher.getInstance(
+                    "SM4/ECB/NoPadding", "KonaCrypto-Native");
+            encrypterECBNoPadding.init(
+                    Cipher.ENCRYPT_MODE, SECRET_KEY);
+
+            encrypterCTRNoPadding = Cipher.getInstance(
+                    "SM4/CTR/NoPadding", "KonaCrypto-Native");
+            encrypterCTRNoPadding.init(
+                    Cipher.ENCRYPT_MODE, SECRET_KEY, IV_PARAM_SPEC);
+
+            encrypterGCMNoPadding = Cipher.getInstance(
+                    "SM4/GCM/NoPadding", "KonaCrypto-Native");
             encrypterGCMNoPadding.init(
                     Cipher.ENCRYPT_MODE, SECRET_KEY, GCM_PARAM_SPEC);
         }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoInsts.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoInsts.java
@@ -33,7 +33,7 @@ import java.util.Set;
 
 public class CryptoInsts {
 
-    static final Provider PROV = CryptoUtils.useNativeCrypto()
+    public static final Provider PROV = CryptoUtils.useNativeCrypto()
             ? KonaCryptoNativeProvider.instance()
             : KonaCryptoProvider.instance();
 

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/KonaCryptoProviderTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/KonaCryptoProviderTest.java
@@ -34,6 +34,6 @@ public class KonaCryptoProviderTest {
 
     @Test
     public void testAddProvider() {
-        Assertions.assertNotNull(Security.getProvider(KonaCryptoProvider.NAME));
+        Assertions.assertNotNull(Security.getProvider(TestUtils.PROVIDER.getName()));
     }
 }

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/TestUtils.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/TestUtils.java
@@ -45,7 +45,13 @@ public class TestUtils {
     public static final byte[] EMPTY = new byte[0];
 
     public static void addProviders() {
-        Security.addProvider(new KonaCryptoProvider());
+        if (PROVIDER instanceof KonaCryptoProvider) {
+            Security.addProvider(KonaCryptoProvider.instance());
+            Security.addProvider(KonaCryptoNativeProvider.instance());
+        } else {
+            Security.addProvider(KonaCryptoNativeProvider.instance());
+            Security.addProvider(KonaCryptoProvider.instance());
+        }
     }
 
     public static void repeatTaskParallelly(Callable<Void> task, int count)

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
@@ -91,8 +91,8 @@ public class TestUtils {
             "--add-exports", "java.base/jdk.internal.access=ALL-UNNAMED");
 
     public static void addProviders() {
-        Security.addProvider(new KonaCryptoProvider());
-        Security.addProvider(new KonaPKIXProvider());
+        Security.addProvider(CryptoInsts.PROV);
+        Security.addProvider(KonaPKIXProvider.instance());
     }
 
     public static Path resFilePath(String resource) {

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/demo/PKIDemo.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/demo/PKIDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,7 @@
 
 package com.tencent.kona.pkix.demo;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.pkix.TestUtils;
 import org.junit.jupiter.api.Test;
 
@@ -287,7 +288,7 @@ public class PKIDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", CryptoInsts.PROV);
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/demo/SignatureDemo.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/demo/SignatureDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,7 @@
 
 package com.tencent.kona.pkix.demo;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.pkix.PKIXUtils;
 import com.tencent.kona.pkix.TestUtils;
 import org.junit.jupiter.api.Assertions;
@@ -107,13 +108,13 @@ public class SignatureDemo {
     @Test
     public void testSignature() throws Exception {
         PrivateKey privateKey = privateKey(KEY);
-        Signature signer = Signature.getInstance("SM3withSM2", "KonaCrypto");
+        Signature signer = Signature.getInstance("SM3withSM2", CryptoInsts.PROV);
         signer.initSign(privateKey);
         signer.update(DATA);
         byte[] sign = signer.sign();
 
         Certificate certificate = certificate(CERT);
-        Signature verifier = Signature.getInstance("SM3withSM2", "KonaCrypto");
+        Signature verifier = Signature.getInstance("SM3withSM2", CryptoInsts.PROV);
         verifier.initVerify(certificate);
         verifier.update(DATA);
         boolean verified = verifier.verify(sign);
@@ -126,7 +127,7 @@ public class SignatureDemo {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(removeBELines(pkcs8PEM)));
         KeyFactory keyFactory = KeyFactory.getInstance(
-                "EC", "KonaCrypto");
+                "EC", CryptoInsts.PROV);
         return keyFactory.generatePrivate(privateKeySpec);
     }
 
@@ -147,13 +148,13 @@ public class SignatureDemo {
     @Test
     public void testSignatureWithCustomAPI() throws Exception {
         PrivateKey privateKey = PKIXUtils.getPrivateKey("EC", KEY);
-        Signature signer = Signature.getInstance("SM3withSM2", "KonaCrypto");
+        Signature signer = Signature.getInstance("SM3withSM2", CryptoInsts.PROV);
         signer.initSign(privateKey);
         signer.update(DATA);
         byte[] sign = signer.sign();
 
         Certificate certificate = PKIXUtils.getCertificate(CERT);
-        Signature verifier = Signature.getInstance("SM3withSM2", "KonaCrypto");
+        Signature verifier = Signature.getInstance("SM3withSM2", CryptoInsts.PROV);
         verifier.initVerify(certificate);
         verifier.update(DATA);
         Assertions.assertTrue(verifier.verify(sign));

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/KeyFactoryTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/KeyFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,7 @@
 
 package com.tencent.kona.pkix.provider;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.sun.security.x509.X509Key;
 import com.tencent.kona.pkix.TestUtils;
 import org.junit.jupiter.api.Assertions;
@@ -55,7 +56,7 @@ public class KeyFactoryTest {
         X509Certificate x509Cert = TestUtils.certAsFile("ca-sm2sm2.crt");
         PublicKey publicKey = x509Cert.getPublicKey();
 
-        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", CryptoInsts.PROV);
 
         ECPublicKeySpec publicKeySpec = keyFactory.getKeySpec(
                 publicKey, ECPublicKeySpec.class);
@@ -81,7 +82,7 @@ public class KeyFactoryTest {
         X509Certificate x509Cert = TestUtils.certAsFile("ca-sm2sm2.crt");
         ECPublicKey publicKey = (ECPublicKey) x509Cert.getPublicKey();
 
-        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", CryptoInsts.PROV);
 
         ECPublicKeySpec ecPublicKeySpec = keyFactory.getKeySpec(
                 publicKey, ECPublicKeySpec.class);
@@ -152,7 +153,7 @@ public class KeyFactoryTest {
 
     private void testGenerateECPrivateKey(ECPrivateKey privateKey)
             throws Exception {
-        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", CryptoInsts.PROV);
 
         ECPrivateKeySpec ecPrivateKeySpec = keyFactory.getKeySpec(
                 privateKey, ECPrivateKeySpec.class);

--- a/kona-provider/src/test/java/com/tencent/kona/TestUtils.java
+++ b/kona-provider/src/test/java/com/tencent/kona/TestUtils.java
@@ -26,6 +26,6 @@ public class TestUtils {
     public static final String PROVIDER = KonaProvider.NAME;
 
     public static void addProviders() {
-        Security.addProvider(new KonaProvider());
+        Security.addProvider(KonaProvider.instance());
     }
 }

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/TestUtils.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/TestUtils.java
@@ -94,9 +94,9 @@ public class TestUtils {
     }
 
     public static void addProviders() {
-        Security.addProvider(new KonaCryptoProvider());
-        Security.addProvider(new KonaPKIXProvider());
-        Security.addProvider(new KonaSSLProvider());
+        Security.addProvider(CryptoInsts.PROV);
+        Security.addProvider(KonaPKIXProvider.instance());
+        Security.addProvider(KonaSSLProvider.instance());
     }
 
     public static Path resFilePath(String resource) {

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithGRPCDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithGRPCDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,7 @@
 
 package com.tencent.kona.ssl.demo;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import io.grpc.Channel;
@@ -345,7 +346,7 @@ public class TLCPWithGRPCDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", CryptoInsts.PROV);
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithJettyDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithJettyDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,7 @@
 
 package com.tencent.kona.ssl.demo;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import org.eclipse.jetty.client.HttpClient;
@@ -364,7 +365,7 @@ public class TLCPWithJettyDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", CryptoInsts.PROV);
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithNettyDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithNettyDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,7 @@
 
 package com.tencent.kona.ssl.demo;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import io.netty.bootstrap.Bootstrap;
@@ -433,7 +434,7 @@ public class TLCPWithNettyDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", CryptoInsts.PROV);
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithTomcatDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithTomcatDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,7 @@
 
 package com.tencent.kona.ssl.demo;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import org.apache.catalina.Context;
@@ -392,7 +393,7 @@ public class TLCPWithTomcatDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", CryptoInsts.PROV);
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithoutCertValidationDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithoutCertValidationDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,7 @@
 
 package com.tencent.kona.ssl.demo;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -328,7 +329,7 @@ public class TLCPWithoutCertValidationDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", CryptoInsts.PROV);
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithGRPCDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithGRPCDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,7 @@
 
 package com.tencent.kona.ssl.demo;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import io.grpc.Channel;
@@ -277,7 +278,7 @@ public class TLSWithGRPCDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", CryptoInsts.PROV);
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithJettyDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithJettyDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,7 @@
 
 package com.tencent.kona.ssl.demo;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import org.eclipse.jetty.client.HttpClient;
@@ -297,7 +298,7 @@ public class TLSWithJettyDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", CryptoInsts.PROV);
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithOkHttpDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithOkHttpDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,7 @@
 
 package com.tencent.kona.ssl.demo;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import okhttp3.ConnectionSpec;
@@ -314,7 +315,7 @@ public class TLSWithOkHttpDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", CryptoInsts.PROV);
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithTomcatDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithTomcatDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,7 @@
 
 package com.tencent.kona.ssl.demo;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.ssl.TestUtils;
 import com.tencent.kona.sun.security.x509.SMCertificate;
 import org.apache.catalina.Context;
@@ -320,7 +321,7 @@ public class TLSWithTomcatDemo {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", CryptoInsts.PROV);
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/Utilities.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/Utilities.java
@@ -23,6 +23,7 @@
 
 package com.tencent.kona.ssl.interop;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.pkix.PKIXUtils;
 import com.tencent.kona.ssl.SSLInsts;
 
@@ -211,7 +212,7 @@ public class Utilities {
     // JDK uses different provider for EC and RSA.
     private static String cryptoProvider(String provider, Cert cert) {
         if (!"SUN".equalsIgnoreCase(provider)) {
-            return "KonaCrypto";
+            return CryptoInsts.PROV.getName();
         }
 
         if("RSA".equalsIgnoreCase(cert.keyAlgo.name)) {

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLCPNettyClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLCPNettyClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,7 @@
 
 package com.tencent.kona.ssl.peers;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.crypto.KonaCryptoProvider;
 import com.tencent.kona.pkix.KonaPKIXProvider;
 import com.tencent.kona.ssl.KonaSSLProvider;
@@ -245,7 +246,7 @@ public class TLCPNettyClient {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", CryptoInsts.PROV);
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLCPNettyServer.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLCPNettyServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,6 +19,7 @@
 
 package com.tencent.kona.ssl.peers;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.crypto.KonaCryptoProvider;
 import com.tencent.kona.pkix.KonaPKIXProvider;
 import com.tencent.kona.ssl.KonaSSLProvider;
@@ -244,7 +245,7 @@ public class TLCPNettyServer {
     private static PrivateKey loadPrivateKey(String keyPEM) throws Exception {
         PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(
                 Base64.getMimeDecoder().decode(keyPEM));
-        KeyFactory keyFactory = KeyFactory.getInstance("EC", "KonaCrypto");
+        KeyFactory keyFactory = KeyFactory.getInstance("EC", CryptoInsts.PROV);
         return keyFactory.generatePrivate(privateKeySpec);
     }
 

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/SSLEngineTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/SSLEngineTest.java
@@ -26,6 +26,7 @@
 
 package com.tencent.kona.ssl.tlcp;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.ssl.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -153,7 +154,7 @@ public class SSLEngineTest {
                 PKCS8EncodedKeySpec priKeySpec = new PKCS8EncodedKeySpec(
                         Base64.getMimeDecoder().decode(endEntityCerts[i].privKeyStr));
                 KeyFactory kf = KeyFactory.getInstance(
-                        endEntityCerts[i].keyAlgo, "KonaCrypto");
+                        endEntityCerts[i].keyAlgo, CryptoInsts.PROV);
                 PrivateKey priKey = kf.generatePrivate(priKeySpec);
 
                 // generate certificate chain

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/SSLSocketTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/SSLSocketTest.java
@@ -36,6 +36,7 @@
 
 package com.tencent.kona.ssl.tlcp;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.ssl.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -439,7 +440,7 @@ public class SSLSocketTest {
                 PKCS8EncodedKeySpec priKeySpec = new PKCS8EncodedKeySpec(
                         Base64.getMimeDecoder().decode(endEntityCerts[i].privKeyStr));
                 KeyFactory kf = KeyFactory.getInstance(
-                        endEntityCerts[i].keyAlgo, "KonaCrypto");
+                        endEntityCerts[i].keyAlgo, CryptoInsts.PROV);
                 PrivateKey priKey = kf.generatePrivate(priKeySpec);
 
                 // generate certificate chain

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/SSLSocketOnTLS12Test.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/SSLSocketOnTLS12Test.java
@@ -36,6 +36,7 @@
 
 package com.tencent.kona.ssl.tls;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.ssl.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -438,7 +439,7 @@ public class SSLSocketOnTLS12Test {
                 PKCS8EncodedKeySpec priKeySpec = new PKCS8EncodedKeySpec(
                     Base64.getMimeDecoder().decode(endEntityCerts[i].privKeyStr));
                 KeyFactory kf = KeyFactory.getInstance(
-                        endEntityCerts[i].keyAlgo, "KonaCrypto");
+                        endEntityCerts[i].keyAlgo, CryptoInsts.PROV);
                 PrivateKey priKey = kf.generatePrivate(priKeySpec);
 
                 // generate certificate chain

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/SSLSocketOnTLS13Test.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/SSLSocketOnTLS13Test.java
@@ -36,6 +36,7 @@
 
 package com.tencent.kona.ssl.tls;
 
+import com.tencent.kona.crypto.CryptoInsts;
 import com.tencent.kona.ssl.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -438,7 +439,7 @@ public class SSLSocketOnTLS13Test {
                 PKCS8EncodedKeySpec priKeySpec = new PKCS8EncodedKeySpec(
                     Base64.getMimeDecoder().decode(endEntityCerts[i].privKeyStr));
                 KeyFactory kf = KeyFactory.getInstance(
-                        endEntityCerts[i].keyAlgo, "KonaCrypto");
+                        endEntityCerts[i].keyAlgo, CryptoInsts.PROV);
                 PrivateKey priKey = kf.generatePrivate(priKeySpec);
 
                 // generate certificate chain


### PR DESCRIPTION
Currently, the crypto JMH tests just run on the pure Java crypto provider, exactly `KonaCrypto`.
They should also run on the native crypto provider, namely `KonaCrypto-Native`.

This PR will resolves #993.