### PR TITLE
TKSS-1144: Backport JDK-8349583: Add mechanism to disable signature schemes based on their TLS scope

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/DisabledAlgorithmConstraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,6 +180,12 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
         }
 
         return true;
+    }
+
+    // Checks if algorithm is disabled for the given TLS scopes.
+    public boolean permits(String algorithm, Set<SSLScope> scopes) {
+        List<Constraint> list = algorithmConstraints.getConstraints(algorithm);
+        return list == null || list.stream().allMatch(c -> c.permits(scopes));
     }
 
     /*
@@ -432,7 +438,7 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
                         denyAfterLimit = true;
                     } else if (entry.startsWith("usage")) {
                         String[] s = (entry.substring(5)).trim().split(" ");
-                        c = new UsageConstraint(algorithm, s);
+                        c = new UsageConstraint(algorithm, s, propertyName);
                         if (debug != null) {
                             debug.println("Constraints usage length is " + s.length);
                         }
@@ -600,6 +606,17 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
          *         'false' otherwise.
          */
         public boolean permits(AlgorithmParameters parameters) {
+            return true;
+        }
+
+        /**
+         * Check if the algorithm constraint permits the given TLS scopes.
+         *
+         * @param scopes TLS scopes
+         * @return 'true' if TLS scopes are allowed,
+         *         'false' otherwise.
+         */
+        public boolean permits(Set<SSLScope> scopes) {
             return true;
         }
 
