### PR TITLE
Backport JDK-8360539: DTLS handshakes fails due to improper cookie validation logic

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/HelloCookieManager.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/HelloCookieManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -190,7 +190,7 @@ abstract class HelloCookieManager {
             byte[] secret;
             d10ManagerLock.lock();
             try {
-                if (((cookieVersion >> 24) & 0xFF) == cookie[0]) {
+                if ((byte) ((cookieVersion >> 24) & 0xFF) == cookie[0]) {
                     secret = cookieSecret;
                 } else {
                     secret = legacySecret;  // including out of window cookies


### PR DESCRIPTION
This is a backport of [JDK-8360539]: DTLS handshakes fails due to improper cookie validation logic.

This PR will resolve #1194.

[JDK-8360539]:
https://bugs.openjdk.org/browse/JDK-8360539