### PR TITLE
Backport JDK-8361125: Fix typo in onTradAbsence

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/KeyShareExtension.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/KeyShareExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ final class KeyShareExtension {
             new CHKeyShareProducer();
     static final ExtensionConsumer chOnLoadConsumer =
             new CHKeyShareConsumer();
-    static final HandshakeAbsence chOnTradAbsence =
+    static final HandshakeAbsence chOnTradeAbsence =
             new CHKeyShareOnTradeAbsence();
     static final SSLStringizer chStringizer =
             new CHKeyShareStringizer();

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/PreSharedKeyExtension.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/PreSharedKeyExtension.java
@@ -56,7 +56,7 @@ final class PreSharedKeyExtension {
             new CHPreSharedKeyOnLoadAbsence();
     static final HandshakeConsumer chOnTradeConsumer =
             new CHPreSharedKeyUpdate();
-    static final HandshakeAbsence chOnTradAbsence =
+    static final HandshakeAbsence chOnTradeAbsence =
             new CHPreSharedKeyOnTradeAbsence();
     static final SSLStringizer chStringizer =
             new CHPreSharedKeyStringizer();

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLExtension.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -143,7 +143,7 @@ enum SSLExtension implements SSLStringizer {
                                 SupportedGroupsExtension.chOnLoadConsumer,
                                 null,
                                 null,
-                                SupportedGroupsExtension.chOnTradAbsence,
+                                SupportedGroupsExtension.chOnTradeAbsence,
                                 SupportedGroupsExtension.sgsStringizer),
     EE_SUPPORTED_GROUPS     (0x000A, "supported_groups",
                                 SSLHandshake.ENCRYPTED_EXTENSIONS,
@@ -434,7 +434,7 @@ enum SSLExtension implements SSLStringizer {
                                 KeyShareExtension.chOnLoadConsumer,
                                 null,
                                 null,
-                                KeyShareExtension.chOnTradAbsence,
+                                KeyShareExtension.chOnTradeAbsence,
                                 KeyShareExtension.chStringizer),
     SH_KEY_SHARE            (0x0033, "key_share",
                                 SSLHandshake.SERVER_HELLO,
@@ -487,7 +487,7 @@ enum SSLExtension implements SSLStringizer {
                                 PreSharedKeyExtension.chOnLoadConsumer,
                                 PreSharedKeyExtension.chOnLoadAbsence,
                                 PreSharedKeyExtension.chOnTradeConsumer,
-                                PreSharedKeyExtension.chOnTradAbsence,
+                                PreSharedKeyExtension.chOnTradeAbsence,
                                 PreSharedKeyExtension.chStringizer),
     SH_PRE_SHARED_KEY       (0x0029, "pre_shared_key",
                                 SSLHandshake.SERVER_HELLO,

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SupportedGroupsExtension.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SupportedGroupsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ final class SupportedGroupsExtension {
             new CHSupportedGroupsProducer();
     static final ExtensionConsumer chOnLoadConsumer =
             new CHSupportedGroupsConsumer();
-    static final HandshakeAbsence chOnTradAbsence =
+    static final HandshakeAbsence chOnTradeAbsence =
             new CHSupportedGroupsOnTradeAbsence();
     static final SSLStringizer sgsStringizer =
             new SupportedGroupsStringizer();


### PR DESCRIPTION
This is a backport of [JDK-8361125]: Fix typo in onTradAbsence.

This PR will resolve #1195.

[JDK-8361125]:
https://bugs.openjdk.org/browse/JDK-8361125