### PR TITLE
TKSS-1263: Native context-creating functions should return 0 instead of OPENSSL_FAILURE for handles

### DIFF
--- a/kona-crypto/src/main/jni/kona_ec_keypair.c
+++ b/kona-crypto/src/main/jni/kona_ec_keypair.c
@@ -69,21 +69,21 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
   (JNIEnv* env, jclass classObj, jint curveNID) {
     EVP_PKEY_CTX* pctx = ec_create_pkey_ctx(NULL);
     if (pctx == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     if (!EVP_PKEY_keygen_init(pctx)) {
         OPENSSL_print_err();
         EVP_PKEY_CTX_free(pctx);
 
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     if (!EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx, curveNID)) {
         OPENSSL_print_err();
         EVP_PKEY_CTX_free(pctx);
 
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     return (jlong)pctx;

--- a/kona-crypto/src/main/jni/kona_ecdh.c
+++ b/kona-crypto/src/main/jni/kona_ecdh.c
@@ -86,25 +86,25 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
   (JNIEnv* env, jclass classObj, jint curveNID, jbyteArray priKey) {
     int key_len = (*env)->GetArrayLength(env, priKey);
     if (key_len <= 0) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
     jbyte* pri_key_bytes = (*env)->GetByteArrayElements(env, priKey, NULL);
     if (pri_key_bytes == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     EC_KEY* pri_key = ec_pri_key_new(curveNID, (const uint8_t *) pri_key_bytes,
                                      key_len);
     (*env)->ReleaseByteArrayElements(env, priKey, pri_key_bytes, JNI_ABORT);
     if (pri_key == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     ECDH_CTX* ctx = ecdh_create_ctx(curveNID, pri_key);
     if (ctx == NULL) {
         EC_KEY_free(pri_key);
 
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     return (jlong)ctx;

--- a/kona-crypto/src/main/jni/kona_ecdsa.c
+++ b/kona-crypto/src/main/jni/kona_ecdsa.c
@@ -70,11 +70,11 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
   (JNIEnv* env, jclass classObj, jint mdNID, jint curveNID, jbyteArray key, jboolean isSign) {
     int key_len = (*env)->GetArrayLength(env, key);
     if (key_len < (isSign ? PRI_KEY_MIN_LEN : PUB_KEY_MIN_LEN)) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
     jbyte* key_bytes = (*env)->GetByteArrayElements(env, key, NULL);
     if (key_bytes == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     EC_KEY* ec_key = NULL;
@@ -88,7 +88,7 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
 
     ECDSA_CTX* ctx = ecdsa_create_ctx(mdNID, ec_key);
     if (ctx == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     return (jlong)ctx;

--- a/kona-crypto/src/main/jni/kona_sm2_cipher.c
+++ b/kona-crypto/src/main/jni/kona_sm2_cipher.c
@@ -35,11 +35,11 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
   (JNIEnv* env, jobject thisObj, jbyteArray key) {
     int key_len = (*env)->GetArrayLength(env, key);
     if (key_len < SM2_PRI_KEY_LEN) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
     jbyte* key_bytes = (*env)->GetByteArrayElements(env, key, NULL);
     if (key_bytes == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     EVP_PKEY* pkey = sm2_load_key((const uint8_t*)key_bytes, key_len);
@@ -47,14 +47,14 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
     (*env)->ReleaseByteArrayElements(env, key, key_bytes, JNI_ABORT);
 
     if (pkey == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     EVP_PKEY_CTX* pctx = sm2_create_pkey_ctx(pkey);
     if (pctx == NULL) {
         EVP_PKEY_free(pkey);
 
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     SM2_CIPHER_CTX* ctx = (SM2_CIPHER_CTX*)OPENSSL_malloc(sizeof(SM2_CIPHER_CTX));
@@ -62,7 +62,7 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
         EVP_PKEY_free(pkey);
         EVP_PKEY_CTX_free(pctx);
 
-        return OPENSSL_FAILURE;
+        return 0;
     }
     ctx->pkey = pkey;
     ctx->pctx = pctx;

--- a/kona-crypto/src/main/jni/kona_sm2_keypair.c
+++ b/kona-crypto/src/main/jni/kona_sm2_keypair.c
@@ -145,7 +145,7 @@ JNIEXPORT jint JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeCr
 JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeCrypto_sm2KeyPairGenCreateCtx
   (JNIEnv* env, jobject thisObj) {
     EVP_PKEY_CTX* ctx = sm2_create_pkey_ctx(NULL);
-    return ctx == NULL ? OPENSSL_FAILURE : (jlong)ctx;
+    return ctx == NULL ? 0 : (jlong)ctx;
 }
 
 JNIEXPORT void JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeCrypto_sm2KeyPairGenFreeCtx

--- a/kona-crypto/src/main/jni/kona_sm2_signature.c
+++ b/kona-crypto/src/main/jni/kona_sm2_signature.c
@@ -97,24 +97,24 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
   (JNIEnv* env, jobject thisObj, jbyteArray key, jbyteArray id, jboolean isSign) {
     int key_len = (*env)->GetArrayLength(env, key);
     if (key_len < SM2_PRI_KEY_LEN) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
     jbyte* key_bytes = (*env)->GetByteArrayElements(env, key, NULL);
     if (key_bytes == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     int id_len = (*env)->GetArrayLength(env, id);
     if (id_len <= 0) {
         (*env)->ReleaseByteArrayElements(env, key, key_bytes, JNI_ABORT);
 
-        return OPENSSL_FAILURE;
+        return 0;
     }
     jbyte* id_bytes = (*env)->GetByteArrayElements(env, id, NULL);
     if (id_bytes == NULL) {
         (*env)->ReleaseByteArrayElements(env, key, key_bytes, JNI_ABORT);
 
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     EVP_PKEY* pkey = sm2_load_key((const uint8_t*)key_bytes, key_len);
@@ -123,7 +123,7 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
         (*env)->ReleaseByteArrayElements(env, key, key_bytes, JNI_ABORT);
         (*env)->ReleaseByteArrayElements(env, id, id_bytes, JNI_ABORT);
 
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     SM2_SIGNATURE_CTX* ctx = sm2_create_md_ctx(pkey, (const uint8_t*)id_bytes, id_len, isSign);

--- a/kona-crypto/src/main/jni/kona_sm3.c
+++ b/kona-crypto/src/main/jni/kona_sm3.c
@@ -97,7 +97,7 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
   (JNIEnv* env, jobject thisObj) {
     EVP_MD_CTX* ctx = sm3_create_ctx();
 
-    return ctx == NULL ? OPENSSL_FAILURE : (jlong)ctx;
+    return ctx == NULL ? 0 : (jlong)ctx;
 }
 
 JNIEXPORT void JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeCrypto_sm3FreeCtx
@@ -191,19 +191,19 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
   (JNIEnv* env, jobject thisObj, jlong pointer) {
     EVP_MD_CTX* orig_ctx = (EVP_MD_CTX*)pointer;
     if (orig_ctx == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     EVP_MD_CTX* new_ctx = EVP_MD_CTX_new();
     if (new_ctx == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     if (!EVP_MD_CTX_copy_ex(new_ctx, orig_ctx)) {
         OPENSSL_print_err();
         EVP_MD_CTX_free(new_ctx);
 
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     return (jlong)new_ctx;
@@ -309,20 +309,20 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
   (JNIEnv* env, jobject thisObj, jbyteArray key) {
     EVP_MAC* mac = hmac();
     if (mac == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     if (key == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     const int key_len = (*env)->GetArrayLength(env, key);
     if (key_len <= 0) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
     jbyte* key_bytes = (*env)->GetByteArrayElements(env, key, NULL);
     if (key_bytes == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     EVP_MAC_CTX* ctx = sm3hmac_create_ctx(mac, (const uint8_t*)key_bytes, key_len);
@@ -418,14 +418,14 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
   (JNIEnv* env, jobject thisObj, jlong pointer) {
     EVP_MAC_CTX* orig_ctx = (EVP_MAC_CTX*)pointer;
     if (orig_ctx == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     EVP_MAC_CTX* new_ctx = EVP_MAC_CTX_dup(orig_ctx);
     if (new_ctx == NULL) {
         OPENSSL_print_err();
 
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     return (jlong)new_ctx;

--- a/kona-crypto/src/main/jni/kona_sm4.c
+++ b/kona-crypto/src/main/jni/kona_sm4.c
@@ -29,17 +29,17 @@
 JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeCrypto_sm4CreateCtx
   (JNIEnv* env, jobject thisObj, jboolean encrypt, jstring mode, jboolean padding, jbyteArray key, jbyteArray iv) {
     if (key == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     jsize key_len = (*env)->GetArrayLength(env, key);
     if (key_len != SM4_KEY_LEN) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     const char* mode_str = (*env)->GetStringUTFChars(env, mode, 0);
     if (mode_str == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     const EVP_CIPHER* cipher = sm4_cipher(mode_str);
@@ -49,21 +49,21 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
     (*env)->ReleaseStringUTFChars(env, mode, mode_str);
 
     if (cipher == NULL) {
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     // Validate iv: ECB requires no iv; GCM requires 12-byte iv; CBC/CTR require 16-byte iv.
     if (is_ecb) {
         if (iv != NULL) {
-            return OPENSSL_FAILURE;
+            return 0;
         }
     } else if (is_gcm) {
         if (iv_len != SM4_GCM_IV_LEN) {
-            return OPENSSL_FAILURE;
+            return 0;
         }
     } else {
         if (iv_len != SM4_IV_LEN) {
-            return OPENSSL_FAILURE;
+            return 0;
         }
     }
 
@@ -71,13 +71,13 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
     if (ctx == NULL) {
         OPENSSL_print_err();
 
-        return OPENSSL_FAILURE;
+        return 0;
     }
 
     jbyte* key_bytes = (*env)->GetByteArrayElements(env, key, NULL);
     jbyte* iv_bytes = iv ? (*env)->GetByteArrayElements(env, iv, NULL) : NULL;
 
-    jlong result = OPENSSL_FAILURE;
+    jlong result = 0;
     if (EVP_CipherInit_ex(ctx, cipher, NULL, (uint8_t*)key_bytes, (uint8_t*)iv_bytes, encrypt)) {
         if (!padding && !EVP_CIPHER_CTX_set_padding(ctx, 0)) {
             OPENSSL_print_err();
@@ -93,7 +93,7 @@ JNIEXPORT jlong JNICALL Java_com_tencent_kona_crypto_provider_nativeImpl_NativeC
         (*env)->ReleaseByteArrayElements(env, iv, iv_bytes, JNI_ABORT);
     }
 
-    if (result == OPENSSL_FAILURE && ctx != NULL) {
+    if (result == 0 && ctx != NULL) {
         EVP_CIPHER_CTX_free(ctx);
     }
 


### PR DESCRIPTION
The jlong handle-returning JNI functions (sm3Clone, sm4CreateCtx, sm2CipherCreateCtx, sm2SignatureCreateCtx, ecdsaCreateCtx, ecdhCreateCtx, ecKeyPairGenCreateCtx, etc.) returned the OPENSSL_FAILURE status constant on error, conflating an int status code with a handle value. They now return 0 explicitly, keeping OPENSSL_SUCCESS/OPENSSL_FAILURE confined to int-returning functions; since OPENSSL_FAILURE is defined as 0, this is a readability and intent change with no effect on the generated binary.

This PR will resolve #1263