### PR TITLE
TKSS-1133: Make sure JMH tests use the target providers

### DIFF
--- a/kona-pkix/src/jmh/java/com/tencent/kona/pkix/perf/KeyStorePerfTest.java
+++ b/kona-pkix/src/jmh/java/com/tencent/kona/pkix/perf/KeyStorePerfTest.java
@@ -179,7 +179,7 @@ public class KeyStorePerfTest {
             = new KeyStore.PasswordProtection(PASSWORD);
 
     static {
-        TestUtils.addProviders();
+        TestUtils.insertProvidersAtTop();
     }
 
     @State(Scope.Benchmark)

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
@@ -95,6 +95,11 @@ public class TestUtils {
         Security.addProvider(KonaPKIXProvider.instance());
     }
 
+    public static void insertProvidersAtTop() {
+        Security.insertProviderAt(CryptoInsts.PROV, 1);
+        Security.insertProviderAt(KonaPKIXProvider.instance(), 1);
+    }
+
     public static Path resFilePath(String resource) {
         return TEST_RES_PATH.resolve(resource);
     }

--- a/kona-ssl/src/jmh/java/com/tencent/kona/ssl/perf/KonaSSLTlcpHandshakePerfTest.java
+++ b/kona-ssl/src/jmh/java/com/tencent/kona/ssl/perf/KonaSSLTlcpHandshakePerfTest.java
@@ -67,7 +67,7 @@ public class KonaSSLTlcpHandshakePerfTest {
             = new SmCertTuple(INTCA_CERT, CLIENT_SIGN_CERT, CLIENT_ENC_CERT);
 
     static {
-        TestUtils.addProviders();
+        TestUtils.insertProvidersAtTop();
     }
 
     private SSLContext serverContext;

--- a/kona-ssl/src/jmh/java/com/tencent/kona/ssl/perf/KonaSSLTlsHandshakePerfTest.java
+++ b/kona-ssl/src/jmh/java/com/tencent/kona/ssl/perf/KonaSSLTlsHandshakePerfTest.java
@@ -81,7 +81,7 @@ public class KonaSSLTlsHandshakePerfTest {
         System.setProperty("com.tencent.kona.ssl.namedGroups", "secp256r1");
         System.setProperty("com.tencent.kona.ssl.client.signatureSchemes", "ecdsa_secp256r1_sha256");
 
-        TestUtils.addProviders();
+        TestUtils.insertProvidersAtTop();
     }
 
     private SSLContext serverContext;

--- a/kona-ssl/src/jmh/java/com/tencent/kona/ssl/perf/KonaSSLTlsHandshakeWithSMPerfTest.java
+++ b/kona-ssl/src/jmh/java/com/tencent/kona/ssl/perf/KonaSSLTlsHandshakeWithSMPerfTest.java
@@ -60,7 +60,7 @@ public class KonaSSLTlsHandshakeWithSMPerfTest {
         System.setProperty("com.tencent.kona.ssl.namedGroups", "curvesm2");
         System.setProperty("com.tencent.kona.ssl.client.signatureSchemes", "sm2sig_sm3");
 
-        TestUtils.addProviders();
+        TestUtils.insertProvidersAtTop();
     }
 
     private SSLContext serverContext;

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/TestUtils.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/TestUtils.java
@@ -99,6 +99,12 @@ public class TestUtils {
         Security.addProvider(KonaSSLProvider.instance());
     }
 
+    public static void insertProvidersAtTop() {
+        Security.insertProviderAt(CryptoInsts.PROV, 1);
+        Security.insertProviderAt(KonaPKIXProvider.instance(), 2);
+        Security.insertProviderAt(KonaSSLProvider.instance(), 3);
+    }
+
     public static Path resFilePath(String resource) {
         return TEST_RES_PATH.resolve(resource);
     }


### PR DESCRIPTION
PKIX and SSL JMH tests should move the TKSS providers to the top.

This PR will resolves #1133.