### PR TITLE
TKSS-1210: Replace THL A29 Limited with Tencent

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2023, 2025, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/.github/workflows/scripts/precheck.sh
+++ b/.github/workflows/scripts/precheck.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2023, 2024, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2022 THL A29 Limited, a Tencent company.  All rights reserved.
+Copyright (C) 2022, Tencent. All rights reserved.
 
 TencentKonaSMSuite is licensed under the GNU GPL v2.0 license with classpath exception.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/buildSrc/src/main/kotlin/CommonTest.kt
+++ b/buildSrc/src/main/kotlin/CommonTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/buildSrc/src/main/kotlin/kona-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/kona-common.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2023, 2025, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/build.gradle.kts
+++ b/kona-crypto/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/ECKeyPairGenPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/ECKeyPairGenPerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/KonaECDHKeyAgreementPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/KonaECDHKeyAgreementPerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/KonaECDSASignaturePerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/KonaECDSASignaturePerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2CipherConstantTimeTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2CipherConstantTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2CipherPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2CipherPerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2KeyAgreementPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2KeyAgreementPerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2KeyPairGenPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2KeyPairGenPerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2SignatureConstantTimeTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2SignatureConstantTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2SignaturePerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM2SignaturePerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM3HMacPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM3HMacPerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM3MessageDigestPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM3MessageDigestPerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4ConstantTimeTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4ConstantTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4DecrypterPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4DecrypterPerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4EncrypterPerfTest.java
+++ b/kona-crypto/src/jmh/java/com/tencent/kona/crypto/perf/SM4EncrypterPerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoInsts.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoInsts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoUtils.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/CryptoUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/KonaCryptoNativeOneShotProvider.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/KonaCryptoNativeOneShotProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/KonaCryptoNativeProvider.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/KonaCryptoNativeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/KonaCryptoProvider.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/KonaCryptoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/ConstructKeys.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/ConstructKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GFMultiplier.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GFMultiplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GFMultipliers.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/GFMultipliers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/HmacPKCS12PBE_SM3.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/HmacPKCS12PBE_SM3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2Cipher.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2Cipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2Engine.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2Engine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyAgreement.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyFactory.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyPairGenerator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2KeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2PrivateKey.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2PrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2PublicKey.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2PublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2Signature.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM2Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM3Engine.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM3Engine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM3HMacKeyGenerator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM3HMacKeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM3MessageDigest.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM3MessageDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4Crypt.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4Crypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4Engine.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4Engine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4GenParameterSpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4GenParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4KeyGenerator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4KeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4ParameterGenerator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4ParameterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4Parameters.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/SM4Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/AlgoCipher.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/AlgoCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/ByteArrayWriter.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/ByteArrayWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/CipherCore.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/CipherCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/ConstructKeys.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/ConstructKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/DataWindow.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/DataWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/Mode.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/Mode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeCrypto.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeCrypto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeECDHKeyAgreement.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeECDHKeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeECDSASignature.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeECDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeECKeyPairGen.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeECKeyPairGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeRef.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2Cipher.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2Cipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2KeyAgreement.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2KeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2KeyPairGen.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2KeyPairGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2Signature.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3HMac.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3HMac.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4Engine.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4Engine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/Padding.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/Padding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2Cipher.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2Cipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2KeyAgreement.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2KeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2KeyPairGenerator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2KeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2OneShotCipher.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2OneShotCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2OneShotKeyAgreement.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2OneShotKeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2OneShotKeyPairGenerator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2OneShotKeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2OneShotSignature.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2OneShotSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2Signature.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM2Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3HMac.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3HMac.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3MessageDigest.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3MessageDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3OneShotHMac.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3OneShotHMac.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3OneShotMessageDigest.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3OneShotMessageDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4Cipher.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4Cipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4Crypt.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4Crypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4OneShotCrypt.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4OneShotCrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4Params.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4Params.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SweepNativeRef.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SweepNativeRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SymmetricCipher.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SymmetricCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/RFC5915EncodedKeySpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/RFC5915EncodedKeySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2KeyAgreementParamSpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2KeyAgreementParamSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2ParameterSpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2ParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2PrivateKeySpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2PrivateKeySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2PublicKeySpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2PublicKeySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2SignatureParameterSpec.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/spec/SM2SignatureParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/util/Constants.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/util/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/util/RangeUtil.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/util/RangeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/util/SM2Ciphertext.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/util/SM2Ciphertext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/util/Sweeper.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/util/Sweeper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/java/lang/MathUtil.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/java/lang/MathUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/java/nio/DirectBufferUtil.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/java/nio/DirectBufferUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/jdk/internal/misc/SharedSecretsUtil.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/jdk/internal/misc/SharedSecretsUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/jdk/internal/misc/UnsafeUtil.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/jdk/internal/misc/UnsafeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECOperator.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/ec/ECOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/Oid.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/Oid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021, 2022, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2021, 2022, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-crypto/src/main/jni/CMakeLists.txt
+++ b/kona-crypto/src/main/jni/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2024, 2025, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/build.sh
+++ b/kona-crypto/src/main/jni/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2024, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/include/kona/kona_common.h
+++ b/kona-crypto/src/main/jni/include/kona/kona_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/include/kona/kona_ec.h
+++ b/kona-crypto/src/main/jni/include/kona/kona_ec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/include/kona/kona_sm2.h
+++ b/kona-crypto/src/main/jni/include/kona/kona_sm2.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/include/kona/kona_sm3.h
+++ b/kona-crypto/src/main/jni/include/kona/kona_sm3.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/kona_common.c
+++ b/kona-crypto/src/main/jni/kona_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/kona_ec.c
+++ b/kona-crypto/src/main/jni/kona_ec.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/kona_ec_keypair.c
+++ b/kona-crypto/src/main/jni/kona_ec_keypair.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/kona_ecdh.c
+++ b/kona-crypto/src/main/jni/kona_ecdh.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/kona_ecdsa.c
+++ b/kona-crypto/src/main/jni/kona_ecdsa.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/kona_sm2_cipher.c
+++ b/kona-crypto/src/main/jni/kona_sm2_cipher.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/kona_sm2_common.c
+++ b/kona-crypto/src/main/jni/kona_sm2_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/kona_sm2_keyagreement.c
+++ b/kona-crypto/src/main/jni/kona_sm2_keyagreement.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/kona_sm2_keypair.c
+++ b/kona-crypto/src/main/jni/kona_sm2_keypair.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/kona_sm2_signature.c
+++ b/kona-crypto/src/main/jni/kona_sm2_signature.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/kona_sm3.c
+++ b/kona-crypto/src/main/jni/kona_sm3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/main/jni/kona_sm4.c
+++ b/kona-crypto/src/main/jni/kona_sm4.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/CryptoUtilsTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/CryptoUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/KonaCryptoProviderTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/KonaCryptoProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/TestUtils.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/ECKeyPairGeneratorTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/ECKeyPairGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/KonaECDHKeyAgreementTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/KonaECDHKeyAgreementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/KonaECDSASignatureTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/KonaECDSASignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/KonaECKeyPairGeneratorTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/KonaECKeyPairGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2CipherTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2CipherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2KeyAgreementTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2KeyAgreementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2KeyFactoryTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2KeyFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2KeyPairGeneratorTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2KeyPairGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2SignatureTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2SignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2WithBCTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM2WithBCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3EngineTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3EngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacKeyGeneratorTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacKeyGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacWithBCTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacWithBCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3WithBCTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3WithBCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4EngineTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4EngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4KeyGeneratorTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4KeyGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4ParameterGeneratorTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4ParameterGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4ParametersTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4ParametersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4WithBCTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4WithBCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeECDHKeyAgreementTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeECDHKeyAgreementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeECDSASignatureTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeECDSASignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeECKeyPairGeneratorTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeECKeyPairGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeRefProfTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeRefProfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3HMacTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3HMacTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4EngineTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4EngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/NativeSM4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/util/SM2CiphertextTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/util/SM2CiphertextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/sun/security/ec/ECOperatorTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/sun/security/ec/ECOperatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/sun/security/ec/RFC5915KeyTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/sun/security/ec/RFC5915KeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/sun/security/pkcs/PKCS8KeyTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/sun/security/pkcs/PKCS8KeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/sun/security/util/OidTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/sun/security/util/OidTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-crypto/src/test/java/com/tencent/kona/sun/security/x509/AlgorithmIdTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/sun/security/x509/AlgorithmIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-demo/build.gradle.kts
+++ b/kona-demo/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-demo/src/main/java/com/tencent/kona/demo/AppConfig.java
+++ b/kona-demo/src/main/java/com/tencent/kona/demo/AppConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-demo/src/main/java/com/tencent/kona/demo/JettyServer.java
+++ b/kona-demo/src/main/java/com/tencent/kona/demo/JettyServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-demo/src/main/java/com/tencent/kona/demo/TomcatServer.java
+++ b/kona-demo/src/main/java/com/tencent/kona/demo/TomcatServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-demo/src/main/resources/application.yml
+++ b/kona-demo/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2023, 2024, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/build.gradle.kts
+++ b/kona-pkix/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/jmh/java/com/tencent/kona/pkix/perf/KeyStorePerfTest.java
+++ b/kona-pkix/src/jmh/java/com/tencent/kona/pkix/perf/KeyStorePerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/main/java/com/tencent/kona/pkix/KonaPKIXProvider.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/pkix/KonaPKIXProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-pkix/src/main/java/com/tencent/kona/pkix/PKIXInsts.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/pkix/PKIXInsts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-pkix/src/main/java/com/tencent/kona/pkix/PKIXUtils.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/pkix/PKIXUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-pkix/src/main/java/com/tencent/kona/pkix/tool/KeyStoreTool.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/pkix/tool/KeyStoreTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-pkix/src/main/java/com/tencent/kona/pkix/tool/KeyTool.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/pkix/tool/KeyTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/CollectionUtil.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/util/CollectionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SMCertificate.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/x509/SMCertificate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2021, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/KonaPKIXProviderTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/KonaPKIXProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/demo/PKIDemo.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/demo/PKIDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/demo/SignatureDemo.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/demo/SignatureDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertPathBuilderTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertPathBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertPathValidatorTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertPathValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertStoreTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertificateFactoryTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/CertificateFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/KeyFactoryTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/KeyFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/KeyStoreProfTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/KeyStoreProfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/KeyStoreTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/provider/KeyStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/tool/KeyStoreToolTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/tool/KeyStoreToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/tool/KeyToolTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/tool/KeyToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/java/com/tencent/kona/pkix/util/PKIXUtilsTest.java
+++ b/kona-pkix/src/test/java/com/tencent/kona/pkix/util/PKIXUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/resources/demo/gen_demo_certs.sh
+++ b/kona-pkix/src/test/resources/demo/gen_demo_certs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2023, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/resources/gen_certs.sh
+++ b/kona-pkix/src/test/resources/gen_certs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2024, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/resources/gen_hybrid_certs.sh
+++ b/kona-pkix/src/test/resources/gen_hybrid_certs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2024, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/resources/gen_ocsp.sh
+++ b/kona-pkix/src/test/resources/gen_ocsp.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2023, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/kona-pkix/src/test/resources/gen_tlcp_certs.sh
+++ b/kona-pkix/src/test/resources/gen_tlcp_certs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2024, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/kona-provider/build.gradle.kts
+++ b/kona-provider/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-provider/src/main/java/com/tencent/kona/KonaProvider.java
+++ b/kona-provider/src/main/java/com/tencent/kona/KonaProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-provider/src/main/java/com/tencent/kona/KonaUtils.java
+++ b/kona-provider/src/main/java/com/tencent/kona/KonaUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-provider/src/test/java/com/tencent/kona/KonaProviderTest.java
+++ b/kona-provider/src/test/java/com/tencent/kona/KonaProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-provider/src/test/java/com/tencent/kona/TestUtils.java
+++ b/kona-provider/src/test/java/com/tencent/kona/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-provider/src/test/java/com/tencent/kona/crypto/SM2Test.java
+++ b/kona-provider/src/test/java/com/tencent/kona/crypto/SM2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-provider/src/test/java/com/tencent/kona/pkix/SignatureDemo.java
+++ b/kona-provider/src/test/java/com/tencent/kona/pkix/SignatureDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-provider/src/test/java/com/tencent/kona/ssl/TLCPWithJettyDemo.java
+++ b/kona-provider/src/test/java/com/tencent/kona/ssl/TLCPWithJettyDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/build.gradle.kts
+++ b/kona-ssl/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/main/java/com/tencent/kona/ssl/KonaSSLProvider.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/ssl/KonaSSLProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-ssl/src/main/java/com/tencent/kona/ssl/SSLInsts.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/ssl/SSLInsts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-ssl/src/main/java/com/tencent/kona/ssl/SSLUtils.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/ssl/SSLUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLLogger.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/SSLLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPKeyAgreement.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/TLCPKeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/Utilities.java
+++ b/kona-ssl/src/main/java/com/tencent/kona/sun/security/ssl/Utilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/KonaSSLProviderTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/KonaSSLProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/SSLUtilsTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/SSLUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/TestUtils.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithGRPCDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithGRPCDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithHttpClientDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithHttpClientDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithJettyDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithJettyDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithNettyDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithNettyDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithTomcatDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithTomcatDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithoutCertValidationDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLCPWithoutCertValidationDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithGRPCDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithGRPCDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithJettyDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithJettyDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithOkHttpDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithOkHttpDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithTomcatDemo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/demo/TLSWithTomcatDemo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/hybrid/HybridUtils.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/hybrid/HybridUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/hybrid/JdkServerJdkClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/hybrid/JdkServerJdkClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/ClientAuth.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/ClientAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/ContextProtocol.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/ContextProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/FileCert.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/FileCert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/OpenSSL.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/OpenSSL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/OpenSSLClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/OpenSSLClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/OpenSSLServer.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/OpenSSLServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/OpenSSLUtils.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/OpenSSLUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/Provider.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/Provider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/ServerCaller.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/ServerCaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2021, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/SignatureScheme.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/SignatureScheme.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/SmCertTuple.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/SmCertTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/Tongsuo.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/Tongsuo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/TongsuoClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/TongsuoClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/TongsuoServer.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/TongsuoServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/TongsuoUtils.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/interop/TongsuoUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/SunJSSEClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/SunJSSEClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/SunJSSEServer.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/SunJSSEServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLCPClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLCPClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLCPNettyClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLCPNettyClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLCPNettyServer.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLCPNettyServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLCPServer.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLCPServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLSClient.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLSClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLSServer.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/peers/TLSServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/ConstraintTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/ConstraintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/JdkServerJdkClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/JdkServerJdkClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/JdkServerTongsuoClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/JdkServerTongsuoClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/NoConstraintTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/NoConstraintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/TLCPProfTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/TLCPProfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2025, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/TlcpUtils.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/TlcpUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/TongsuoServerJdkClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tlcp/TongsuoServerJdkClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/JdkServerJdkClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/JdkServerJdkClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/JdkServerTongsuoClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/JdkServerTongsuoClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/KonaServerSunJSSEClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/KonaServerSunJSSEClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/SunJSSEServerKonaClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/SunJSSEServerKonaClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/TongsuoServerJdkClientTest.java
+++ b/kona-ssl/src/test/java/com/tencent/kona/ssl/tls/TongsuoServerJdkClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2024, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/proto/message.proto
+++ b/kona-ssl/src/test/proto/message.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/resources/demo/gen_demo_certs.sh
+++ b/kona-ssl/src/test/resources/demo/gen_demo_certs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2023, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/resources/gen_certs.sh
+++ b/kona-ssl/src/test/resources/gen_certs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2024, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/resources/gen_hybrid_certs.sh
+++ b/kona-ssl/src/test/resources/gen_hybrid_certs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2024, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/resources/gen_ocsp.sh
+++ b/kona-ssl/src/test/resources/gen_ocsp.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2023, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/kona-ssl/src/test/resources/gen_tlcp_certs.sh
+++ b/kona-ssl/src/test/resources/gen_tlcp_certs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022, 2024, THL A29 Limited, a Tencent company. All rights reserved.
+# Copyright (C) 2022, 2024, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, 2023, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
According to the [notice], it has to replace `THL A29 Limited` with `Tencent` in the copyright notes.

This PR will resolve #1210.

[notice]:
https://github.com/Tencent/.github/blob/main/profile/README.md