### PR TITLE
TKSS-1199: Backport JDK-8349594: Enhance TLS protocol support

### DIFF
--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateMessage.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateMessage.java
@@ -1100,6 +1100,15 @@ final class CertificateMessage {
 
             // clean up this consumer
             hc.handshakeConsumers.remove(SSLHandshake.CERTIFICATE.id);
+
+            // Ensure that the Certificate message has not been sent w/o
+            // an EncryptedExtensions preceding
+            if (hc.handshakeConsumers.containsKey(
+                    SSLHandshake.ENCRYPTED_EXTENSIONS.id)) {
+                throw hc.conContext.fatal(Alert.UNEXPECTED_MESSAGE,
+                        "Unexpected Certificate handshake message");
+            }
+
             T13CertificateMessage cm = new T13CertificateMessage(hc, message);
             if (hc.sslConfig.isClientMode) {
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateVerify.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/CertificateVerify.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1167,6 +1167,14 @@ final class CertificateVerify {
 
             // Clean up this consumer
             hc.handshakeConsumers.remove(SSLHandshake.CERTIFICATE_VERIFY.id);
+
+            // Ensure that the Certificate Verify message has not been sent w/o
+            // a Certificate message preceding
+            if (hc.handshakeConsumers.containsKey(
+                    SSLHandshake.CERTIFICATE.id)) {
+                throw hc.conContext.fatal(Alert.UNEXPECTED_MESSAGE,
+                        "Unexpected Certificate Verify handshake message");
+            }
 
             T13CertificateVerifyMessage cvm =
                     new T13CertificateVerifyMessage(hc, message);

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/Finished.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/Finished.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -899,6 +899,14 @@ final class Finished {
 
         private void onConsumeFinished(ClientHandshakeContext chc,
                 ByteBuffer message) throws IOException {
+            // Ensure that the Finished message has not been sent w/o
+            // an EncryptedExtensions preceding
+            if (chc.handshakeConsumers.containsKey(
+                    SSLHandshake.ENCRYPTED_EXTENSIONS.id)) {
+                throw chc.conContext.fatal(Alert.UNEXPECTED_MESSAGE,
+                        "Unexpected Finished handshake message");
+            }
+
             // Make sure that any expected CertificateVerify message
             // has been received and processed.
             if (!chc.isResumption) {


### PR DESCRIPTION
This is a backport of[ JDK-8349594]: Enhance TLS protocol support.
This is a vulnerability issue with CVE-2025-30754.

This PR will resolve #1199.

[ JDK-8349594]:
https://github.com/openjdk/jdk21u/commit/bab305aff7bff5603507aa1516396728c1a1e146