### PR TITLE
TKSS-1042: sm2ToUncompPubKey, sm2GenPubKey and sm2ValidatePoint can be static

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeCrypto.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeCrypto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify
@@ -190,9 +190,9 @@ final class NativeCrypto {
     native int    sm4GCMProcTag(long pointer, byte[] tag);
 
     /* ***** SM2 ***** */
-    native byte[] sm2ToUncompPubKey(byte[] compPubKey);
-    native byte[] sm2GenPubKey(byte[] priKey);
-    native int    sm2ValidatePoint(byte[] point);
+    static native byte[] sm2ToUncompPubKey(byte[] compPubKey);
+    static native byte[] sm2GenPubKey(byte[] priKey);
+    static native int    sm2ValidatePoint(byte[] point);
 
     native long   sm2KeyPairGenCreateCtx();
     native void   sm2KeyPairGenFreeCtx(long pointer);

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2KeyPairGen.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2KeyPairGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify
@@ -54,7 +54,7 @@ final class NativeSM2KeyPairGen extends NativeRef {
             return keyPair;
         } else if (keyPair.length == SM2_PRIKEY_LEN + SM2_COMP_PUBKEY_LEN) {
             // Convert the compressed public key to the uncompressed
-            byte[] uncompPubKey = nativeCrypto().sm2ToUncompPubKey(
+            byte[] uncompPubKey = NativeCrypto.sm2ToUncompPubKey(
                     CryptoUtils.copy(keyPair, SM2_PRIKEY_LEN, SM2_COMP_PUBKEY_LEN));
             byte[] uncompKeyPair = new byte[SM2_PRIKEY_LEN + SM2_PUBKEY_LEN];
             System.arraycopy(keyPair, 0, uncompKeyPair, 0, SM2_PRIKEY_LEN);

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2KeyAgreement.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2KeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify
@@ -113,7 +113,7 @@ public final class SM2KeyAgreement extends KeyAgreementSpi {
         }
 
         SM2PublicKey sm2PublicKey = new SM2PublicKey((ECPublicKey) key);
-        if (NativeCrypto.nativeCrypto().sm2ValidatePoint(sm2PublicKey.getEncoded())
+        if (NativeCrypto.sm2ValidatePoint(sm2PublicKey.getEncoded())
                 != OPENSSL_SUCCESS) {
             throw new InvalidKeyException("Public key is invalid");
         }

--- a/kona-crypto/src/main/jni/include/kona/kona_jni.h
+++ b/kona-crypto/src/main/jni/include/kona/kona_jni.h
@@ -169,7 +169,7 @@ JNIEXPORT jint JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeCr
  * Signature: ([B)[B
  */
 JNIEXPORT jbyteArray JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeCrypto_sm2ToUncompPubKey
-  (JNIEnv *, jobject, jbyteArray);
+  (JNIEnv *, jclass, jbyteArray);
 
 /*
  * Class:     com_tencent_kona_crypto_provider_nativeImpl_NativeCrypto
@@ -177,7 +177,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_Na
  * Signature: ([B)[B
  */
 JNIEXPORT jbyteArray JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeCrypto_sm2GenPubKey
-  (JNIEnv *, jobject, jbyteArray);
+  (JNIEnv *, jclass, jbyteArray);
 
 /*
  * Class:     com_tencent_kona_crypto_provider_nativeImpl_NativeCrypto
@@ -185,7 +185,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_Na
  * Signature: ([B)I
  */
 JNIEXPORT jint JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeCrypto_sm2ValidatePoint
-  (JNIEnv *, jobject, jbyteArray);
+  (JNIEnv *, jclass, jbyteArray);
 
 /*
  * Class:     com_tencent_kona_crypto_provider_nativeImpl_NativeCrypto

--- a/kona-crypto/src/main/jni/kona_sm2_keypair.c
+++ b/kona-crypto/src/main/jni/kona_sm2_keypair.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
 #include "kona/kona_sm2.h"
 
 JNIEXPORT jbyteArray JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeCrypto_sm2ToUncompPubKey
-  (JNIEnv* env, jobject thisObj, jbyteArray compPubKey) {
+  (JNIEnv* env, jclass classObj, jbyteArray compPubKey) {
     jsize comp_pub_key_len = (*env)->GetArrayLength(env, compPubKey);
     if (comp_pub_key_len != SM2_COMP_PUB_KEY_LEN) {
         return NULL;
@@ -93,7 +93,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_Na
 }
 
 JNIEXPORT jbyteArray JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeCrypto_sm2GenPubKey
-  (JNIEnv* env, jobject thisObj, jbyteArray priKey) {
+  (JNIEnv* env, jclass classObj, jbyteArray priKey) {
     jsize pri_key_len = (*env)->GetArrayLength(env, priKey);
     if (pri_key_len != SM2_PRI_KEY_LEN) {
         return NULL;
@@ -121,7 +121,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_Na
 }
 
 JNIEXPORT jint JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeCrypto_sm2ValidatePoint
-  (JNIEnv* env, jobject thisObj, jbyteArray point) {
+  (JNIEnv* env, jclass classObj, jbyteArray point) {
     int point_len = (*env)->GetArrayLength(env, point);
     if (point_len != SM2_PUB_KEY_LEN) {
         return OPENSSL_FAILURE;

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2Test.java
@@ -81,7 +81,7 @@ public class NativeSM2Test {
     }
 
     private void testToUncompPubKey(byte[] expectedPubKey, byte[] compPubKey) {
-        byte[] uncompPubKey = NativeCrypto.nativeCrypto().sm2ToUncompPubKey(compPubKey);
+        byte[] uncompPubKey = NativeCrypto.sm2ToUncompPubKey(compPubKey);
         Assertions.assertArrayEquals(expectedPubKey, uncompPubKey);
     }
 
@@ -105,7 +105,7 @@ public class NativeSM2Test {
     public void testSM2GenPubKey() {
         try (NativeSM2KeyPairGen sm2 = new NativeSM2KeyPairGen()) {
             byte[] keyPair = sm2.genKeyPair();
-            byte[] pubKey = NativeCrypto.nativeCrypto().sm2GenPubKey(copy(keyPair, 0, SM2_PRIKEY_LEN));
+            byte[] pubKey = NativeCrypto.sm2GenPubKey(copy(keyPair, 0, SM2_PRIKEY_LEN));
             Assertions.assertArrayEquals(copy(keyPair, SM2_PRIKEY_LEN, SM2_PUBKEY_LEN), pubKey);
         }
     }


### PR DESCRIPTION
The native methods `sm2ToUncompPubKey`, `sm2GenPubKey` and `sm2ValidatePoint` in `NativeCrypto` can be static.

This PR will resolves #1042.