### PR TITLE
TKSS-1131: ECKeyPairGenPerfTest involves ACCP

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@
 
 [versions]
 bouncycastle = "1.80"
+accp = "2.4.1"
 
 grpc = "1.58.0"
 tomcat = "9.0.78"
@@ -38,6 +39,7 @@ protobufPlugin = "0.9.4"
 
 [libraries]
 bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
+
 jetty-server = { module = "org.eclipse.jetty:jetty-server", version.ref = "jetty" }
 jetty-http2-server = { module = "org.eclipse.jetty.http2:http2-server", version.ref = "jetty" }
 jetty-servlet = { module = "org.eclipse.jetty:jetty-servlet", version.ref = "jetty" }

--- a/kona-crypto/build.gradle.kts
+++ b/kona-crypto/build.gradle.kts
@@ -17,12 +17,39 @@
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+import org.gradle.nativeplatform.platform.internal.ArchitectureInternal
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 plugins {
     id("kona-common")
 }
 
+val os: OperatingSystem = DefaultNativePlatform.getCurrentOperatingSystem()
+val arch: ArchitectureInternal = DefaultNativePlatform.getCurrentArchitecture()
+
+fun getAccpClassifier(os: OperatingSystem, arch: ArchitectureInternal): String {
+    return when {
+        os.isLinux && arch.isAmd64 -> "linux-x86_64"
+        os.isLinux && arch.isArm64 -> "linux-aarch_64"
+        os.isMacOsX && arch.isAmd64 -> "osx-x86_64"
+        os.isMacOsX && arch.isArm64 -> "osx-aarch_64"
+        // Just use linux-x86_64 for other platforms, like Windows
+        else -> "linux-x86_64"
+    }
+}
+
 dependencies {
     testImplementation(libs.bcprov.jdk18on)
+
+    val accpClassifier = getAccpClassifier(os, arch)
+    testImplementation(
+        mapOf(
+            "group" to "software.amazon.cryptools",
+            "name" to "AmazonCorrettoCryptoProvider",
+            "version" to libs.versions.accp.get(),
+            "classifier" to accpClassifier
+        )
+    )
 
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/ECKeyPairGenPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/ECKeyPairGenPerfTest.java
@@ -22,9 +22,13 @@ package com.tencent.kona.crypto.perf;
 import com.tencent.kona.crypto.TestUtils;
 import org.openjdk.jmh.annotations.*;
 
+import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECPoint;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -45,7 +49,8 @@ public class ECKeyPairGenPerfTest {
     @State(Scope.Benchmark)
     public static class KeyPairGenHolder {
 
-        @Param({"SunEC", "KonaCrypto-Native", "KonaCrypto-NativeOneShot"})
+        @Param({"SunEC", "AmazonCorrettoCryptoProvider",
+                "KonaCrypto-Native", "KonaCrypto-NativeOneShot"})
         String provider;
 
         @Param({"secp256r1", "secp384r1", "secp521r1"})
@@ -61,7 +66,12 @@ public class ECKeyPairGenPerfTest {
     }
 
     @Benchmark
-    public KeyPair genKeyPair(KeyPairGenHolder holder) {
-        return holder.keyPairGenerator.generateKeyPair();
+    public BigInteger[] genKeyPair(KeyPairGenHolder holder) {
+        KeyPair keyPair = holder.keyPairGenerator.generateKeyPair();
+        ECPrivateKey privateKey = (ECPrivateKey) keyPair.getPrivate();
+        ECPublicKey publicKey = (ECPublicKey) keyPair.getPublic();
+        ECPoint publicPoint = publicKey.getW();
+        return new BigInteger[]{privateKey.getS(),
+                publicPoint.getAffineX(), publicPoint.getAffineY()};
     }
 }

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/TestUtils.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/TestUtils.java
@@ -19,6 +19,7 @@
 
 package com.tencent.kona.crypto;
 
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import com.tencent.kona.crypto.spec.SM2PrivateKeySpec;
 import com.tencent.kona.crypto.spec.SM2PublicKeySpec;
 
@@ -48,6 +49,7 @@ public class TestUtils {
         Security.addProvider(KonaCryptoProvider.instance());
         Security.addProvider(KonaCryptoNativeProvider.instance());
         Security.addProvider(KonaCryptoNativeOneShotProvider.instance());
+        Security.addProvider(new AmazonCorrettoCryptoProvider());
     }
 
     public static void repeatTaskParallelly(Callable<Void> task, int count)


### PR DESCRIPTION
`ECKeyPairGenPerfTest` covers AWS ACCP.

This PR will resolves #1131.