### PR TITLE
TKSS-1048: Backport JDK-8320743: AEAD ciphers throw undocumented exceptions on overflow

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GaloisCounterMode.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GaloisCounterMode.java
@@ -236,7 +236,7 @@ abstract class GaloisCounterMode extends CipherSpi {
             params.init(spec);
             return params;
         } catch (NoSuchAlgorithmException | InvalidParameterSpecException e) {
-            throw new RuntimeException(e);
+            throw new ProviderException(e);
         }
     }
 
@@ -795,7 +795,7 @@ abstract class GaloisCounterMode extends CipherSpi {
         int mergeBlock(byte[] buffer, int bufOfs, int bufLen, byte[] in,
             int inOfs, int inLen, byte[] block) {
             if (bufLen > blockSize) {
-                throw new RuntimeException("mergeBlock called on an ibuffer " +
+                throw new ProviderException("mergeBlock called on an ibuffer " +
                     "too big:  " + bufLen + " bytes");
             }
 


### PR DESCRIPTION
This is a backport of [JDK-8320743]: AEAD ciphers throw undocumented exceptions on overflow.

This PR will resolves #1048.

[JDK-8320743]:
https://bugs.openjdk.org/browse/JDK-8320743