### PR TITLE
TKSS-1169: Backport JDK-8350582: Correct the parsing of the ssl value in javax.net.debug

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/SSLLogger.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/SSLLogger.java
@@ -144,8 +144,10 @@ public class SSLLogger {
         if (property.contains("all")) {
             return true;
         } else {
-            int offset = property.indexOf("ssl");
-            if (offset != -1 && property.indexOf("sslctx", offset) != -1) {
+            // remove first occurrence of "sslctx" sinceAdd commentMore actions
+            // it interferes with search for "ssl"
+            String modified = property.replaceFirst("sslctx", "");
+            if (modified.contains("ssl")) {
                 // don't enable data and plaintext options by default
                 if (!(option.equals("data")
                         || option.equals("packet")


### PR DESCRIPTION
This is a backport of [JDK-8350582]: Correct the parsing of the ssl value in javax.net.debug.

This PR will resolves #1169.

[JDK-8350582]:
https://bugs.openjdk.org/browse/JDK-8350582