### PR TITLE
Backport JDK-8156715: TrustStoreManager does not buffer keystore input stream

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TrustStoreManager.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TrustStoreManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -388,9 +388,10 @@ final class TrustStoreManager {
             }
 
             if (!"NONE".equals(descriptor.storeName)) {
-                try (@SuppressWarnings("removal") FileInputStream fis = AccessController.doPrivileged(
-                        new OpenFileInputStreamAction(descriptor.storeFile))) {
-                    ks.load(fis, password);
+                try (BufferedInputStream bis =
+                        new BufferedInputStream(
+                                new FileInputStream(descriptor.storeFile))) {
+                    ks.load(bis, password);
                 } catch (FileNotFoundException fnfe) {
                     // No file available, no KeyStore available.
                     if (SSLLogger.isOn && SSLLogger.isOn("trustmanager")) {


### PR DESCRIPTION
This a backport of [JDK-8156715]: TrustStoreManager does not buffer keystore input stream.

This PR will resolve #1192.

[JDK-8156715]:
https://bugs.openjdk.org/browse/JDK-8156715