### PR TITLE
TKSS-1061: Backport JDK-8342062: Reformat keytool and jarsigner output for keys with a named parameter set

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/tools/keytool/Resources.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/tools/keytool/Resources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -307,10 +307,12 @@ public class Resources extends java.util.ListResourceBundle {
                 "Specifying -keysize for generating EC keys is deprecated, please use \"-groupname %s\" instead."},
         {"Key.pair.not.generated.alias.alias.already.exists",
                 "Key pair not generated, alias <{0}> already exists"},
-        {"Generating.keysize.bit.keyAlgName.key.pair.and.self.signed.certificate.sigAlgName.with.a.validity.of.validality.days.for",
-                "Generating {0} bit {1} key pair and self-signed certificate ({2}) with a validity of {3} days\n\tfor: {4}"},
-        {"Generating.keysize.bit.keyAlgName.key.pair.and.a.certificate.sigAlgName.issued.by.signerAlias.with.a.validity.of.validality.days.for",
-                "Generating {0} bit {1} key pair and a certificate ({2}) issued by <{3}> with a validity of {4} days\n\tfor: {5}"},
+        {"size.bit.alg",
+                "%1$d-bit %2$s"},
+        {"Generating.full.keyAlgName.key.pair.and.self.signed.certificate.sigAlgName.with.a.validity.of.days.for",
+                "Generating {0} key pair and self-signed certificate ({1}) with a validity of {2} days\n\tfor: {3}"},
+        {"Generating.full.keyAlgName.key.pair.and.a.certificate.sigAlgName.issued.by.signerAlias.with.a.validity.of.days.for",
+                "Generating {0} key pair and a certificate ({1}) issued by <{2}> with a validity of {3} days\n\tfor: {4}"},
         {"Enter.key.password.for.alias.", "Enter key password for <{0}>"},
         {".RETURN.if.same.as.keystore.password.",
                 "\t(RETURN if same as keystore password):  "},
@@ -479,10 +481,9 @@ public class Resources extends java.util.ListResourceBundle {
         {"alias.in.keystore", "Issuer <%s>"},
         {"with.weak", "%s (weak)"},
         {"with.disabled", "%s (disabled)"},
-        {"key.bit", "%1$d-bit %2$s key"},
-        {"key.bit.weak", "%1$d-bit %2$s key (weak)"},
-        {"key.bit.disabled", "%1$d-bit %2$s key (disabled)"},
-        {"unknown.size.1", "%s key of unknown size"},
+        {"key.bit", "%s key"},
+        {"key.bit.weak", "%s key (weak)"},
+        {"key.bit.disabled", "%s key (disabled)"},
         {".PATTERN.printX509Cert.with.weak",
                 "Owner: {0}\nIssuer: {1}\nSerial number: {2}\nValid from: {3} until: {4}\nCertificate fingerprints:\n\t SHA1: {5}\n\t SHA256: {6}\nSignature algorithm name: {7}\nSubject Public Key Algorithm: {8}\nVersion: {9}"},
         {"PKCS.10.with.weak",
@@ -493,7 +494,7 @@ public class Resources extends java.util.ListResourceBundle {
         {"whose.sigalg.usagesignedjar", "%1$s uses the %2$s signature algorithm which is considered a security risk and cannot be used to sign JARs after %3$s."},
         {"Unable.to.parse.denyAfter.string.in.exception.message", "Unable to parse denyAfter date string in exception message"},
         {"whose.sigalg.weak", "%1$s uses the %2$s signature algorithm which is considered a security risk."},
-        {"whose.key.disabled", "%1$s uses a %2$s which is considered a security risk and is disabled."},
+        {"whose.key.weak", "%1$s uses a %2$s which is considered a security risk. It will be disabled in a future update."},
         {"whose.key.weak", "%1$s uses a %2$s which is considered a security risk. This key size will be disabled in a future update."},
         {"jks.storetype.warning", "The %1$s keystore uses a proprietary format. It is recommended to migrate to PKCS12 which is an industry standard format using \"keytool -importkeystore -srckeystore %2$s -destkeystore %2$s -deststoretype pkcs12\"."},
         {"migrate.keystore.warning", "Migrated \"%1$s\" to %4$s. The %2$s keystore is backed up as \"%3$s\"."},

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/KeyUtil.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/KeyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -165,26 +165,6 @@ public final class KeyUtil {
         }
 
         return -1;
-    }
-
-    /**
-     * Returns the algorithm name of the given key object. If an EC key is
-     * specified, returns the algorithm name and its named curve.
-     *
-     * @param key the key object, cannot be null
-     * @return the algorithm name of the given key object, or return in the
-     *       form of "EC (named curve)" if the given key object is an EC key
-     */
-    public static final String fullDisplayAlgName(Key key) {
-        String result = key.getAlgorithm();
-        if (key instanceof ECKey) {
-            ECParameterSpec paramSpec = ((ECKey) key).getParams();
-            if (paramSpec instanceof NamedCurve) {
-                NamedCurve nc = (NamedCurve)paramSpec;
-                result += " (" + nc.getNameAndAliases()[0] + ")";
-            }
-        }
-        return result;
     }
 
     /**


### PR DESCRIPTION
This is a backport of [JDK-8342062]: Reformat keytool and jarsigner output for keys with a named parameter set.

This PR will resolves #1061.

[JDK-8342062]:
https://bugs.openjdk.org/browse/JDK-8342062