### PR TITLE
TKSS-1176: Backport JDK-8310003: Improve logging when default truststore is inaccessible

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TrustStoreManager.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TrustStoreManager.java
@@ -116,7 +116,7 @@ final class TrustStoreManager {
                 SSLLogger.fine(
                     "trustStore is: " + storeName + "\n" +
                     "trustStore type is: " + storeType + "\n" +
-                    "trustStore provider is: " + storeProvider + "\n" +
+                    "trustStore provider is: " + (storeProvider.isEmpty() ? "unspecified" : storeProvider) + "\n" +
                     "the last modified time is: " + (new Date(lastModified)));
             }
         }


### PR DESCRIPTION
This is a backport of [JDK-8310003]: Improve logging when default truststore is inaccessible.

This PR will resolves #1176.

[JDK-8310003]:
https://bugs.openjdk.org/browse/JDK-8310003