### PR TITLE
TKSS-1231: Backport JDK-8368032: Enhance Certificate Checking

### DIFF
--- a/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/URICertStore.java
+++ b/kona-pkix/src/main/java/com/tencent/kona/sun/security/provider/certpath/URICertStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLConnection;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
@@ -47,8 +48,11 @@ import java.security.cert.X509CRL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
 
 import com.tencent.kona.sun.security.action.GetPropertyAction;
 import com.tencent.kona.pkix.PKIXInsts;
@@ -59,6 +63,9 @@ import com.tencent.kona.sun.security.x509.URIName;
 import com.tencent.kona.sun.security.action.GetIntegerAction;
 import com.tencent.kona.sun.security.util.Cache;
 import com.tencent.kona.sun.security.util.Debug;
+import com.tencent.kona.sun.security.util.SecurityProperties;
+
+import javax.security.auth.x500.X500Principal;
 
 /**
  * A <code>CertStore</code> that retrieves <code>Certificates</code> or
@@ -185,6 +192,166 @@ class URICertStore extends CertStoreSpi {
     }
 
     /**
+     * Enumeration for the allowed schemes we support when following a
+     * URI from an authorityInfoAccess extension on a certificate.
+     */
+    private enum AllowedScheme {
+        HTTP(HttpFtpRuleMatcher.HTTP),
+        HTTPS(HttpFtpRuleMatcher.HTTPS),
+        LDAP(LdapRuleMatcher.LDAP),
+        LDAPS(LdapRuleMatcher.LDAPS),
+        FTP(HttpFtpRuleMatcher.FTP);
+
+        final URIRuleMatcher ruleMatcher;
+
+        AllowedScheme(URIRuleMatcher matcher) {
+            ruleMatcher = matcher;
+        }
+
+        /**
+         * Return an {@code AllowedScheme} based on a case-insensitive match
+         * @param name the scheme name to be matched
+         * @return the {@code AllowedScheme} that corresponds to the
+         *      {@code name} provided, or null if there is no match.
+         */
+        static AllowedScheme nameOf(String name) {
+            if (name == null) {
+                return null;
+            }
+
+            try {
+                return AllowedScheme.valueOf(name.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException iae) {
+                return null;
+            }
+        }
+    }
+
+    private static Set<URI> CA_ISS_URI_FILTERS = null;
+    private static final boolean CA_ISS_ALLOW_ANY;
+
+    static {
+        boolean allowAny = false;
+        try {
+            if (Builder.USE_AIA) {
+                CA_ISS_URI_FILTERS = new LinkedHashSet<>();
+                String aiaPropVal = Optional.ofNullable(
+                        SecurityProperties.privilegedGetOverridable(
+                                "com.tencent.kona.pkix.allowedAIALocations")).
+                        map(String::trim).orElse("");
+                if (aiaPropVal.equalsIgnoreCase("any")) {
+                    allowAny = true;
+                    if (debug != null) {
+                        debug.println("allowedAIALocations: Warning: " +
+                                "Allow-All URI filtering enabled!");
+                    }
+                } else {
+                    // Load all the valid rules from the Security property
+                    if (!aiaPropVal.isEmpty()) {
+                        String[] aiaUriStrs = aiaPropVal.trim().split("\\s+");
+                        addCaIssUriFilters(aiaUriStrs);
+                    }
+
+                    if (CA_ISS_URI_FILTERS.isEmpty()) {
+                        if (debug != null) {
+                            debug.println("allowedAIALocations: Warning: " +
+                                    "No valid filters found. Deny-all URI " +
+                                    "filtering is active.");
+                        }
+                    }
+                }
+            }
+        } finally {
+            CA_ISS_ALLOW_ANY = allowAny;
+        }
+    }
+
+    /**
+     * Populate the filter collection from the list of AIA CA issuer URIs
+     * found in the {@code com.tencent.kona.pkix.allowedAIALocations} security
+     * or system property.
+     *
+     * @param aiaUriStrs array containing String URI filters
+     */
+    private static void addCaIssUriFilters(String[] aiaUriStrs) {
+        for (String aiaStr : aiaUriStrs) {
+            if (aiaStr != null && !aiaStr.isEmpty()) {
+                try {
+                    AllowedScheme scheme;
+                    URI aiaUri = new URI(aiaStr).normalize();
+                    // It must be absolute and non-opaque
+                    if (!aiaUri.isAbsolute() || aiaUri.isOpaque()) {
+                        if (debug != null) {
+                            debug.println("allowedAIALocations: Skipping " +
+                                    "non-absolute or opaque URI " + aiaUri);
+                        }
+                    } else if (aiaUri.getHost() == null) {
+                        // We do not allow rules with URIs that omit a hostname
+                        // or address.
+                        if (debug != null) {
+                            debug.println("allowedAIALocations: Skipping " +
+                                    "URI rule with no hostname or address: " +
+                                    aiaUri);
+                        }
+                    } else if ((scheme = AllowedScheme.nameOf(
+                            aiaUri.getScheme())) != null) {
+                        // When it is an LDAP type, we can check the path
+                        // portion (the DN) for proper structure and reject
+                        // the rule early if it isn't correct.
+                        if (scheme == AllowedScheme.LDAP ||
+                                scheme == AllowedScheme.LDAPS) {
+                            try {
+                                new X500Principal(aiaUri.getPath().
+                                        replaceFirst("^/+", ""));
+                            } catch (IllegalArgumentException iae) {
+                                if (debug != null) {
+                                    debug.println("allowedAIALocations: " +
+                                            "Skipping LDAP rule: " + iae);
+                                }
+                                continue;
+                            }
+                        }
+
+                        // When a URI has a non-null query or fragment
+                        // warn the user upon adding the rule that those
+                        // components will be ignored
+                        if (aiaUri.getQuery() != null) {
+                            if (debug != null) {
+                                debug.println("allowedAIALocations: " +
+                                        "Rule will ignore non-null query");
+                            }
+                        }
+                        if (aiaUri.getFragment() != null) {
+                            if (debug != null) {
+                                debug.println("allowedAIALocations: " +
+                                        "Rule will ignore non-null fragment");
+                            }
+                        }
+
+                        CA_ISS_URI_FILTERS.add(aiaUri);
+                        if (debug != null) {
+                            debug.println("allowedAIALocations: Added " +
+                                    aiaUri + " to URI filters");
+                        }
+                    } else {
+                        if (debug != null) {
+                            debug.println("allowedAIALocations: Disallowed " +
+                                    "filter URI scheme: " +
+                                    aiaUri.getScheme());
+                        }
+                    }
+                } catch (URISyntaxException urise) {
+                    if (debug != null) {
+                        debug.println("allowedAIALocations: Skipping " +
+                                "filter URI entry " + aiaStr +
+                                ": parse failure at index " + urise.getIndex());
+                    }
+                }
+            }
+        }
+    }
+
+    /**
      * Creates a URICertStore.
      *
      * @param params specifying the URI
@@ -246,6 +413,39 @@ class URICertStore extends CertStoreSpi {
             return null;
         }
         URI uri = ((URIName) gn).getURI();
+
+        // Before performing any instantiation make sure that
+        // the URI passes any filtering rules.  This processing should
+        // only occur if the com.tencent.kona.pkix.enableAIAcaIssuers is true
+        // and the "any" rule has not been specified.
+        if (Builder.USE_AIA && !CA_ISS_ALLOW_ANY) {
+            URI normAIAUri = uri.normalize();
+            AllowedScheme scheme = AllowedScheme.nameOf(normAIAUri.getScheme());
+
+            if (scheme == null) {
+                if (debug != null) {
+                    debug.println("allowedAIALocations: No matching ruleset " +
+                            "for scheme " + normAIAUri.getScheme());
+                }
+                return null;
+            }
+
+            // Go through each of the filter rules and see if any will
+            // make a positive match against the caIssuer URI.  If nothing
+            // matches then we won't instantiate a URICertStore.
+            if (CA_ISS_URI_FILTERS.stream().noneMatch(rule ->
+                    scheme.ruleMatcher.matchRule(rule, normAIAUri))) {
+                if (debug != null) {
+                    debug.println("allowedAIALocations: Warning - " +
+                        "The caIssuer URI " + normAIAUri +
+                        " in the AuthorityInfoAccess extension is denied " +
+                        "access. Use the com.tencent.kona.pkix.allowedAIALocations" +
+                        " security/system property to allow access.");
+                }
+                return null;
+            }
+        }
+
         try {
             return URICertStore.getInstance(new URICertStoreParameters(uri));
         } catch (Exception ex) {
@@ -272,7 +472,7 @@ class URICertStore extends CertStoreSpi {
     @Override
     @SuppressWarnings("unchecked")
     public synchronized Collection<X509Certificate> engineGetCertificates
-    (CertSelector selector) throws CertStoreException {
+            (CertSelector selector) throws CertStoreException {
 
         if (ldap) {
             // caching mechanism, see the class description for more info.
@@ -464,6 +664,161 @@ class URICertStore extends CertStoreSpi {
         protected UCS(CertStoreSpi spi, Provider p, String type,
                       CertStoreParameters params) {
             super(spi, p, type, params);
+        }
+    }
+
+    /**
+     * URIRuleMatcher - abstract base class for the rule sets used for
+     * various URI schemes.
+     */
+    static abstract class URIRuleMatcher {
+        protected final int wellKnownPort;
+
+        protected URIRuleMatcher(int port) {
+            wellKnownPort = port;
+        }
+
+        /**
+         * Attempt to match the scheme, host and port between a filter
+         * rule URI and a URI coming from an AIA extension.
+         *
+         * @param filterRule the filter rule to match against
+         * @param caIssuer the AIA URI being compared
+         * @return true if the scheme, host and port numbers match, false if
+         * any of the components do not match. If a port number is omitted in
+         * either the filter rule or AIA URI, the well-known port for that
+         * scheme is used in the comparison.
+         */
+        boolean schemeHostPortCheck(URI filterRule, URI caIssuer) {
+            if (!filterRule.getScheme().equalsIgnoreCase(
+                    caIssuer.getScheme())) {
+                return false;
+            } else if (!filterRule.getHost().equalsIgnoreCase(
+                    caIssuer.getHost())) {
+                return false;
+            } else {
+                try {
+                    // Check for port matching, taking into consideration
+                    // default ports
+                    int fPort = (filterRule.getPort() == -1) ? wellKnownPort :
+                            filterRule.getPort();
+                    int caiPort = (caIssuer.getPort() == -1) ? wellKnownPort :
+                            caIssuer.getPort();
+                    if (fPort != caiPort) {
+                        return false;
+                    }
+                } catch (IllegalArgumentException iae) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /**
+         * Attempt to match an AIA URI against a specific filter rule.  The
+         * specific rules to apply are implementation dependent.
+         *
+         * @param filterRule the filter rule to match against
+         * @param caIssuer the AIA URI being compared
+         * @return true if all matching rules pass, false if any fail.
+         */
+        abstract boolean matchRule(URI filterRule, URI caIssuer);
+    }
+
+    static class HttpFtpRuleMatcher extends URIRuleMatcher {
+        static final HttpFtpRuleMatcher HTTP = new HttpFtpRuleMatcher(80);
+        static final HttpFtpRuleMatcher HTTPS = new HttpFtpRuleMatcher(443);
+        static final HttpFtpRuleMatcher FTP = new HttpFtpRuleMatcher(21);
+
+        private HttpFtpRuleMatcher(int port) {
+            super(port);
+        }
+
+        @Override
+        boolean matchRule(URI filterRule, URI caIssuer) {
+            // Check for scheme/host/port matching
+            if (!schemeHostPortCheck(filterRule, caIssuer)) {
+                return false;
+            }
+
+            // Check the path component to make sure the filter is at
+            // least a root of the AIA caIssuer URI's path.  It must be
+            // a case-sensitive match for all platforms.
+            if (!isRootOf(filterRule, caIssuer)) {
+                if (debug != null) {
+                    debug.println("allowedAIALocations: Match failed: " +
+                            "AIA URI is not within the rule's path hierarchy.");
+                }
+                return false;
+            }
+            return true;
+        }
+
+        /**
+         * Performs a hierarchical containment check, ensuring that the
+         * base URI's path is a root component of the candidate path.  The
+         * path comparison is case-sensitive.  If the base path ends in a
+         * slash (/) then all candidate paths that begin with the base
+         * path are allowed.  If it does not end in a slash, then it is
+         * assumed that the leaf node in the base path is a file component
+         * and both paths must match exactly.
+         *
+         * @param base the URI that contains the root path
+         * @param candidate the URI that contains the path being evaluated
+         * @return true if {@code candidate} is a child path of {@code base},
+         *         false otherwise.
+         */
+        private static boolean isRootOf(URI base, URI candidate) {
+            // Note: The URIs have already been normalized at this point and
+            // HTTP URIs cannot have null paths.  If it's an empty path
+            // then consider the path to be "/".
+            String basePath = Optional.of(base.getPath()).
+                    filter(p -> !p.isEmpty()).orElse("/");
+            String candPath = Optional.of(candidate.getPath()).
+                    filter(p -> !p.isEmpty()).orElse("/");
+            return (basePath.endsWith("/")) ? candPath.startsWith(basePath) :
+                    candPath.equals(basePath);
+        }
+    }
+
+    static class LdapRuleMatcher extends URIRuleMatcher {
+        static final LdapRuleMatcher LDAP = new LdapRuleMatcher(389);
+        static final LdapRuleMatcher LDAPS = new LdapRuleMatcher(636);
+
+        private LdapRuleMatcher(int port) {
+            super(port);
+        }
+
+        @Override
+        boolean matchRule(URI filterRule, URI caIssuer) {
+            // Check for scheme/host/port matching
+            if (!schemeHostPortCheck(filterRule, caIssuer)) {
+                return false;
+            }
+
+            // Obtain the base DN component and compare
+            try {
+                X500Principal filterBaseDn = new X500Principal(
+                        filterRule.getPath().replaceFirst("^/+", ""));
+                X500Principal caIssBaseDn = new X500Principal(
+                        caIssuer.getPath().replaceFirst("^/+", ""));
+                if (!filterBaseDn.equals(caIssBaseDn)) {
+                    if (debug != null) {
+                        debug.println("allowedAIALocations: Match failed: " +
+                                "Base DN mismatch (" + filterBaseDn + " vs " +
+                                caIssBaseDn + ")");
+                    }
+                    return false;
+                }
+            } catch (IllegalArgumentException iae) {
+                if (debug != null) {
+                    debug.println("allowedAIALocations: Match failed on DN: " +
+                            iae);
+                }
+                return false;
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
This is a backport of [JDK-8368032]: Enhance Certificate Checking.
This is an vulnerability issue with [CVE-2026-21945].

This PR will resolves #1231.

[JDK-8368032]:
https://github.com/openjdk/jdk25u/commit/405a5699ebd097464ed3fc9345414b0774a2edc9

[CVE-2026-21945]:
https://nvd.nist.gov/vuln/detail/CVE-2026-21945