### PR TITLE
TKSS-1030: Add tests on closing a native crypto instance twice

### DIFF
--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3HMacTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3HMacTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,5 +136,13 @@ public class NativeSM3HMacTest {
         Assertions.assertThrows(
                 IllegalStateException.class,
                 () -> sm3hmac.doFinal(MESSAGE));
+    }
+
+    @Test
+    public void testCloseTwice() {
+        NativeSM3HMac sm3hmac = new NativeSM3HMac(KEY);
+        sm3hmac.doFinal(MESSAGE);
+        sm3hmac.close();
+        sm3hmac.close();
     }
 }

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,5 +132,13 @@ public class NativeSM3Test {
         Assertions.assertThrows(
                 IllegalStateException.class,
                 () -> sm3.doFinal(MESSAGE_SHORT));
+    }
+
+    @Test
+    public void testCloseTwice() {
+        NativeSM3 sm3 = new NativeSM3();
+        sm3.doFinal(MESSAGE_LONG);
+        sm3.close();
+        sm3.close();
     }
 }

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -171,6 +171,23 @@ public class NativeSM4Test {
     }
 
     @Test
+    public void testUseClosedCBCRef() {
+        SM4CBC sm4 = new SM4CBC(true, false, KEY, IV);
+        sm4.close();
+
+        Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> sm4.doFinal(MESSAGE_32));
+    }
+
+    @Test
+    public void testCloseCBCTwice() {
+        SM4CBC sm4 = new SM4CBC(true, false, KEY, IV);
+        sm4.close();
+        sm4.close();
+    }
+
+    @Test
     public void testCTR() {
         try(SM4CTR encrypter = new SM4CTR(true, KEY, IV)) {
             byte[] ciphertext = encrypter.doFinal(MESSAGE_32);
@@ -246,6 +263,23 @@ public class NativeSM4Test {
                     NullPointerException.class,
                     () -> encrypter.doFinal(null));
         }
+    }
+
+    @Test
+    public void testUseClosedCTRRef() {
+        SM4CTR sm4 = new SM4CTR(true, KEY, IV);
+        sm4.close();
+
+        Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> sm4.doFinal(MESSAGE_32));
+    }
+
+    @Test
+    public void testCloseCTRTwice() {
+        SM4CTR sm4 = new SM4CTR(true, KEY, IV);
+        sm4.close();
+        sm4.close();
     }
 
     @Test
@@ -339,6 +373,23 @@ public class NativeSM4Test {
                     NullPointerException.class,
                     () -> encrypter.doFinal(null));
         }
+    }
+
+    @Test
+    public void testUseClosedECBRef() {
+        SM4ECB sm4 = new SM4ECB(true, false, KEY);
+        sm4.close();
+
+        Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> sm4.doFinal(MESSAGE_32));
+    }
+
+    @Test
+    public void testCloseECBTwice() {
+        SM4ECB sm4 = new SM4ECB(true, false, KEY);
+        sm4.close();
+        sm4.close();
     }
 
     @Test
@@ -453,6 +504,23 @@ public class NativeSM4Test {
     }
 
     @Test
+    public void testUseClosedGCMRef() {
+        SM4GCM sm4 = new SM4GCM(false, KEY, GCM_IV);
+        sm4.close();
+
+        Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> sm4.doFinal(MESSAGE_32));
+    }
+
+    @Test
+    public void testCloseGCMTwice() {
+        SM4GCM sm4 = new SM4GCM(false, KEY, GCM_IV);
+        sm4.close();
+        sm4.close();
+    }
+
+    @Test
     public void testKey() {
         Assertions.assertThrows(
                 IllegalStateException.class,
@@ -476,15 +544,5 @@ public class NativeSM4Test {
         Assertions.assertThrows(
                 IllegalStateException.class,
                 ()-> new SM4GCM(true, KEY, IV).close());
-    }
-
-    @Test
-    public void testUseClosedRef() {
-        SM4ECB sm4 = new SM4ECB(true, false, KEY);
-        sm4.close();
-
-        Assertions.assertThrows(
-                IllegalStateException.class,
-                () -> sm4.doFinal(MESSAGE_32));
     }
 }


### PR DESCRIPTION
It should check the case closing a native crypto instance twice.

This PR will resolves #1030.