### PR TITLE
TKSS-1180: Backport JDK-8358316: PKCS8Key.getEncoded() can throw NPE after JDK-8298420

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS8Key.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/pkcs/PKCS8Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -204,7 +204,8 @@ public class PKCS8Key implements PrivateKey, InternalPrivateKey {
      * or {@code null} if an encoding error occurs.
      */
     public byte[] getEncoded() {
-        return getEncodedInternal().clone();
+        byte[] b = getEncodedInternal();
+        return (b != null) ? b.clone() : null;
     }
 
     /**


### PR DESCRIPTION
This is a backport of [JDK-8358316]: PKCS8Key.getEncoded() can throw NPE after JDK-8298420.

This PR will resolves #1180.

[JDK-8358316]:
https://bugs.openjdk.org/browse/JDK-8358316