### PR TITLE
TKSS-1062: Backport JDK-8347596: Update HSS/LMS public key encoding

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/KeyUtil.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/KeyUtil.java
@@ -396,7 +396,7 @@ public final class KeyUtil {
         try {
             DerValue val = new DerValue(publicKey.getEncoded());
             val.data.getDerValue();
-            byte[] rawKey = new DerValue(val.data.getBitString()).getOctetString();
+            byte[] rawKey = val.data.getBitString();
             // According to https://www.rfc-editor.org/rfc/rfc8554.html:
             // Section 6.1: HSS public key is u32str(L) || pub[0], where pub[0]
             // is the LMS public key for the top-level tree.


### PR DESCRIPTION
This is a backport of [JDK-8347596]: Update HSS/LMS public key encoding.

This PR will resolves #1062.

[JDK-8347596]:
https://bugs.openjdk.org/browse/JDK-8347596