### PR TITLE
TKSS-1145: Backport JDK-8351366: Remove the java.security.debug=scl option

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/Debug.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/Debug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,7 +109,6 @@ public class Debug {
         System.err.println("pkcs12        PKCS12 KeyStore debugging");
         System.err.println("properties    Security property and configuration file debugging");
         System.err.println("sunpkcs11     SunPKCS11 provider debugging");
-        System.err.println("scl           permissions SecureClassLoader assigns");
         System.err.println("securerandom  SecureRandom");
         System.err.println("ts            timestamping");
         System.err.println();


### PR DESCRIPTION
This is a backport of [JDK-8351366]: Remove the java.security.debug=scl option.

This PR will resolves #1145.

[JDK-8351366]:
https://bugs.openjdk.org/browse/JDK-8351366