### PR TITLE
TKSS-998: Run all unit tests on the native crypto provider

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -56,5 +56,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
-      - name: Execute Gradle build
-        run: ./gradlew clean build
+      - name: Execute tests with the pure Java crypto
+        run: ./gradlew clean test
+
+      - name: Execute tests with the native crypto
+        run: ./gradlew clean testNativeOnCurrent

--- a/buildSrc/src/main/kotlin/kona-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/kona-common.gradle.kts
@@ -60,6 +60,18 @@ tasks {
     }
 
     val testOnCurrent = register("testOnCurrent", CommonTest::class) {
+        jvmArgs("-Dcom.tencent.kona.useNativeCrypto=false")
+
+        systemProperty("test.classpath", classpath.joinToString(separator = ":"))
+
+        doFirst {
+            println("Testing JDK: " + javaLauncher.get().metadata.installationPath)
+        }
+    }
+
+    register("testNativeOnCurrent", CommonTest::class) {
+        jvmArgs("-Dcom.tencent.kona.useNativeCrypto=true")
+
         systemProperty("test.classpath", classpath.joinToString(separator = ":"))
 
         doFirst {
@@ -68,6 +80,8 @@ tasks {
     }
 
     register("testOnAdop8", CommonTest::class) {
+        jvmArgs("-Dcom.tencent.kona.useNativeCrypto=false")
+
         systemProperty("test.classpath", classpath.joinToString(separator = ":"))
 
         javaLauncher.set(javaToolchains.launcherFor {
@@ -81,7 +95,8 @@ tasks {
     }
 
     register("testOnAdop11", CommonTest::class) {
-        jvmArgs("--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED")
+        jvmArgs("-Dcom.tencent.kona.useNativeCrypto=false",
+            "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED")
 
         systemProperty("test.classpath", classpath.joinToString(separator = ":"))
 
@@ -96,7 +111,8 @@ tasks {
     }
 
     register("testOnAdop17", CommonTest::class) {
-        jvmArgs("--add-exports", "java.base/jdk.internal.access=ALL-UNNAMED")
+        jvmArgs("-Dcom.tencent.kona.useNativeCrypto=false",
+            "--add-exports", "java.base/jdk.internal.access=ALL-UNNAMED")
 
         systemProperty("test.classpath", classpath.joinToString(separator = ":"))
 
@@ -111,7 +127,8 @@ tasks {
     }
 
     register("testOnAdop21", CommonTest::class) {
-        jvmArgs("--add-exports", "java.base/jdk.internal.access=ALL-UNNAMED")
+        jvmArgs("-Dcom.tencent.kona.useNativeCrypto=false",
+            "--add-exports", "java.base/jdk.internal.access=ALL-UNNAMED")
 
         systemProperty("test.classpath", classpath.joinToString(separator = ":"))
 
@@ -126,6 +143,8 @@ tasks {
     }
 
     register("testOnKona8", CommonTest::class) {
+        jvmArgs("-Dcom.tencent.kona.useNativeCrypto=false");
+
         systemProperty("test.classpath", classpath.joinToString(separator = ":"))
 
         javaLauncher.set(javaToolchains.launcherFor {
@@ -139,6 +158,9 @@ tasks {
     }
 
     register("testOnKona11", CommonTest::class) {
+        jvmArgs("-Dcom.tencent.kona.useNativeCrypto=false",
+            "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED")
+
         systemProperty("test.classpath", classpath.joinToString(separator = ":"))
 
         javaLauncher.set(javaToolchains.launcherFor {
@@ -152,6 +174,9 @@ tasks {
     }
 
     register("testOnKona17", CommonTest::class) {
+        jvmArgs("-Dcom.tencent.kona.useNativeCrypto=false",
+            "--add-exports", "java.base/jdk.internal.access=ALL-UNNAMED")
+
         systemProperty("test.classpath", classpath.joinToString(separator = ":"))
 
         javaLauncher.set(javaToolchains.launcherFor {
@@ -165,6 +190,9 @@ tasks {
     }
 
     register("testOnKona21", CommonTest::class) {
+        jvmArgs("-Dcom.tencent.kona.useNativeCrypto=false",
+            "--add-exports", "java.base/jdk.internal.access=ALL-UNNAMED")
+
         systemProperty("test.classpath", classpath.joinToString(separator = ":"))
 
         javaLauncher.set(javaToolchains.launcherFor {
@@ -178,6 +206,9 @@ tasks {
     }
 
     register("testOnGraal17", CommonTest::class) {
+        jvmArgs("-Dcom.tencent.kona.useNativeCrypto=false",
+            "--add-exports", "java.base/jdk.internal.access=ALL-UNNAMED")
+
         systemProperty("test.classpath", classpath.joinToString(separator = ":"))
 
         javaLauncher.set(javaToolchains.launcherFor {
@@ -191,6 +222,9 @@ tasks {
     }
 
     register("testOnGraal21", CommonTest::class) {
+        jvmArgs("-Dcom.tencent.kona.useNativeCrypto=false",
+            "--add-exports", "java.base/jdk.internal.access=ALL-UNNAMED")
+
         systemProperty("test.classpath", classpath.joinToString(separator = ":"))
 
         javaLauncher.set(javaToolchains.launcherFor {

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcClient.java
@@ -23,6 +23,7 @@
 
 package com.tencent.kona.ssl.interop;
 
+import com.tencent.kona.crypto.CryptoUtils;
 import com.tencent.kona.ssl.TestUtils;
 
 import javax.net.ssl.KeyManagerFactory;
@@ -198,6 +199,8 @@ public class JdkProcClient extends AbstractClient {
     public void connect(String host, int port) throws IOException {
         props.put(JdkProcUtils.PROP_HOST, host);
         props.put(JdkProcUtils.PROP_PORT, port + "");
+        props.put(JdkProcUtils.PROP_USE_NATIVE_CRYPTO,
+                CryptoUtils.useNativeCrypto() + "");
 
         process = JdkProcUtils.java(jdk, Collections.emptyList(), getClass(),
                 props, getLogPath());

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcServer.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcServer.java
@@ -23,6 +23,7 @@
 
 package com.tencent.kona.ssl.interop;
 
+import com.tencent.kona.crypto.CryptoUtils;
 import com.tencent.kona.ssl.TestUtils;
 
 import javax.net.ssl.KeyManagerFactory;
@@ -213,6 +214,9 @@ public class JdkProcServer extends AbstractServer {
 
     @Override
     public void accept() throws IOException {
+        props.put(JdkProcUtils.PROP_USE_NATIVE_CRYPTO,
+                CryptoUtils.useNativeCrypto() + "");
+
         process = JdkProcUtils.java(jdk, Collections.emptyList(), getClass(),
                 props, getLogPath());
         try {

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcUtils.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/JdkProcUtils.java
@@ -58,6 +58,8 @@ public class JdkProcUtils {
     public static final String PROP_MESSAGE = "test.message";
     public static final String PROP_READ_RESPONSE = "test.read.response";
 
+    public static final String PROP_USE_NATIVE_CRYPTO = "com.tencent.kona.useNativeCrypto";
+
     /*
      * Converts a Cert instance to a string, which contains the field values of
      * the Cert. The values are separated by comma.


### PR DESCRIPTION
It should allow to run all unit tests on the native crypto provider.
It can provide an additional Gradle task to achieve that.

This PR will resolves #998.