### PR TITLE
TKSS-1004: KonaSSLTlcpHandshakePerfTest adds case on TLCP_ECDHE_SM4_CBC_SM3

### DIFF
--- a/kona-ssl/src/jmh/java/com/tencent/kona/ssl/perf/KonaSSLTlcpHandshakePerfTest.java
+++ b/kona-ssl/src/jmh/java/com/tencent/kona/ssl/perf/KonaSSLTlcpHandshakePerfTest.java
@@ -87,6 +87,9 @@ public class KonaSSLTlcpHandshakePerfTest {
     @Param({"TLCPv1.1"})
     String protocol;
 
+    @Param({"TLCP_ECC_SM4_CBC_SM3", "TLCP_ECDHE_SM4_CBC_SM3"})
+    String cipherSuite;
+
     @Param({"false", "true"})
     boolean resume;
 
@@ -168,7 +171,7 @@ public class KonaSSLTlcpHandshakePerfTest {
         clientEngine = clientContext.createSSLEngine("client", 80);
         clientEngine.setUseClientMode(true);
         clientEngine.setEnabledProtocols(new String[] {"TLCPv1.1"});
-        clientEngine.setEnabledCipherSuites(new String[] { "TLCP_ECC_SM4_CBC_SM3" });
+        clientEngine.setEnabledCipherSuites(new String[] {cipherSuite});
     }
 
     private HandshakeStatus checkResult(SSLEngine engine, SSLEngineResult result) {


### PR DESCRIPTION
`KonaSSLTlcpHandshakePerfTest` currently uses cipher suite `TLCP_ECC_SM4_CBC_SM3`.
It should also cover `TLCP_ECDHE_SM4_CBC_SM3`.

This PR will resolves #1004.