### PR TITLE
TKSS-1117: Workflow supports Kona JDK

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -41,6 +41,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         java-version: [8, 11, 17, 21]
+        java-distribution: [temurin, kona]
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -48,10 +50,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: tencent/setup-tencent-kona@v4
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'temurin'
+          distribution: ${{ matrix.java-distribution }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3


### PR DESCRIPTION
The PR workflow could run tests against Kona JDK with the Action `setup-tencent-kona`.

This PR will resolves #1117.