@@ -780,14 +797,49 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
 
     /*
      * The usage constraint is for the "usage" keyword.  It checks against the
-     * variant value in ConstraintsParameters.
+     * variant value in ConstraintsParameters and against TLS scopes.
      */
     private static class UsageConstraint extends Constraint {
         String[] usages;
+        Set<SSLScope> scopes;
 
-        UsageConstraint(String algorithm, String[] usages) {
+        UsageConstraint(
+                String algorithm, String[] usages, String propertyName) {
             this.algorithm = algorithm;
-            this.usages = usages;
+
+            // Support TLS scopes only for jdk.tls.disabledAlgorithms property.
+            if (PROPERTY_TLS_DISABLED_ALGS.equals(propertyName)) {
+                for (String usage : usages) {
+                    SSLScope scope = SSLScope.nameOf(usage);
+
+                    if (scope != null) {
+                        if (this.scopes == null) {
+                            this.scopes = new HashSet<>(usages.length);
+                        }
+                        this.scopes.add(scope);
+                    } else {
+                        this.usages = usages;
+                    }
+                }
+
+                if (this.scopes != null && this.usages != null) {
+                    throw new IllegalArgumentException(
+                            "Can't mix TLS protocol specific constraints"
+                                    + " with other usage constraints");
+                }
+
+            } else {
+                this.usages = usages;
+            }
+        }
+
+        @Override
+        public boolean permits(Set<SSLScope> scopes) {
+            if (this.scopes == null || scopes == null) {
+                return true;
+            }
+
+            return Collections.disjoint(this.scopes, scopes);
         }
 
         @Override

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/SSLScope.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/SSLScope.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.tencent.kona.sun.security.util;
+
+/*
+ * Scopes defining different parts of TLS protocol.
+ */
+
+public enum SSLScope {
+    // Handshake signature scope as in signature_algorithms extension.
+    HANDSHAKE_SIGNATURE("HandshakeSignature"),
+
+    // Certificate signature scope as in signature_algorithms_cert extension.
+    CERTIFICATE_SIGNATURE("CertificateSignature");
+
+    private final String name;
+
+    SSLScope(String name) {
+        this.name = name;
+    }
+
+    // Note: the SSLScope name is case-insensitive.
+    public static SSLScope nameOf(String scopeName) {
+        for (SSLScope scope : SSLScope.values()) {
+            if (scope.name.equalsIgnoreCase(scopeName)) {
+                return scope;
+            }
+        }
+
+        return null;
+    }
+}

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/HandshakeContext.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/HandshakeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ abstract class HandshakeContext implements ConnectionContext {
     // consolidated parameters
     final List<ProtocolVersion>             activeProtocols;
     final List<CipherSuite>                 activeCipherSuites;
-    final AlgorithmConstraints              algorithmConstraints;
+    final SSLAlgorithmConstraints           algorithmConstraints;
     final ProtocolVersion                   maximumActiveProtocol;
 
     // output stream
@@ -136,6 +136,7 @@ abstract class HandshakeContext implements ConnectionContext {
 
     // SignatureScheme
     List<SignatureScheme>                   localSupportedSignAlgs;
+    List<SignatureScheme>                   localSupportedCertSignAlgs;
     List<SignatureScheme>                   peerRequestedSignatureSchemes;
     List<SignatureScheme>                   peerRequestedCertSignSchemes;
 

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/PostHandshakeContext.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/PostHandshakeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ final class PostHandshakeContext extends HandshakeContext {
                 "Post-handshake not supported in " + negotiatedProtocol.name);
         }
 
-        this.localSupportedSignAlgs = new ArrayList<>(
+        this.localSupportedCertSignAlgs = new ArrayList<>(
             context.conSession.getLocalSupportedSignatureSchemes());
 
         // Add the potential post-handshake consumers.

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLAlgorithmConstraints.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLAlgorithmConstraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,8 @@ import java.security.Key;
 import java.util.Set;
 import javax.net.ssl.*;
 import com.tencent.kona.sun.security.util.DisabledAlgorithmConstraints;
+import com.tencent.kona.sun.security.util.SSLScope;
+
 import static com.tencent.kona.sun.security.util.DisabledAlgorithmConstraints.*;
 
 /**
@@ -42,11 +44,11 @@ import static com.tencent.kona.sun.security.util.DisabledAlgorithmConstraints.*;
  */
 final class SSLAlgorithmConstraints implements AlgorithmConstraints {
 
-    private static final AlgorithmConstraints tlsDisabledAlgConstraints =
+    private static final DisabledAlgorithmConstraints tlsDisabledAlgConstraints =
             new DisabledAlgorithmConstraints(PROPERTY_TLS_DISABLED_ALGS,
                     new SSLAlgorithmDecomposer());
 
-    private static final AlgorithmConstraints x509DisabledAlgConstraints =
+    private static final DisabledAlgorithmConstraints x509DisabledAlgConstraints =
             new DisabledAlgorithmConstraints(PROPERTY_CERTPATH_DISABLED_ALGS,
                     new SSLAlgorithmDecomposer(true));
 
@@ -56,11 +58,11 @@ final class SSLAlgorithmConstraints implements AlgorithmConstraints {
     private final boolean enabledX509DisabledAlgConstraints;
 
     // the default algorithm constraints
-    static final AlgorithmConstraints DEFAULT =
+    static final SSLAlgorithmConstraints DEFAULT =
                         new SSLAlgorithmConstraints(null, true);
 
     // the default SSL only algorithm constraints
-    static final AlgorithmConstraints DEFAULT_SSL_ONLY =
+    static final SSLAlgorithmConstraints DEFAULT_SSL_ONLY =
                         new SSLAlgorithmConstraints(null, false);
 
     private SSLAlgorithmConstraints(AlgorithmConstraints userSpecifiedConstraints,
@@ -84,11 +86,11 @@ final class SSLAlgorithmConstraints implements AlgorithmConstraints {
      * @param userSpecifiedConstraints additional constraints to check
      * @return a SSLAlgorithmConstraints instance
      */
-    static AlgorithmConstraints wrap(AlgorithmConstraints userSpecifiedConstraints) {
+    static SSLAlgorithmConstraints wrap(AlgorithmConstraints userSpecifiedConstraints) {
         return wrap(userSpecifiedConstraints, true);
     }
 
-    private static AlgorithmConstraints wrap(
+    private static SSLAlgorithmConstraints wrap(
             AlgorithmConstraints userSpecifiedConstraints,
             boolean withDefaultCertPathConstraints) {
         if (nullIfDefault(userSpecifiedConstraints) == null) {
@@ -199,22 +201,22 @@ final class SSLAlgorithmConstraints implements AlgorithmConstraints {
 
         if (peerSpecifiedConstraints != null) {
             permitted = peerSpecifiedConstraints.permits(
-                                    primitives, algorithm, parameters);
+                    primitives, algorithm, parameters);
         }
 
         if (permitted && userSpecifiedConstraints != null) {
             permitted = userSpecifiedConstraints.permits(
-                                    primitives, algorithm, parameters);
+                    primitives, algorithm, parameters);
         }
 
         if (permitted) {
             permitted = tlsDisabledAlgConstraints.permits(
-                                    primitives, algorithm, parameters);
+                    primitives, algorithm, parameters);
         }
 
         if (permitted && enabledX509DisabledAlgConstraints) {
             permitted = x509DisabledAlgConstraints.permits(
-                                    primitives, algorithm, parameters);
+                    primitives, algorithm, parameters);
         }
 
         return permitted;
@@ -252,27 +254,31 @@ final class SSLAlgorithmConstraints implements AlgorithmConstraints {
 
         if (peerSpecifiedConstraints != null) {
             permitted = peerSpecifiedConstraints.permits(
-                                    primitives, algorithm, key, parameters);
+                    primitives, algorithm, key, parameters);
         }
 
         if (permitted && userSpecifiedConstraints != null) {
             permitted = userSpecifiedConstraints.permits(
-                                    primitives, algorithm, key, parameters);
+                    primitives, algorithm, key, parameters);
         }
 
         if (permitted) {
             permitted = tlsDisabledAlgConstraints.permits(
-                                    primitives, algorithm, key, parameters);
+                    primitives, algorithm, key, parameters);
         }
 
         if (permitted && enabledX509DisabledAlgConstraints) {
             permitted = x509DisabledAlgConstraints.permits(
-                                    primitives, algorithm, key, parameters);
+                    primitives, algorithm, key, parameters);
         }
 
         return permitted;
     }
 
+    // Checks if algorithm is disabled for the given TLS scopes.
+    boolean permits(String algorithm, Set<SSLScope> scopes) {
+        return tlsDisabledAlgConstraints.permits(algorithm, scopes);
+    }
 
     private static class SupportedSignatureAlgorithmConstraints
                                     implements AlgorithmConstraints {

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLSessionImpl.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLSessionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -196,10 +196,10 @@ final class SSLSessionImpl extends ExtendedSSLSession {
         this.sessionId = id;
         this.host = hc.conContext.transport.getPeerHost();
         this.port = hc.conContext.transport.getPeerPort();
-        this.localSupportedSignAlgs = hc.localSupportedSignAlgs == null ?
+        this.localSupportedSignAlgs = hc.localSupportedCertSignAlgs == null ?
                 Collections.emptySet() :
                 Collections.unmodifiableCollection(
-                        new ArrayList<>(hc.localSupportedSignAlgs));
+                        new ArrayList<>(hc.localSupportedCertSignAlgs));
         this.serverNameIndication = hc.negotiatedServerName;
         this.requestedServerNames = Collections.unmodifiableList(
                 new ArrayList<>(hc.getRequestedServerNames()));

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ServerHello.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ServerHello.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,9 @@ import com.tencent.kona.sun.security.ssl.SSLCipher.SSLReadCipher;
 import com.tencent.kona.sun.security.ssl.SSLCipher.SSLWriteCipher;
 import com.tencent.kona.sun.security.ssl.SSLHandshake.HandshakeMessage;
 import com.tencent.kona.sun.security.ssl.SupportedVersionsExtension.SHSupportedVersionsSpec;
+
+import static com.tencent.kona.sun.security.ssl.SignatureScheme.CERTIFICATE_SCOPE;
+import static com.tencent.kona.sun.security.ssl.SignatureScheme.HANDSHAKE_SCOPE;
 
 /**
  * Pack of the ServerHello/HelloRetryRequest handshake message.
@@ -278,9 +281,18 @@ final class ServerHello {
 
                 if (shc.localSupportedSignAlgs == null) {
                     shc.localSupportedSignAlgs =
-                        SignatureScheme.getSupportedAlgorithms(
-                                shc.sslConfig,
-                                shc.algorithmConstraints, shc.activeProtocols);
+                            SignatureScheme.getSupportedAlgorithms(
+                                    shc.sslConfig,
+                                    shc.algorithmConstraints, shc.activeProtocols,
+                                    HANDSHAKE_SCOPE);
+                }
+
+                if (shc.localSupportedCertSignAlgs == null) {
+                    shc.localSupportedCertSignAlgs =
+                            SignatureScheme.getSupportedAlgorithms(
+                                    shc.sslConfig,
+                                    shc.algorithmConstraints, shc.activeProtocols,
+                                    CERTIFICATE_SCOPE);
                 }
 
                 SSLSessionImpl session =
@@ -521,9 +533,18 @@ final class ServerHello {
 
                 if (shc.localSupportedSignAlgs == null) {
                     shc.localSupportedSignAlgs =
-                        SignatureScheme.getSupportedAlgorithms(
-                                shc.sslConfig,
-                                shc.algorithmConstraints, shc.activeProtocols);
+                            SignatureScheme.getSupportedAlgorithms(
+                                    shc.sslConfig,
+                                    shc.algorithmConstraints, shc.activeProtocols,
+                                    HANDSHAKE_SCOPE);
+                }
+
+                if (shc.localSupportedCertSignAlgs == null) {
+                    shc.localSupportedCertSignAlgs =
+                            SignatureScheme.getSupportedAlgorithms(
+                                    shc.sslConfig,
+                                    shc.algorithmConstraints, shc.activeProtocols,
+                                    CERTIFICATE_SCOPE);
                 }
 
                 SSLSessionImpl session =

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SessionTicketExtension.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SessionTicketExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,8 @@ import com.tencent.kona.sun.security.ssl.SSLExtension.ExtensionConsumer;
 import com.tencent.kona.sun.security.ssl.SSLExtension.SSLExtensionSpec;
 import com.tencent.kona.sun.security.ssl.SSLHandshake.HandshakeMessage;
 import com.tencent.kona.sun.security.util.HexDumpEncoder;
+
+import static com.tencent.kona.sun.security.ssl.SignatureScheme.CERTIFICATE_SCOPE;
 
 /**
  * SessionTicketExtension is an implementation of RFC 5077 with some internals
@@ -352,11 +354,12 @@ final class SessionTicketExtension {
                 return new SessionTicketSpec().getEncoded();
             }
 
-            if (chc.localSupportedSignAlgs == null) {
-                chc.localSupportedSignAlgs =
+            if (chc.localSupportedCertSignAlgs == null) {
+                chc.localSupportedCertSignAlgs =
                         SignatureScheme.getSupportedAlgorithms(
                                 chc.sslConfig,
-                                chc.algorithmConstraints, chc.activeProtocols);
+                                chc.algorithmConstraints, chc.activeProtocols,
+                                CERTIFICATE_SCOPE);
             }
 
             return chc.resumingSession.getPskIdentity();

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SignatureAlgorithmsExtension.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SignatureAlgorithmsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.text.MessageFormat;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import javax.net.ssl.SSLProtocolException;
@@ -36,6 +37,8 @@ import javax.net.ssl.SSLProtocolException;
 import com.tencent.kona.sun.security.ssl.SSLExtension.ExtensionConsumer;
 import com.tencent.kona.sun.security.ssl.SSLExtension.SSLExtensionSpec;
 import com.tencent.kona.sun.security.ssl.SSLHandshake.HandshakeMessage;
+
+import static com.tencent.kona.sun.security.ssl.SignatureScheme.HANDSHAKE_SCOPE;
 
 /**
  * Pack of the "signature_algorithms" extensions [RFC 5246].
@@ -190,7 +193,8 @@ final class SignatureAlgorithmsExtension {
                 chc.localSupportedSignAlgs =
                     SignatureScheme.getSupportedAlgorithms(
                             chc.sslConfig,
-                            chc.algorithmConstraints, chc.activeProtocols);
+                            chc.algorithmConstraints, chc.activeProtocols,
+                            HANDSHAKE_SCOPE);
             }
 
             int vectorLen = SignatureScheme.sizeInRecord() *
@@ -279,7 +283,8 @@ final class SignatureAlgorithmsExtension {
                     SignatureScheme.getSupportedAlgorithms(
                             shc.sslConfig,
                             shc.algorithmConstraints, shc.negotiatedProtocol,
-                            spec.signatureSchemes);
+                            spec.signatureSchemes,
+                            HANDSHAKE_SCOPE);
             if (sss == null || sss.isEmpty()) {
                 throw shc.conContext.fatal(Alert.HANDSHAKE_FAILURE,
                         "No supported signature algorithm");
@@ -417,7 +422,8 @@ final class SignatureAlgorithmsExtension {
                     SignatureScheme.getSupportedAlgorithms(
                             shc.sslConfig,
                             shc.algorithmConstraints,
-                            Arrays.asList(shc.negotiatedProtocol));
+                            Collections.singletonList(shc.negotiatedProtocol),
+                            HANDSHAKE_SCOPE);
 
             int vectorLen = SignatureScheme.sizeInRecord() * sigAlgs.size();
             byte[] extData = new byte[vectorLen + 2];
@@ -507,7 +513,8 @@ final class SignatureAlgorithmsExtension {
                     SignatureScheme.getSupportedAlgorithms(
                             chc.sslConfig,
                             chc.algorithmConstraints, chc.negotiatedProtocol,
-                            spec.signatureSchemes);
+                            spec.signatureSchemes,
+                            HANDSHAKE_SCOPE);
             if (sss == null || sss.isEmpty()) {
                 throw chc.conContext.fatal(Alert.HANDSHAKE_FAILURE,
                         "No supported signature algorithm");

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SignatureScheme.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SignatureScheme.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +46,7 @@ import com.tencent.kona.crypto.spec.SM2SignatureParameterSpec;
 import com.tencent.kona.sun.security.ssl.NamedGroup.NamedGroupSpec;
 import com.tencent.kona.sun.security.ssl.X509Authentication.X509Possession;
 import com.tencent.kona.sun.security.util.KeyUtil;
+import com.tencent.kona.sun.security.util.SSLScope;
 import com.tencent.kona.sun.security.util.SignatureUtil;
 
 enum SignatureScheme {
@@ -231,8 +231,17 @@ enum SignatureScheme {
     }
 
     // performance optimization
+    // Handshake signature scope.
+    static final Set<SSLScope> HANDSHAKE_SCOPE =
+            Collections.singleton(SSLScope.HANDSHAKE_SIGNATURE);
+
+    // Certificate signature scope.
+    static final Set<SSLScope> CERTIFICATE_SCOPE =
+            Collections.singleton(SSLScope.CERTIFICATE_SIGNATURE);
+
+    // Non-TLS specific SIGNATURE CryptoPrimitive.
     private static final Set<CryptoPrimitive> SIGNATURE_PRIMITIVE_SET =
-        Collections.unmodifiableSet(EnumSet.of(CryptoPrimitive.SIGNATURE));
+            Collections.singleton(CryptoPrimitive.SIGNATURE);
 
     // This ID, exactly TLSv1.3+GM+Cipher+Suite, is defined by RFC 8998.
     // It is only used by signature scheme sm2sig_sm3 for TLS 1.3 handshaking.
@@ -373,24 +382,25 @@ enum SignatureScheme {
         return 2;
     }
 
-    private boolean isPermitted(AlgorithmConstraints constraints) {
-        return constraints.permits(SIGNATURE_PRIMITIVE_SET,
-                        this.name, null) &&
-               constraints.permits(SIGNATURE_PRIMITIVE_SET,
-                        this.keyAlgorithm, null) &&
-               constraints.permits(SIGNATURE_PRIMITIVE_SET,
-                        this.algorithm, (signAlgParams != null ?
-                                signAlgParams.parameters : null)) &&
-                        (namedGroup == null ||
-                            namedGroup.isPermitted(constraints));
+    private boolean isPermitted(
+            SSLAlgorithmConstraints constraints, Set<SSLScope> scopes) {
+        return constraints.permits(this.name, scopes)
+                && constraints.permits(this.keyAlgorithm, scopes)
+                && constraints.permits(this.algorithm, scopes)
+                && constraints.permits(SIGNATURE_PRIMITIVE_SET, this.name, null)
+                && constraints.permits(SIGNATURE_PRIMITIVE_SET, this.keyAlgorithm, null)
+                && constraints.permits(SIGNATURE_PRIMITIVE_SET, this.algorithm,
+                (signAlgParams != null ? signAlgParams.parameters : null))
+                && (namedGroup == null || namedGroup.isPermitted(constraints));
     }
 
     // Get local supported algorithm collection complying to algorithm
-    // constraints.
+    // constraints and SSL scopes.
     static List<SignatureScheme> getSupportedAlgorithms(
             SSLConfiguration config,
-            AlgorithmConstraints constraints,
-            List<ProtocolVersion> activeProtocols) {
+            SSLAlgorithmConstraints constraints,
+            List<ProtocolVersion> activeProtocols,
+            Set<SSLScope> scopes) {
         List<SignatureScheme> supported = new LinkedList<>();
 
         List<SignatureScheme> schemesToCheck =
@@ -410,14 +420,14 @@ enum SignatureScheme {
 
             boolean isMatch = false;
             for (ProtocolVersion pv : activeProtocols) {
-                if (ss.supportedProtocols.contains(pv)) {
+                if (ss.isSupportedProtocol(pv, scopes)) {
                     isMatch = true;
                     break;
                 }
             }
 
             if (isMatch) {
-                if (ss.isPermitted(constraints)) {
+                if (ss.isPermitted(constraints, scopes)) {
                     supported.add(ss);
                 } else if (SSLLogger.isOn &&
                         SSLLogger.isOn("ssl,handshake,verbose")) {
@@ -436,8 +446,10 @@ enum SignatureScheme {
 
     static List<SignatureScheme> getSupportedAlgorithms(
             SSLConfiguration config,
-            AlgorithmConstraints constraints,
-            ProtocolVersion protocolVersion, int[] algorithmIds) {
+            SSLAlgorithmConstraints constraints,
+            ProtocolVersion protocolVersion,
+            int[] algorithmIds,
+            Set<SSLScope> scopes) {
         List<SignatureScheme> supported = new LinkedList<>();
         for (int ssid : algorithmIds) {
             SignatureScheme ss = SignatureScheme.valueOf(ssid);
@@ -447,13 +459,11 @@ enum SignatureScheme {
                             "Unsupported signature scheme: " +
                             SignatureScheme.nameOf(ssid));
                 }
-            } else if (ss.isAvailable &&
-                    ss.supportedProtocols.contains(protocolVersion) &&
-                    (config.signatureSchemes == null ||
-                            Utilities.contains(config.signatureSchemes, ss.name)) &&
-                    ss.isPermitted(constraints)) {
+            } else if ((config.signatureSchemes == null
+                        || Utilities.contains(config.signatureSchemes, ss.name))
+                    && ss.isAllowed(constraints, protocolVersion, scopes)) {
                 supported.add(ss);
-            } else {
+            }else {
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
                     SSLLogger.warning(
                             "Unsupported signature scheme: " + ss.name);
@@ -465,16 +475,14 @@ enum SignatureScheme {
     }
 
     static SignatureScheme getPreferableAlgorithm(
-            AlgorithmConstraints constraints,
+            SSLAlgorithmConstraints constraints,
             List<SignatureScheme> schemes,
             String keyAlgorithm,
             ProtocolVersion version) {
 
         for (SignatureScheme ss : schemes) {
-            if (ss.isAvailable &&
-                    ss.handshakeSupportedProtocols.contains(version) &&
-                    keyAlgorithm.equalsIgnoreCase(ss.keyAlgorithm) &&
-                    ss.isPermitted(constraints)) {
+            if (keyAlgorithm.equalsIgnoreCase(ss.keyAlgorithm)
+                    && ss.isAllowed(constraints, version, HANDSHAKE_SCOPE)) {
                 return ss;
             }
         }
@@ -484,7 +492,7 @@ enum SignatureScheme {
 
     static Map.Entry<SignatureScheme, Signature> getSignerOfPreferableAlgorithm(
             SSLConfiguration sslConfig,
-            AlgorithmConstraints constraints,
+            SSLAlgorithmConstraints constraints,
             List<SignatureScheme> schemes,
             X509Possession x509Possession,
             ProtocolVersion version) {
@@ -498,7 +506,7 @@ enum SignatureScheme {
 
     static Map.Entry<SignatureScheme, Signature> getSignerOfPreferableAlgorithm(
             SSLConfiguration sslConfig,
-            AlgorithmConstraints constraints,
+            SSLAlgorithmConstraints constraints,
             List<SignatureScheme> schemes,
             PrivateKey signingKey,
             PublicKey publicKey,
@@ -517,10 +525,9 @@ enum SignatureScheme {
             keySize = Integer.MAX_VALUE;
         }
         for (SignatureScheme ss : schemes) {
-            if (ss.isAvailable && (keySize >= ss.minimalKeySize) &&
-                    ss.handshakeSupportedProtocols.contains(version) &&
+            if (keySize >= ss.minimalKeySize &&
                     keyAlgorithm.equalsIgnoreCase(ss.keyAlgorithm) &&
-                    ss.isPermitted(constraints)) {
+                    ss.isAllowed(constraints, version, HANDSHAKE_SCOPE)) {
                 if ((ss.namedGroup != null) && (ss.namedGroup.spec ==
                         NamedGroupSpec.NAMED_GROUP_ECDHE)) {
                     if (namedGroup == ss.namedGroup) {
@@ -574,6 +581,26 @@ enum SignatureScheme {
         }
 
         return null;
+    }
+
+    // Returns true if this signature scheme is supported for the given
+    // protocol version and SSL scopes.
+    private boolean isSupportedProtocol(
+            ProtocolVersion version, Set<SSLScope> scopes) {
+        if (scopes != null && scopes.equals(HANDSHAKE_SCOPE)) {
+            return this.handshakeSupportedProtocols.contains(version);
+        } else {
+            return this.supportedProtocols.contains(version);
+        }
+    }
+
+    // Returns true if this signature scheme is available, supported and
+    // permitted for the given constraints, protocol version and SSL scopes.
+    private boolean isAllowed(SSLAlgorithmConstraints constraints,
+                              ProtocolVersion version, Set<SSLScope> scopes) {
+        return isAvailable
+                && isSupportedProtocol(version, scopes)
+                && isPermitted(constraints, scopes);
     }
 
     static String[] getAlgorithmNames(Collection<SignatureScheme> schemes) {

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/Utilities.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/Utilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify
@@ -21,7 +21,6 @@
 package com.tencent.kona.sun.security.ssl;
 
 import javax.net.ssl.SSLParameters;
-import java.nio.charset.StandardCharsets;
 
 public class Utilities extends com.tencent.kona.sun.security.util.Utilities {
 


### PR DESCRIPTION
This is a backport of [JDK-8349583]: Add mechanism to disable signature schemes based on their TLS scope.

This PR will resolves #1144.

[JDK-8349583]:
https://bugs.openjdk.org/browse/JDK-8349583