### PR TITLE
TKSS-1146: Backport JDK-8349890: option -Djava.security.debug=x509,ava breaks special chars

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AVA.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/AVA.java
@@ -655,7 +655,7 @@ public class AVA implements DerEncoder {
      */
     public String toString() {
         return toKeywordValueString
-                (toKeyword(DEFAULT, Collections.emptyMap()));
+                (toKeyword(DEFAULT, Collections.emptyMap()), true);
     }
 
     /**
@@ -674,7 +674,7 @@ public class AVA implements DerEncoder {
      * OID/keyword map.
      */
     public String toRFC1779String(Map<String, String> oidMap) {
-        return toKeywordValueString(toKeyword(RFC1779, oidMap));
+        return toKeywordValueString(toKeyword(RFC1779, oidMap), false);
     }
 
     /**
@@ -773,12 +773,6 @@ public class AVA implements DerEncoder {
                     // escape null character
                     sbuffer.append("\\00");
 
-                } else if (debug != null && Debug.isOn("ava")) {
-
-                    // embed non-printable/non-escaped char
-                    // as escaped hex pairs for debugging
-                    byte[] valueBytes = Character.toString(c).getBytes(UTF_8);
-                    HexFormat.of().withPrefix("\\").withUpperCase().formatHex(sbuffer, valueBytes);
                 } else {
 
                     // append non-printable/non-escaped char
@@ -903,14 +897,6 @@ public class AVA implements DerEncoder {
                         }
                     }
 
-                } else if (debug != null && Debug.isOn("ava")) {
-
-                    // embed non-printable/non-escaped char
-                    // as escaped hex pairs for debugging
-
-                    previousWhite = false;
-                    byte[] valueBytes = Character.toString(c).getBytes(UTF_8);
-                    HexFormat.of().withPrefix("\\").withUpperCase().formatHex(sbuffer, valueBytes);
                 } else {
 
                     // append non-printable/non-escaped char
@@ -960,7 +946,7 @@ public class AVA implements DerEncoder {
         return AVAKeyword.hasKeyword(oid, RFC2253);
     }
 
-    private String toKeywordValueString(String keyword) {
+    private String toKeywordValueString(String keyword, Boolean isFromToString) {
         /*
          * Construct the value with as little copying and garbage
          * production as practical.  First the keyword (mandatory),
@@ -1034,7 +1020,7 @@ public class AVA implements DerEncoder {
 
                         sbuffer.append(c);
 
-                    } else if (debug != null && Debug.isOn("ava")) {
+                    } else if (debug != null && isFromToString && Debug.isOn("ava")) {
 
                         // embed non-printable/non-escaped char
                         // as escaped hex pairs for debugging


### PR DESCRIPTION
This is a backport of [JDK-8349890]: option -Djava.security.debug=x509,ava breaks special chars.

This PR will resolves #1146.

[JDK-8349890]:
https://bugs.openjdk.org/browse/JDK-8349890