### PR TITLE
TKSS-996: Add native SM4 cipher benchmarks

### DIFF
--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4DecrypterPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4DecrypterPerfTest.java
@@ -292,12 +292,22 @@ public class SM4DecrypterPerfTest {
     }
 
     @Benchmark
+    public byte[] cbcPaddingNative(DecrypterHolderNative holder) throws Exception {
+        return holder.decrypterCBCPadding.doFinal(holder.ciphertextCBCPadding);
+    }
+
+    @Benchmark
     public byte[] cbcPaddingBC(DecrypterHolderBC holder) throws Exception {
         return holder.decrypterCBCPadding.doFinal(holder.ciphertextCBCPadding);
     }
 
     @Benchmark
     public byte[] cbcNoPadding(DecrypterHolder holder) throws Exception {
+        return holder.decrypterCBCNoPadding.doFinal(holder.ciphertextCBCNoPadding);
+    }
+
+    @Benchmark
+    public byte[] cbcNoPaddingNative(DecrypterHolderNative holder) throws Exception {
         return holder.decrypterCBCNoPadding.doFinal(holder.ciphertextCBCNoPadding);
     }
 
@@ -312,6 +322,11 @@ public class SM4DecrypterPerfTest {
     }
 
     @Benchmark
+    public byte[] ecbNative(DecrypterHolderNative holder) throws Exception {
+        return holder.decrypterECBNoPadding.doFinal(holder.ciphertextECBNoPadding);
+    }
+
+    @Benchmark
     public byte[] ecbBC(DecrypterHolderBC holder) throws Exception {
         return holder.decrypterECBNoPadding.doFinal(holder.ciphertextECBNoPadding);
     }
@@ -322,12 +337,22 @@ public class SM4DecrypterPerfTest {
     }
 
     @Benchmark
+    public byte[] ctrNative(DecrypterHolderNative holder) throws Exception {
+        return holder.decrypterCTRNoPadding.doFinal(holder.ciphertextCTRNoPadding);
+    }
+
+    @Benchmark
     public byte[] ctrBC(DecrypterHolderBC holder) throws Exception {
         return holder.decrypterCTRNoPadding.doFinal(holder.ciphertextCTRNoPadding);
     }
 
     @Benchmark
     public byte[] gcm(DecrypterHolder holder) throws Exception {
+        return holder.decrypterGCMNoPadding.doFinal(holder.ciphertextGCMNoPadding);
+    }
+
+    @Benchmark
+    public byte[] gcmNative(DecrypterHolderNative holder) throws Exception {
         return holder.decrypterGCMNoPadding.doFinal(holder.ciphertextGCMNoPadding);
     }
 

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4EncrypterPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4EncrypterPerfTest.java
@@ -190,12 +190,22 @@ public class SM4EncrypterPerfTest {
     }
 
     @Benchmark
+    public byte[] cbcPaddingNative(EncrypterHolderNative holder) throws Exception {
+        return holder.encrypterCBCPadding.doFinal(DATA);
+    }
+
+    @Benchmark
     public byte[] cbcPaddingBC(EncrypterHolderBC holder) throws Exception {
         return holder.encrypterCBCPadding.doFinal(DATA);
     }
 
     @Benchmark
     public byte[] cbcNoPadding(EncrypterHolder holder) throws Exception {
+        return holder.encrypterCBCNoPadding.doFinal(DATA);
+    }
+
+    @Benchmark
+    public byte[] cbcNoPaddingNative(EncrypterHolderNative holder) throws Exception {
         return holder.encrypterCBCNoPadding.doFinal(DATA);
     }
 
@@ -210,6 +220,11 @@ public class SM4EncrypterPerfTest {
     }
 
     @Benchmark
+    public byte[] ctrNative(EncrypterHolderNative holder) throws Exception {
+        return holder.encrypterCTRNoPadding.doFinal(DATA);
+    }
+
+    @Benchmark
     public byte[] ctrBC(EncrypterHolderBC holder) throws Exception {
         return holder.encrypterCTRNoPadding.doFinal(DATA);
     }
@@ -220,12 +235,22 @@ public class SM4EncrypterPerfTest {
     }
 
     @Benchmark
+    public byte[] ecbNative(EncrypterHolderNative holder) throws Exception {
+        return holder.encrypterECBNoPadding.doFinal(DATA);
+    }
+
+    @Benchmark
     public byte[] ecbBC(EncrypterHolderBC holder) throws Exception {
         return holder.encrypterECBNoPadding.doFinal(DATA);
     }
 
     @Benchmark
     public byte[] gcm(EncrypterHolder holder) throws Exception {
+        return holder.encrypterGCMNoPadding.doFinal(DATA);
+    }
+
+    @Benchmark
+    public byte[] gcmNative(EncrypterHolderNative holder) throws Exception {
         return holder.encrypterGCMNoPadding.doFinal(DATA);
     }
 


### PR DESCRIPTION
`SM4EncrypterPerfTest` and `SM4DecrypterPerfTest` should add benchmarks for the native crypto implementations.

This PR will resolves #996.