### PR TITLE
TKSS-1168: Backport JDK-8350807: Certificates using MD5 algorithm that are disabled by default are incorrectly allowed in TLSv1.3 when re-enabled

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertSignAlgsExtension.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertSignAlgsExtension.java
@@ -101,13 +101,7 @@ final class CertSignAlgsExtension {
             }
 
             // Produce the extension.
-            if (chc.localSupportedCertSignAlgs == null) {
-                chc.localSupportedCertSignAlgs =
-                        SignatureScheme.getSupportedAlgorithms(
-                                chc.sslConfig,
-                                chc.algorithmConstraints, chc.activeProtocols,
-                                CERTIFICATE_SCOPE);
-            }
+            SignatureScheme.updateHandshakeLocalSupportedAlgs(chc);
 
             int vectorLen = SignatureScheme.sizeInRecord() *
                     chc.localSupportedCertSignAlgs.size();
@@ -246,15 +240,8 @@ final class CertSignAlgsExtension {
             }
 
             // Produce the extension.
-            if (shc.localSupportedCertSignAlgs == null) {
-                shc.localSupportedCertSignAlgs =
-                        SignatureScheme.getSupportedAlgorithms(
-                                shc.sslConfig,
-                                shc.algorithmConstraints,
-                                Collections.singletonList(shc.negotiatedProtocol),
-                                CERTIFICATE_SCOPE);
-            }
-
+            // localSupportedCertSignAlgs has been already updated when we set
+            // the negotiated protocol.
             int vectorLen = SignatureScheme.sizeInRecord()
                     * shc.localSupportedCertSignAlgs.size();
             byte[] extData = new byte[vectorLen + 2];

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateMessage.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -703,49 +703,6 @@ final class CertificateMessage {
                 throw shc.conContext.fatal(Alert.CERTIFICATE_UNKNOWN, ce);
             }
         }
