### PR TITLE
TKSS-1078: SM2 JMH tests missed provider KonaCrypto-NativeOneShot

### DIFF
--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2CipherPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2CipherPerfTest.java
@@ -75,7 +75,7 @@ public class SM2CipherPerfTest {
     @State(Scope.Benchmark)
     public static class DecrypterHolder {
 
-        @Param({"KonaCrypto", "KonaCrypto-Native"})
+        @Param({"KonaCrypto", "KonaCrypto-Native", "KonaCrypto-NativeOneShot"})
         String provider;
 
         @Param({"Small", "Mid", "Big"})

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2SignaturePerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2SignaturePerfTest.java
@@ -82,7 +82,7 @@ public class SM2SignaturePerfTest {
     @State(Scope.Benchmark)
     public static class VerifierHolder {
 
-        @Param({"KonaCrypto", "KonaCrypto-Native"})
+        @Param({"KonaCrypto", "KonaCrypto-Native", "KonaCrypto-NativeOneShot"})
         String provider;
 
         @Param({"Small", "Mid", "Big"})


### PR DESCRIPTION
`SM2SignaturePerfTest` and `SM2CipherPerfTest` should cover `KonaCrypto-NativeOneShot` as well.

This PR will resolvese #1078.