### PR TITLE
TKSS-1229: Backport JDK-8368301: sun/security/util/math/intpoly compiler warnings

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/Curve25519OrderField.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/Curve25519OrderField.java
@@ -36,7 +36,7 @@ public final class Curve25519OrderField extends IntegerPolynomial {
     private static final int MAX_ADDS = 1;
     public static final BigInteger MODULUS = evaluateModulus();
     private static final long CARRY_ADD = 1 << 25;
-    private static final int LIMB_MASK = -1 >>> (64 - BITS_PER_LIMB);
+    private static final long LIMB_MASK = -1L >>> (64 - BITS_PER_LIMB);
 
     public static final Curve25519OrderField ONE = new Curve25519OrderField();
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/Curve448OrderField.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/Curve448OrderField.java
@@ -36,7 +36,7 @@ public final class Curve448OrderField extends IntegerPolynomial {
     private static final int MAX_ADDS = 1;
     public static final BigInteger MODULUS = evaluateModulus();
     private static final long CARRY_ADD = 1 << 27;
-    private static final int LIMB_MASK = -1 >>> (64 - BITS_PER_LIMB);
+    private static final long LIMB_MASK = -1L >>> (64 - BITS_PER_LIMB);
 
     public static final Curve448OrderField ONE = new Curve448OrderField();
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomial25519.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomial25519.java
@@ -36,7 +36,7 @@ public final class IntegerPolynomial25519 extends IntegerPolynomial {
     private static final int MAX_ADDS = 1;
     public static final BigInteger MODULUS = evaluateModulus();
     private static final long CARRY_ADD = 1 << 25;
-    private static final int LIMB_MASK = -1 >>> (64 - BITS_PER_LIMB);
+    private static final long LIMB_MASK = -1L >>> (64 - BITS_PER_LIMB);
 
     public static final IntegerPolynomial25519 ONE = new IntegerPolynomial25519();
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomialP256.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomialP256.java
@@ -36,7 +36,7 @@ public final class IntegerPolynomialP256 extends IntegerPolynomial {
     private static final int MAX_ADDS = 2;
     public static final BigInteger MODULUS = evaluateModulus();
     private static final long CARRY_ADD = 1 << 25;
-    private static final int LIMB_MASK = -1 >>> (64 - BITS_PER_LIMB);
+    private static final long LIMB_MASK = -1L >>> (64 - BITS_PER_LIMB);
 
     public static final IntegerPolynomialP256 ONE = new IntegerPolynomialP256();
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomialP384.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomialP384.java
@@ -36,7 +36,7 @@ public final class IntegerPolynomialP384 extends IntegerPolynomial {
     private static final int MAX_ADDS = 2;
     public static final BigInteger MODULUS = evaluateModulus();
     private static final long CARRY_ADD = 1 << 27;
-    private static final int LIMB_MASK = -1 >>> (64 - BITS_PER_LIMB);
+    private static final long LIMB_MASK = -1L >>> (64 - BITS_PER_LIMB);
 
     public static final IntegerPolynomialP384 ONE = new IntegerPolynomialP384();
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomialP521.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomialP521.java
@@ -36,7 +36,7 @@ public final class IntegerPolynomialP521 extends IntegerPolynomial {
     private static final int MAX_ADDS = 2;
     public static final BigInteger MODULUS = evaluateModulus();
     private static final long CARRY_ADD = 1 << 27;
-    private static final int LIMB_MASK = -1 >>> (64 - BITS_PER_LIMB);
+    private static final long LIMB_MASK = -1L >>> (64 - BITS_PER_LIMB);
 
     public static final IntegerPolynomialP521 ONE = new IntegerPolynomialP521();
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomialSM2.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/IntegerPolynomialSM2.java
@@ -36,7 +36,7 @@ public final class IntegerPolynomialSM2 extends IntegerPolynomial {
     private static final int MAX_ADDS = 2;
     public static final BigInteger MODULUS = evaluateModulus();
     private static final long CARRY_ADD = 1 << 25;
-    private static final int LIMB_MASK = -1 >>> (64 - BITS_PER_LIMB);
+    private static final long LIMB_MASK = -1L >>> (64 - BITS_PER_LIMB);
 
     public static final IntegerPolynomialSM2 ONE = new IntegerPolynomialSM2();
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/P256OrderField.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/P256OrderField.java
@@ -36,7 +36,7 @@ public final class P256OrderField extends IntegerPolynomial {
     private static final int MAX_ADDS = 1;
     public static final BigInteger MODULUS = evaluateModulus();
     private static final long CARRY_ADD = 1 << 25;
-    private static final int LIMB_MASK = -1 >>> (64 - BITS_PER_LIMB);
+    private static final long LIMB_MASK = -1L >>> (64 - BITS_PER_LIMB);
 
     public static final P256OrderField ONE = new P256OrderField();
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/P384OrderField.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/P384OrderField.java
@@ -36,7 +36,7 @@ public final class P384OrderField extends IntegerPolynomial {
     private static final int MAX_ADDS = 1;
     public static final BigInteger MODULUS = evaluateModulus();
     private static final long CARRY_ADD = 1 << 27;
-    private static final int LIMB_MASK = -1 >>> (64 - BITS_PER_LIMB);
+    private static final long LIMB_MASK = -1L >>> (64 - BITS_PER_LIMB);
 
     public static final P384OrderField ONE = new P384OrderField();
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/P521OrderField.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/P521OrderField.java
@@ -36,7 +36,7 @@ public final class P521OrderField extends IntegerPolynomial {
     private static final int MAX_ADDS = 1;
     public static final BigInteger MODULUS = evaluateModulus();
     private static final long CARRY_ADD = 1 << 27;
-    private static final int LIMB_MASK = -1 >>> (64 - BITS_PER_LIMB);
+    private static final long LIMB_MASK = -1L >>> (64 - BITS_PER_LIMB);
 
     public static final P521OrderField ONE = new P521OrderField();
 

--- a/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/SM2OrderField.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/sun/security/util/math/intpoly/SM2OrderField.java
@@ -36,7 +36,7 @@ public final class SM2OrderField extends IntegerPolynomial {
     private static final int MAX_ADDS = 1;
     public static final BigInteger MODULUS = evaluateModulus();
     private static final long CARRY_ADD = 1 << 25;
-    private static final int LIMB_MASK = -1 >>> (64 - BITS_PER_LIMB);
+    private static final long LIMB_MASK = -1L >>> (64 - BITS_PER_LIMB);
 
     public static final SM2OrderField ONE = new SM2OrderField();
 

--- a/kona-crypto/src/test/java/com/tencent/kona/sun/security/util/math/intpoly/FieldGen.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/sun/security/util/math/intpoly/FieldGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -492,7 +492,7 @@ public class FieldGen {
         String fileName = params.getClassName() + ".java";
         PrintWriter out = new PrintWriter(Files.newBufferedWriter(
                 destPath.resolve(fileName)));
-        out.print(text);
+        out.println(text);
         out.close();
     }
 
@@ -647,7 +647,7 @@ public class FieldGen {
         result.appendLine("private static final long CARRY_ADD = 1 << "
                 + (params.getBitsPerLimb() - 1) + ";");
         if (params.getBitsPerLimb() * params.getNumLimbs() != params.getPower()) {
-            result.appendLine("private static final int LIMB_MASK = -1 "
+            result.appendLine("private static final long LIMB_MASK = -1L "
                     + ">>> (64 - BITS_PER_LIMB);");
         }
 


### PR DESCRIPTION
This is a backport of [JDK-8368301]: sun/security/util/math/intpoly compiler warnings.

This PR will resolves #1229.

[JDK-8368301]:
https://bugs.openjdk.org/browse/JDK-8368301