### PR TITLE
TKSS-1059: Backport JDK-8343467: Remove unnecessary @SuppressWarnings annotations (security)

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBES2Parameters.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/PBES2Parameters.java
@@ -203,7 +203,6 @@ abstract class PBES2Parameters extends AlgorithmParametersSpi {
        this.cipherParam = ((PBEParameterSpec)paramSpec).getParameterSpec();
     }
 
-    @SuppressWarnings("deprecation")
     protected void engineInit(byte[] encoded)
         throws IOException
     {
@@ -236,7 +235,6 @@ abstract class PBES2Parameters extends AlgorithmParametersSpi {
         this.pbes2AlgorithmName = "PBEWith" + kdfAlgo + "And" + cipherAlgo;
     }
 
-    @SuppressWarnings("deprecation")
     private String parseKDF(DerValue keyDerivationFunc) throws IOException {
 
         if (!pkcs5PBKDF2_OID.equals(keyDerivationFunc.data.getOID())) {
@@ -297,7 +295,6 @@ abstract class PBES2Parameters extends AlgorithmParametersSpi {
         return kdfAlgo;
     }
 
-    @SuppressWarnings("deprecation")
     private String parseES(DerValue encryptionScheme) throws IOException {
         String cipherAlgo;
 

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/internal/interfaces/TlsMasterSecret.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/internal/interfaces/TlsMasterSecret.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,6 @@ public interface TlsMasterSecret extends SecretKey {
      * ineffectual. Do not use; no replacement.
      */
     @Deprecated
-    @SuppressWarnings("serial")
     long serialVersionUID = -461748105810469773L;
 
     /**


### PR DESCRIPTION
This is a backport of [JDK-8343467]: Remove unnecessary @SuppressWarnings annotations (security).

This PR will resolves #1059.

[JDK-8343467]:
https://bugs.openjdk.org/browse/JDK-8343467