### PR TITLE
TKSS-1143: Backport JDK-8346129: Simplify EdDSA & XDH curve name usage

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/KeyUtil.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/KeyUtil.java
@@ -26,17 +26,11 @@
 package com.tencent.kona.sun.security.util;
 
 import java.io.IOException;
-import java.security.AlgorithmParameters;
-import java.security.Key;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.PublicKey;
+import java.security.*;
 import java.security.interfaces.ECKey;
 import java.security.interfaces.RSAKey;
 import java.security.interfaces.DSAKey;
 import java.security.interfaces.DSAParams;
-//import java.security.interfaces.XECKey;
-import java.security.SecureRandom;
 import java.security.spec.KeySpec;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.InvalidParameterSpecException;
@@ -46,7 +40,6 @@ import javax.crypto.interfaces.DHPublicKey;
 import javax.crypto.spec.DHParameterSpec;
 import javax.crypto.spec.DHPublicKeySpec;
 import java.math.BigInteger;
-//import java.security.spec.NamedParameterSpec;
 import java.util.Arrays;
 
 import com.tencent.kona.sun.security.jca.JCAUtil;
@@ -165,6 +158,22 @@ public final class KeyUtil {
         }
 
         return -1;
+    }
+
+    /**
+     * If the key is a sub-algorithm of a larger group of algorithms, this
+     * method will return that sub-algorithm.  For example, key.getAlgorithm()
+     * returns "EdDSA", but the underlying key may be "Ed448".  For
+     * DisabledAlgorithmConstraints (DAC), this distinction is important.
+     * "EdDSA" means all curves for DAC, but when using it with
+     * KeyPairGenerator, "EdDSA" means "Ed25519".
+     */
+    public static String getAlgorithm(Key key) {
+        if (key instanceof ECKey || key instanceof RSAKey) {
+            return key.getAlgorithm();
+        }
+
+        throw new ProviderException("Unsupported key type: " + key.getAlgorithm());
     }
 
     /**

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/AlgorithmChecker.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/AlgorithmChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -223,7 +223,8 @@ public final class AlgorithmChecker extends PKIXCertPathChecker {
                 CertPathConstraintsParameters cp =
                         new CertPathConstraintsParameters(trustedPubKey, variant,
                                 anchor, date);
-                dac.permits(trustedPubKey.getAlgorithm(), cp, true);
+                dac.permits(KeyUtil.getAlgorithm(trustedPubKey),
+                        cp, true);
             }
             // Check the signature algorithm and parameters against constraints
             CertPathConstraintsParameters cp =


### PR DESCRIPTION
This is a backport of [JDK-8346129]: Simplify EdDSA & XDH curve name usage.

This PR will resolves #1143.

[JDK-8346129]:
https://bugs.openjdk.org/browse/JDK-8346129