-
-        /**
-         * When a failure happens during certificate checking from an
-         * {@link X509TrustManager}, determine what TLS alert description
-         * to use.
-         *
-         * @param cexc The exception thrown by the {@link X509TrustManager}
-         *
-         * @return A byte value corresponding to a TLS alert description number.
-         */
-        private static Alert getCertificateAlert(
-                ClientHandshakeContext chc, CertificateException cexc) {
-            // The specific reason for the failure will determine how to
-            // set the alert description value
-            Alert alert = Alert.CERTIFICATE_UNKNOWN;
-
-            Throwable baseCause = cexc.getCause();
-            if (baseCause instanceof CertPathValidatorException) {
-                CertPathValidatorException cpve =
-                        (CertPathValidatorException)baseCause;
-                Reason reason = cpve.getReason();
-                if (reason == BasicReason.REVOKED) {
-                    alert = chc.staplingActive ?
-                            Alert.BAD_CERT_STATUS_RESPONSE :
-                            Alert.CERTIFICATE_REVOKED;
-                } else if (
-                        reason == BasicReason.UNDETERMINED_REVOCATION_STATUS) {
-                    alert = chc.staplingActive ?
-                            Alert.BAD_CERT_STATUS_RESPONSE :
-                            Alert.CERTIFICATE_UNKNOWN;
-                } else if (reason == BasicReason.ALGORITHM_CONSTRAINED) {
-                    alert = Alert.UNSUPPORTED_CERTIFICATE;
-                } else if (reason == BasicReason.EXPIRED) {
-                    alert = Alert.CERTIFICATE_EXPIRED;
-                } else if (reason == BasicReason.INVALID_SIGNATURE ||
-                        reason == BasicReason.NOT_YET_VALID) {
-                    alert = Alert.BAD_CERTIFICATE;
-                }
-            }
-
-            return alert;
-        }
-
     }
 
     /**
@@ -1336,40 +1293,59 @@ final class CertificateMessage {
 
             return certs;
         }
+    }
 
-        /**
-         * When a failure happens during certificate checking from an
-         * {@link X509TrustManager}, determine what TLS alert description
-         * to use.
-         *
-         * @param cexc The exception thrown by the {@link X509TrustManager}
-         *
-         * @return A byte value corresponding to a TLS alert description number.
-         */
-        private static Alert getCertificateAlert(
-                ClientHandshakeContext chc, CertificateException cexc) {
-            // The specific reason for the failure will determine how to
-            // set the alert description value
-            Alert alert = Alert.CERTIFICATE_UNKNOWN;
+    /**Add commentMore actions
+     * When a failure happens during certificate checking from an
+     * {@link X509TrustManager}, determine what TLS alert description
+     * to use.
+     *
+     * @param cexc The exception thrown by the {@link X509TrustManager}
+     * @return A byte value corresponding to a TLS alert description number.
+     */
+    private static Alert getCertificateAlert(
+            ClientHandshakeContext chc, CertificateException cexc) {
+        // The specific reason for the failure will determine how to
+        // set the alert description value
+        Alert alert = Alert.CERTIFICATE_UNKNOWN;
 
-            Throwable baseCause = cexc.getCause();
-            if (baseCause instanceof CertPathValidatorException) {
-                CertPathValidatorException cpve =
-                        (CertPathValidatorException)baseCause;
-                Reason reason = cpve.getReason();
-                if (reason == BasicReason.REVOKED) {
-                    alert = chc.staplingActive ?
-                            Alert.BAD_CERT_STATUS_RESPONSE :
-                            Alert.CERTIFICATE_REVOKED;
-                } else if (
-                        reason == BasicReason.UNDETERMINED_REVOCATION_STATUS) {
-                    alert = chc.staplingActive ?
-                            Alert.BAD_CERT_STATUS_RESPONSE :
-                            Alert.CERTIFICATE_UNKNOWN;
+        Throwable baseCause = cexc.getCause();
+        if (baseCause instanceof CertPathValidatorException) {
+            CertPathValidatorException cpve = (CertPathValidatorException) baseCause;
+            Reason reason = cpve.getReason();
+            if (reason == BasicReason.REVOKED) {
+                alert = chc.staplingActive ?
+                        Alert.BAD_CERT_STATUS_RESPONSE :
+                        Alert.CERTIFICATE_REVOKED;
+            } else if (reason == BasicReason.UNDETERMINED_REVOCATION_STATUS) {
+                alert = chc.staplingActive ?
+                        Alert.BAD_CERT_STATUS_RESPONSE :
+                        Alert.CERTIFICATE_UNKNOWN;
+            } else if (reason == BasicReason.EXPIRED) {
+                alert = Alert.CERTIFICATE_EXPIRED;
+            } else if (reason == BasicReason.INVALID_SIGNATURE
+                    || reason == BasicReason.NOT_YET_VALID) {
+                alert = Alert.BAD_CERTIFICATE;
+            } else if (reason == BasicReason.ALGORITHM_CONSTRAINED) {
+                alert = Alert.UNSUPPORTED_CERTIFICATE;
+
+                // Per TLSv1.3 RFC we MUST abort the handshake with a
+                // "bad_certificate" alert if we reject certificate
+                // because of the signature using MD5 or SHA1 algorithm.
+                if (chc.negotiatedProtocol != null
+                        && chc.negotiatedProtocol.useTLS13PlusSpec()) {
+                    final String exMsg = cexc.getMessage().toUpperCase();
+
+                    if (exMsg.contains("MD5WITH")
+                            || exMsg.contains("SHA1WITH")) {
+                        alert = Alert.BAD_CERTIFICATE;
+                    }
                 }
             }
 
-            return alert;
+
         }
+
+        return alert;
     }
 }

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateRequest.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -640,25 +640,11 @@ final class CertificateRequest {
             // The producing happens in server side only.
             ServerHandshakeContext shc = (ServerHandshakeContext) context;
 
-            if (shc.localSupportedSignAlgs == null) {
-                shc.localSupportedSignAlgs =
-                        SignatureScheme.getSupportedAlgorithms(
-                                shc.sslConfig,
-                                shc.algorithmConstraints, shc.activeProtocols,
-                                HANDSHAKE_SCOPE);
-            }
-
-            if (shc.localSupportedCertSignAlgs == null) {
-                shc.localSupportedCertSignAlgs =
-                        SignatureScheme.getSupportedAlgorithms(
-                                shc.sslConfig,
-                                shc.algorithmConstraints, shc.activeProtocols,
-                                CERTIFICATE_SCOPE);
-            }
-
             // According to TLSv1.2 RFC, CertificateRequest message must
             // contain signature schemes supported for both:
             // handshake signatures and certificate signatures.
+            // localSupportedSignAlgs and localSupportedCertSignAlgs have been
+            // already updated when we set the negotiated protocol.
             List<SignatureScheme> certReqSignAlgs =
                     new ArrayList<>(shc.localSupportedSignAlgs);
             certReqSignAlgs.retainAll(shc.localSupportedCertSignAlgs);

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ClientHello.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ClientHello.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -827,6 +827,10 @@ final class ClientHello {
                 SSLLogger.fine(
                     "Negotiated protocol version: " + negotiatedProtocol.name);
             }
+
+            // Protocol version is negotiated, update locally supportedAdd commentMore actions
+            // signature schemes according to the protocol being used.
+            SignatureScheme.updateHandshakeLocalSupportedAlgs(context);
 
             // Consume the handshake message for the specific protocol version.
             if (negotiatedProtocol.isDTLS) {

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/PreSharedKeyExtension.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/PreSharedKeyExtension.java
@@ -444,13 +444,7 @@ final class PreSharedKeyExtension {
         // localSupportedCertSignAlgs field is populated.  This is particularly
         // important when client authentication was used in an initial session,
         // and it is now being resumed.
-        if (shc.localSupportedCertSignAlgs == null) {
-            shc.localSupportedCertSignAlgs =
-                    SignatureScheme.getSupportedAlgorithms(
-                            shc.sslConfig,
-                            shc.algorithmConstraints, shc.activeProtocols,
-                            CERTIFICATE_SCOPE);
-        }
+        SignatureScheme.updateHandshakeLocalSupportedAlgs(shc);
 
         // Validate the required client authentication.
         if (result &&

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ServerHello.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/ServerHello.java
@@ -51,9 +51,6 @@ import com.tencent.kona.sun.security.ssl.SSLCipher.SSLWriteCipher;
 import com.tencent.kona.sun.security.ssl.SSLHandshake.HandshakeMessage;
 import com.tencent.kona.sun.security.ssl.SupportedVersionsExtension.SHSupportedVersionsSpec;
 
-import static com.tencent.kona.sun.security.ssl.SignatureScheme.CERTIFICATE_SCOPE;
-import static com.tencent.kona.sun.security.ssl.SignatureScheme.HANDSHAKE_SCOPE;
-
 /**
  * Pack of the ServerHello/HelloRetryRequest handshake message.
  */
@@ -277,22 +274,6 @@ final class ServerHello {
                 if (!shc.sslConfig.enableSessionCreation) {
                     throw new SSLException(
                         "Not resumption, and no new session is allowed");
-                }
-
-                if (shc.localSupportedSignAlgs == null) {
-                    shc.localSupportedSignAlgs =
-                            SignatureScheme.getSupportedAlgorithms(
-                                    shc.sslConfig,
-                                    shc.algorithmConstraints, shc.activeProtocols,
-                                    HANDSHAKE_SCOPE);
-                }
-
-                if (shc.localSupportedCertSignAlgs == null) {
-                    shc.localSupportedCertSignAlgs =
-                            SignatureScheme.getSupportedAlgorithms(
-                                    shc.sslConfig,
-                                    shc.algorithmConstraints, shc.activeProtocols,
-                                    CERTIFICATE_SCOPE);
                 }
 
                 SSLSessionImpl session =
@@ -529,22 +510,6 @@ final class ServerHello {
                 if (!shc.sslConfig.enableSessionCreation) {
                     throw new SSLException(
                         "Not resumption, and no new session is allowed");
-                }
-
-                if (shc.localSupportedSignAlgs == null) {
-                    shc.localSupportedSignAlgs =
-                            SignatureScheme.getSupportedAlgorithms(
-                                    shc.sslConfig,
-                                    shc.algorithmConstraints, shc.activeProtocols,
-                                    HANDSHAKE_SCOPE);
-                }
-
-                if (shc.localSupportedCertSignAlgs == null) {
-                    shc.localSupportedCertSignAlgs =
-                            SignatureScheme.getSupportedAlgorithms(
-                                    shc.sslConfig,
-                                    shc.algorithmConstraints, shc.activeProtocols,
-                                    CERTIFICATE_SCOPE);
                 }
 
                 SSLSessionImpl session =
@@ -968,6 +933,10 @@ final class ServerHello {
                     "Negotiated protocol version: " + serverVersion.name);
             }
 
+            // Protocol version is negotiated, update locally supportedAdd commentMore actions
+            // signature schemes according to the protocol being used.
+            SignatureScheme.updateHandshakeLocalSupportedAlgs(chc);
+
             // TLS 1.3 key share extension may have produced client
             // possessions for TLS 1.3 key exchanges.
             //
@@ -1018,6 +987,10 @@ final class ServerHello {
                 SSLLogger.fine(
                     "Negotiated protocol version: " + serverVersion.name);
             }
+
+            // Protocol version is negotiated, update locally supported
+            // signature schemes according to the protocol being used.
+            SignatureScheme.updateHandshakeLocalSupportedAlgs(chc);
 
             if (serverHello.serverRandom.isVersionDowngrade(chc)) {
                 throw chc.conContext.fatal(Alert.ILLEGAL_PARAMETER,

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SessionTicketExtension.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SessionTicketExtension.java
@@ -46,8 +46,6 @@ import com.tencent.kona.sun.security.ssl.SSLExtension.SSLExtensionSpec;
 import com.tencent.kona.sun.security.ssl.SSLHandshake.HandshakeMessage;
 import com.tencent.kona.sun.security.util.HexDumpEncoder;
 
-import static com.tencent.kona.sun.security.ssl.SignatureScheme.CERTIFICATE_SCOPE;
-
 /**
  * SessionTicketExtension is an implementation of RFC 5077 with some internals
  * that are used for stateless operation in TLS 1.3.
@@ -354,13 +352,7 @@ final class SessionTicketExtension {
                 return new SessionTicketSpec().getEncoded();
             }
 
-            if (chc.localSupportedCertSignAlgs == null) {
-                chc.localSupportedCertSignAlgs =
-                        SignatureScheme.getSupportedAlgorithms(
-                                chc.sslConfig,
-                                chc.algorithmConstraints, chc.activeProtocols,
-                                CERTIFICATE_SCOPE);
-            }
+            SignatureScheme.updateHandshakeLocalSupportedAlgs(chc);
 
             return chc.resumingSession.getPskIdentity();
         }

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SignatureAlgorithmsExtension.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SignatureAlgorithmsExtension.java
@@ -189,13 +189,7 @@ final class SignatureAlgorithmsExtension {
             }
 
             // Produce the extension.
-            if (chc.localSupportedSignAlgs == null) {
-                chc.localSupportedSignAlgs =
-                    SignatureScheme.getSupportedAlgorithms(
-                            chc.sslConfig,
-                            chc.algorithmConstraints, chc.activeProtocols,
-                            HANDSHAKE_SCOPE);
-            }
+            SignatureScheme.updateHandshakeLocalSupportedAlgs(chc);
 
             int vectorLen = SignatureScheme.sizeInRecord() *
                     chc.localSupportedSignAlgs.size();
@@ -418,18 +412,14 @@ final class SignatureAlgorithmsExtension {
             }
 
             // Produce the extension.
-            List<SignatureScheme> sigAlgs =
-                    SignatureScheme.getSupportedAlgorithms(
-                            shc.sslConfig,
-                            shc.algorithmConstraints,
-                            Collections.singletonList(shc.negotiatedProtocol),
-                            HANDSHAKE_SCOPE);
-
-            int vectorLen = SignatureScheme.sizeInRecord() * sigAlgs.size();
+            // localSupportedSignAlgs has been already updated when we
+            // set the negotiated protocol.
+            int vectorLen = SignatureScheme.sizeInRecord()
+                    * shc.localSupportedSignAlgs.size();
             byte[] extData = new byte[vectorLen + 2];
             ByteBuffer m = ByteBuffer.wrap(extData);
             Record.putInt16(m, vectorLen);
-            for (SignatureScheme ss : sigAlgs) {
+            for (SignatureScheme ss : shc.localSupportedSignAlgs) {
                 Record.putInt16(m, ss.id);
             }
 

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SignatureScheme.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SignatureScheme.java
@@ -394,9 +394,40 @@ enum SignatureScheme {
                 && (namedGroup == null || namedGroup.isPermitted(constraints));
     }
 
+    // Helper method to update all locally supported signature schemes forAdd commentMore actions
+    // a given HandshakeContext.
+    static void updateHandshakeLocalSupportedAlgs(HandshakeContext hc) {
+        // To improve performance we only update when necessary.
+        // No need to do anything if we already computed the local supported
+        // algorithms and either there is no negotiated protocol yet or the
+        // only active protocol ends up to be the negotiated protocol.
+        if (hc.localSupportedSignAlgs != null
+                && hc.localSupportedCertSignAlgs != null
+                && (hc.negotiatedProtocol == null
+                || hc.activeProtocols.size() == 1)) {
+            return;
+        }
+
+        List<ProtocolVersion> protocols = hc.negotiatedProtocol != null ?
+                Collections.singletonList(hc.negotiatedProtocol) :
+                hc.activeProtocols;
+
+        hc.localSupportedSignAlgs = getSupportedAlgorithms(
+                hc.sslConfig,
+                hc.algorithmConstraints,
+                protocols,
+                HANDSHAKE_SCOPE);
+
+        hc.localSupportedCertSignAlgs = getSupportedAlgorithms(
+                hc.sslConfig,
+                hc.algorithmConstraints,
+                protocols,
+                CERTIFICATE_SCOPE);
+    }
+
     // Get local supported algorithm collection complying to algorithm
     // constraints and SSL scopes.
-    static List<SignatureScheme> getSupportedAlgorithms(
+    private static List<SignatureScheme> getSupportedAlgorithms(
             SSLConfiguration config,
             SSLAlgorithmConstraints constraints,
             List<ProtocolVersion> activeProtocols,


### PR DESCRIPTION
This is a backport of [JDK-8350807]: Certificates using MD5 algorithm that are disabled by default are incorrectly allowed in TLSv1.3 when re-enabled.

This PR will resolves #1168.

[JDK-8350807]:
https://bugs.openjdk.org/browse/JDK-8350807