### PR TITLE
TKSS-1102: Change the JNI headers output directory

### DIFF
--- a/kona-crypto/build.gradle.kts
+++ b/kona-crypto/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,18 +36,20 @@ dependencies {
 tasks.register<Exec>("genJNIHeaders") {
     dependsOn("compileJava")
 
+    val konaIncludeDir = file("src/main/jni/include/kona").absolutePath
     if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
         commandLine = listOf(
             "javah",
             "-classpath", sourceSets["main"].runtimeClasspath.asPath,
-            "-d", file("src/main/jni").absolutePath,
+            "-d", konaIncludeDir,
             "com.tencent.kona.crypto.provider.nativeImpl.NativeCrypto"
         )
     } else {
         commandLine = listOf(
             "javac",
             "-classpath", sourceSets["main"].runtimeClasspath.asPath,
-            "-h", file("src/main/jni").absolutePath,
+            "-h", konaIncludeDir,
+            "-d", konaIncludeDir,
             file("src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeCrypto.java").absolutePath
         )
     }


### PR DESCRIPTION
`genJNIHeaders` task would generate the headers file in `src/main/jni/include/kona`.

This PR will resolves #1102.