### PR TITLE
TKSS-1002: Check pointer value

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeMAC.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeMAC.java
@@ -37,7 +37,9 @@ public class NativeMAC extends NativeRef {
 
     @Override
     public void close() {
-        nativeCrypto().sm3hmacFreeMac(pointer);
-        super.close();
+        if (pointer != 0) {
+            nativeCrypto().sm3hmacFreeMac(pointer);
+            super.close();
+        }
     }
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeRef.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeRef.java
@@ -28,7 +28,7 @@ abstract class NativeRef implements Closeable {
     long pointer;
 
     NativeRef(long pointer) {
-        if (pointer <= 0) {
+        if (pointer == 0) {
             throw new IllegalStateException("Create context failed");
         }
 

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2Cipher.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2Cipher.java
@@ -55,7 +55,9 @@ final class NativeSM2Cipher extends NativeRef {
             throw new BadPaddingException("Invalid plaintext");
         }
 
-        byte[] ciphertext = nativeCrypto().sm2CipherEncrypt(pointer, plaintext);
+        byte[] ciphertext = pointer == 0
+                ? null
+                : nativeCrypto().sm2CipherEncrypt(pointer, plaintext);
         if (ciphertext == null) {
             throw new BadPaddingException("Encrypt failed");
         }
@@ -67,7 +69,9 @@ final class NativeSM2Cipher extends NativeRef {
             throw new BadPaddingException("Invalid ciphertext");
         }
 
-        byte[] cleartext = nativeCrypto().sm2CipherDecrypt(pointer, ciphertext);
+        byte[] cleartext = pointer == 0
+                ? null
+                : nativeCrypto().sm2CipherDecrypt(pointer, ciphertext);
         if (cleartext == null) {
             throw new BadPaddingException("Decrypt failed");
         }
@@ -76,7 +80,9 @@ final class NativeSM2Cipher extends NativeRef {
 
     @Override
     public void close() {
-        nativeCrypto().sm2CipherFreeCtx(pointer);
-        super.close();
+        if (pointer != 0) {
+            nativeCrypto().sm2CipherFreeCtx(pointer);
+            super.close();
+        }
     }
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2KeyAgreement.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2KeyAgreement.java
@@ -52,7 +52,7 @@ public class NativeSM2KeyAgreement extends NativeRef {
             throw new IllegalStateException("Shared key length must be greater than 0");
         }
 
-        byte[] sharedKey = nativeCrypto().sm2DeriveKey(pointer,
+        byte[] sharedKey = pointer == 0 ? null : nativeCrypto().sm2DeriveKey(pointer,
                 priKey, pubKey, ePriKey, id,
                 peerPubKey, peerEPubKey, peerId,
                 isInitiator, sharedKeyLength);
@@ -64,7 +64,9 @@ public class NativeSM2KeyAgreement extends NativeRef {
 
     @Override
     public void close() {
-        nativeCrypto().sm2KeyExFreeCtx(pointer);
-        super.close();
+        if (pointer != 0) {
+            nativeCrypto().sm2KeyExFreeCtx(pointer);
+            super.close();
+        }
     }
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2KeyPairGen.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2KeyPairGen.java
@@ -43,7 +43,9 @@ final class NativeSM2KeyPairGen extends NativeRef {
     // K is the private key, 32-bytes
     // X and Y are the coordinates of the public key, 32-bytes
     public byte[] genKeyPair() {
-        byte[] keyPair = nativeCrypto().sm2KeyPairGenGenKeyPair(pointer);
+        byte[] keyPair = pointer == 0
+                ? null
+                : nativeCrypto().sm2KeyPairGenGenKeyPair(pointer);
         if (keyPair == null) {
             throw new IllegalStateException("Generate key pair failed");
         }
@@ -65,7 +67,9 @@ final class NativeSM2KeyPairGen extends NativeRef {
 
     @Override
     public void close() {
-        nativeCrypto().sm2KeyPairGenFreeCtx(pointer);
-        super.close();
+        if (pointer != 0) {
+            nativeCrypto().sm2KeyPairGenFreeCtx(pointer);
+            super.close();
+        }
     }
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2Signature.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2Signature.java
@@ -22,8 +22,7 @@ package com.tencent.kona.crypto.provider.nativeImpl;
 
 import javax.crypto.BadPaddingException;
 
-import static com.tencent.kona.crypto.provider.nativeImpl.NativeCrypto.OPENSSL_SUCCESS;
-import static com.tencent.kona.crypto.provider.nativeImpl.NativeCrypto.nativeCrypto;
+import static com.tencent.kona.crypto.provider.nativeImpl.NativeCrypto.*;
 import static com.tencent.kona.crypto.util.Constants.*;
 
 /**
@@ -81,7 +80,9 @@ final class NativeSM2Signature extends NativeRef {
             throw new BadPaddingException("Message cannot be null");
         }
 
-        byte[] signature = nativeCrypto().sm2SignatureSign(pointer, message);
+        byte[] signature = pointer == 0
+                ? null
+                : nativeCrypto().sm2SignatureSign(pointer, message);
         if (signature == null) {
             throw new BadPaddingException("Sign failed");
         }
@@ -97,13 +98,17 @@ final class NativeSM2Signature extends NativeRef {
             throw new BadPaddingException("Invalid signature");
         }
 
-        int verified = nativeCrypto().sm2SignatureVerify(pointer, message, signature);
+        int verified = pointer == 0
+                ? OPENSSL_FAILURE
+                : nativeCrypto().sm2SignatureVerify(pointer, message, signature);
         return verified == OPENSSL_SUCCESS;
     }
 
     @Override
     public void close() {
-        nativeCrypto().sm2SignatureFreeCtx(pointer);
-        super.close();
+        if (pointer != 0) {
+            nativeCrypto().sm2SignatureFreeCtx(pointer);
+            super.close();
+        }
     }
 }


### PR DESCRIPTION
Although the JNI/C functions check the pointers, it would also be better to check them on the Java layer.
If the pointer is 0, for example the native object is already closed, then it's unnecessary to call native methods.

This PR will resolves #1012.