### PR TITLE
TKSS-1022: Need to re-create NativeSM4.SM4GCM instance when opmode is changed

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4.java
@@ -215,7 +215,7 @@ abstract class NativeSM4 extends NativeRef {
             return encrypt ? encDoFinal(data) : decDoFinal(data);
         }
 
-        byte[] encDoFinal(byte[] data) {
+        private byte[] encDoFinal(byte[] data) {
             Objects.requireNonNull(data);
 
             byte[] lastOut = update(data);
@@ -229,7 +229,7 @@ abstract class NativeSM4 extends NativeRef {
             return out;
         }
 
-        byte[] decDoFinal(byte[] data) {
+        private byte[] decDoFinal(byte[] data) {
             if (data == null || data.length < SM4_GCM_TAG_LEN) {
                 throw new IllegalArgumentException("data must not be less than 16-bytes");
             }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4Crypt.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4Crypt.java
@@ -33,6 +33,7 @@ class SM4Crypt extends SymmetricCipher {
 
     private static final Sweeper SWEEPER = Sweeper.instance();
 
+    private boolean opChanged = false;
     private boolean decrypting = false;
     private SM4Params paramSpec;
     private byte[] key;
@@ -62,6 +63,7 @@ class SM4Crypt extends SymmetricCipher {
                     "Wrong key size: expected 16-byte, actual " + key.length);
         }
 
+        this.opChanged = this.decrypting != decrypting;
         this.decrypting = decrypting;
         this.paramSpec = paramSpec;
         this.key = key;
@@ -85,7 +87,7 @@ class SM4Crypt extends SymmetricCipher {
                 break;
             case GCM:
                 gcmLastCipherBlock = new DataWindow(SM4_GCM_TAG_LEN);
-                if (sm4 == null) {
+                if (sm4 == null || opChanged) {
                     sm4 = new NativeSM4.SM4GCM(!decrypting, key, iv);
                     SWEEPER.register(this, new SweepNativeRef(sm4));
                 } else {

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4Test.java
@@ -732,6 +732,26 @@ public class SM4Test {
     }
 
     @Test
+    public void testGCMWithBadTag() throws Exception {
+        SecretKey secretKey = new SecretKeySpec(KEY, "SM4");
+        GCMParameterSpec paramSpec = new GCMParameterSpec(
+                SM4_GCM_TAG_LEN * 8, GCM_IV);
+
+        Cipher cipher = Cipher.getInstance("SM4/GCM/NoPadding", PROVIDER);
+
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey, paramSpec);
+        byte[] ciphertext = cipher.doFinal(MESSAGE);
+
+        // Change the tag bytes
+        ciphertext[ciphertext.length - 1] = 0x00;
+        ciphertext[ciphertext.length - 2] = 0x00;
+
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, paramSpec);
+        Assertions.assertThrows(AEADBadTagException.class,
+                () -> cipher.doFinal(ciphertext));
+    }
+
+    @Test
     public void testUpdateData() throws Exception {
         testUpdateData("SM4/CBC/NoPadding", new IvParameterSpec(IV), true);
         testUpdateData("SM4/CBC/NoPadding", new IvParameterSpec(IV), false);


### PR DESCRIPTION
`NativeSM4.SM4GCM` instance has to be re-created if the initiation changes the opmode.

This PR will resolves #1022.