### PR TITLE
TKSS-1026: SM4DecrypterPerfTest should cover KonaCrypto provider

### DIFF
--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4DecrypterPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4DecrypterPerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public class SM4DecrypterPerfTest {
     @State(Scope.Benchmark)
     public static class DecrypterHolder {
 
-        @Param({"KonaCrypto-Native"})
+        @Param({"KonaCrypto", "KonaCrypto-Native"})
         String provider;
 
         @Param({"Small", "Mid", "Big"})

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4Crypt.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4Crypt.java
@@ -91,7 +91,7 @@ class SM4Crypt extends SymmetricCipher {
                     sm4 = new NativeSM4.SM4GCM(!decrypting, key, iv);
                     SWEEPER.register(this, new SweepNativeRef(sm4));
                 } else {
-                    ((NativeSM4.SM4GCM) sm4).setIV (iv);
+                    ((NativeSM4.SM4GCM) sm4).setIV(iv);
                 }
                 break;
             case CTR:


### PR DESCRIPTION
`SM4DecrypterPerfTest` misses `KonaCrypto` provider.