### PR TITLE
TKSS-1261: Native sm3hmac_create_ctx should return NULL instead of OPENSSL_FAILURE on error

### DIFF
--- a/kona-crypto/src/main/jni/kona_sm3.c
+++ b/kona-crypto/src/main/jni/kona_sm3.c
@@ -267,18 +267,18 @@ JNIEXPORT jbyteArray JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_Na
 
 EVP_MAC_CTX* sm3hmac_create_ctx(EVP_MAC* mac, const uint8_t* key, size_t key_len) {
     if (mac == NULL) {
-        return OPENSSL_FAILURE;
+        return NULL;
     }
 
     if (key == NULL || key_len == 0) {
-        return OPENSSL_FAILURE;
+        return NULL;
     }
 
     EVP_MAC_CTX* ctx = EVP_MAC_CTX_new(mac);
     if (ctx == NULL) {
         OPENSSL_print_err();
 
-        return OPENSSL_FAILURE;
+        return NULL;
     }
 
     OSSL_PARAM params[] = {
@@ -290,7 +290,7 @@ EVP_MAC_CTX* sm3hmac_create_ctx(EVP_MAC* mac, const uint8_t* key, size_t key_len
         OPENSSL_print_err();
         EVP_MAC_CTX_free(ctx);
 
-        return OPENSSL_FAILURE;
+        return NULL;
     }
 
     return ctx;


### PR DESCRIPTION
sm3hmac_create_ctx has a return type of EVP_MAC_CTX*, but its error paths return OPENSSL_FAILURE (an int macro with value 0), which is an implicit int-to-pointer conversion that can trigger -Wint-conversion warnings on some compilers. These error returns should be changed to return NULL; so that pointer-returning functions and status-returning functions keep consistent return-value semantics.

This PR will resolves #1261