### PR TITLE
TKSS-1000: Run PKIX and SSL JMH tests with the native crypto provider

### DIFF
--- a/buildSrc/src/main/kotlin/kona-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/kona-common.gradle.kts
@@ -249,6 +249,13 @@ tasks {
     register("jmh", type=JavaExec::class) {
         mainClass.set("org.openjdk.jmh.Main")
         classpath(sourceSets["jmh"].runtimeClasspath)
+        jvmArgs("-Dcom.tencent.kona.useNativeCrypto=false")
+    }
+
+    register("jmhNative", type=JavaExec::class) {
+        mainClass.set("org.openjdk.jmh.Main")
+        classpath(sourceSets["jmh"].runtimeClasspath)
+        jvmArgs("-Dcom.tencent.kona.useNativeCrypto=true")
     }
 }
 


### PR DESCRIPTION
It should allow to run PKIX and SSL JMH tests with the dual crypto providers respectively.
It can provide an additional Gradle task to achieve that.

This PR will resolves #1000.