### PR TITLE
TKSS-1095: SM2 OneShot implementations should use NativeCrypto sm2OneShot methods

### DIFF
--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2SignatureTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2SignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2025, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -265,7 +265,7 @@ public class SM2SignatureTest {
         verifier.setParameter(paramSpec);
         verifier.initVerify(pubKey);
         Assertions.assertThrows(NullPointerException.class,
-                () -> signer.update((byte[]) null));
+                () -> verifier.update((byte[]) null));
     }
 
     @Test
@@ -289,7 +289,7 @@ public class SM2SignatureTest {
         verifier.setParameter(paramSpec);
         verifier.initVerify(pubKey);
         Assertions.assertThrows(NullPointerException.class,
-                () -> signer.update((ByteBuffer) null));
+                () -> verifier.update((ByteBuffer) null));
     }
 
     @Test


### PR DESCRIPTION
`SM2OneShotCipher` and`SM2OneShotSignature` would use `sm2OneShotXXX` methods.

This PR will resolves #1095.