### PR TITLE
TKSS-1138: Compatible OCSP readtimeout property with OCSP timeout

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/OCSP.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/OCSP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,6 @@ public final class OCSP {
     private static final Debug debug = Debug.getInstance("certpath");
 
     private static final int DEFAULT_CONNECT_TIMEOUT = 15000;
-    private static final int DEFAULT_READ_TIMEOUT = 15000;
 
     /**
      * Integer value indicating the timeout length, in milliseconds, to be
@@ -82,7 +81,7 @@ public final class OCSP {
      * zero is interpreted as an infinite timeout.
      */
     private static final int READ_TIMEOUT = initializeTimeout(
-            "com.sun.security.ocsp.readtimeout", DEFAULT_READ_TIMEOUT);
+            "com.sun.security.ocsp.readtimeout", CONNECT_TIMEOUT);
 
     /**
      * Initialize the timeout length by getting the OCSP timeout


### PR DESCRIPTION
This is a backport of [JDK-8347506]: Compatible OCSP readtimeout property with OCSP timeout.

This PR will resolves #1138.

[JDK-8347506]:
https://bugs.openjdk.org/browse/JDK-8347506