### PR TITLE
docs(kona-crypto): 修复密钥对生成器实例化示例代码中的算法名称缺少引号的问题

### DIFF
--- a/kona-crypto/README.md
+++ b/kona-crypto/README.md
@@ -64,7 +64,7 @@ Generating SM2 key pair is the same as generating the key pairs on other EC curv
 Create `KeyPairGenerator` implementation on `ECKeyPairGenerator`.
 
 ```
-KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("EC);
+KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("EC");
 keyPairGenerator.initialize(spec);
 ```
 
@@ -73,7 +73,7 @@ keyPairGenerator.initialize(spec);
 If create `KeyPairGenerator` implementation on `SM2KeyPairGenerator`, the codes are the belows,
 
 ```
-KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("SM2);
+KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("SM2");
 ```
 
 Generate key pair.
@@ -122,7 +122,7 @@ Using SM2 signature is the same as using other existing signatures, like ECDSA, 
 Create Signature instance.
 
 ```
-Signature signature = Signature.getInstance("SM2);
+Signature signature = Signature.getInstance("SM2");
 ```
 
 Initialize the Signature instance with the private key for signing.

--- a/kona-crypto/README_cn.md
+++ b/kona-crypto/README_cn.md
@@ -108,7 +108,7 @@ PrivateKey privateKey = keyFactory.generatePrivate(privateKeySpec);
 创建Signature实例。
 
 ```
-Signature signature = Signature.getInstance("SM2);
+Signature signature = Signature.getInstance("SM2");
 ```
 
 使用私钥进行初始化，以准备进行签名操作。

--- a/kona-crypto/README_cn.md
+++ b/kona-crypto/README_cn.md
@@ -64,7 +64,7 @@ position的值越小，代表的优先级越高，最小可为1。然而，并�
 创建使用`ECKeyPairGenerator`的`KeyPairGenerator`实例。
 
 ```
-KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("EC);
+KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("EC");
 keyPairGenerator.initialize(spec);
 ```
 
@@ -73,7 +73,7 @@ keyPairGenerator.initialize(spec);
 若创建使用`SM2KeyPairGenerator`的`KeyPairGenerator`实例，则代码如下。
 
 ```
-KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("SM2);
+KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("SM2");
 ```
 
 生成密钥对。


### PR DESCRIPTION
- 修正了 EC 和 SM2 密钥对生成器实例化代码中的算法名称缺少引号的问题
- 在 `getInstance` 方法中添加了缺失的引号