### PR TITLE
TKSS-1267: Native context may leak in SM3/SM3HMac clone() and SM4OneShotCrypt

### DIFF
--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3HMac.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3HMac.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025, Tencent. All rights reserved.
+ * Copyright (C) 2024, 2026, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify
@@ -95,6 +95,13 @@ public final class SM3HMac extends MacSpi implements Cloneable {
     public SM3HMac clone() throws CloneNotSupportedException {
         SM3HMac clone = (SM3HMac) super.clone();
         clone.sm3HMac = sm3HMac.clone();
+
+        // The cloned native context is a brand-new allocation that is not
+        // covered by the original object's Sweeper registration. Register the
+        // clone so its native context gets released as well, otherwise it
+        // would leak for the lifetime of the JVM.
+        SWEEPER.register(clone, new SweepNativeRef(clone.sm3HMac));
+
         return clone;
     }
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3MessageDigest.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM3MessageDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, Tencent. All rights reserved.
+ * Copyright (C) 2024, 2026, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify
@@ -77,6 +77,13 @@ public final class SM3MessageDigest extends MessageDigest implements Cloneable {
     public SM3MessageDigest clone() throws CloneNotSupportedException {
         SM3MessageDigest clone = (SM3MessageDigest) super.clone();
         clone.sm3 = sm3.clone();
+
+        // The cloned native context is a brand-new allocation that is not
+        // covered by the original object's Sweeper registration. Register the
+        // clone so its native context gets released as well, otherwise it
+        // would leak for the lifetime of the JVM.
+        SWEEPER.register(clone, new SweepNativeRef(clone.sm3));
+
         return clone;
     }
 }

--- a/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4OneShotCrypt.java
+++ b/kona-crypto/src/main/java/com/tencent/kona/crypto/provider/nativeImpl/SM4OneShotCrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, Tencent. All rights reserved.
+ * Copyright (C) 2022, 2026, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify
@@ -21,6 +21,7 @@
 package com.tencent.kona.crypto.provider.nativeImpl;
 
 import com.tencent.kona.crypto.util.RangeUtil;
+import com.tencent.kona.crypto.util.Sweeper;
 import com.tencent.kona.crypto.CryptoUtils;
 
 import javax.crypto.AEADBadTagException;
@@ -29,6 +30,8 @@ import java.security.InvalidKeyException;
 import static com.tencent.kona.crypto.util.Constants.*;
 
 class SM4OneShotCrypt extends SymmetricCipher {
+
+    private static final Sweeper SWEEPER = Sweeper.instance();
 
     private boolean opChanged = false;
     private boolean decrypting = false;
@@ -54,7 +57,14 @@ class SM4OneShotCrypt extends SymmetricCipher {
         this.key = null;
         this.gcmLastCipherBlock = null;
 
-        this.sm4 = null;
+        // A previous init() may have left a native context behind (e.g. the
+        // caller re-initialized without ever reaching doFinal). Release it
+        // explicitly here so it is freed promptly rather than waiting for the
+        // Sweeper to reclaim it after this object becomes unreachable.
+        if (this.sm4 != null) {
+            this.sm4.close();
+            this.sm4 = null;
+        }
 
         if (!"SM4".equalsIgnoreCase(algorithm)) {
             throw new InvalidKeyException(
@@ -82,20 +92,24 @@ class SM4OneShotCrypt extends SymmetricCipher {
         switch (mode) {
             case ECB:
                 sm4 = new NativeSM4.SM4ECB(!decrypting, padding, key);
+                SWEEPER.register(this, new SweepNativeRef(sm4));
                 break;
             case CBC:
                 sm4 = new NativeSM4.SM4CBC(!decrypting, padding, key, iv);
+                SWEEPER.register(this, new SweepNativeRef(sm4));
                 break;
             case GCM:
                 gcmLastCipherBlock = new DataWindow(SM4_GCM_TAG_LEN);
                 if (sm4 == null || opChanged) {
                     sm4 = new NativeSM4.SM4GCM(!decrypting, key, iv);
+                    SWEEPER.register(this, new SweepNativeRef(sm4));
                 } else {
                     ((NativeSM4.SM4GCM) sm4).setIV(iv);
                 }
                 break;
             case CTR:
                 sm4 = new NativeSM4.SM4CTR(!decrypting, key, iv);
+                SWEEPER.register(this, new SweepNativeRef(sm4));
                 break;
             default:
                 throw new IllegalStateException("Unexpected mode: " + mode);

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3HMacTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2024, Tencent. All rights reserved.
+ * Copyright (C) 2022, 2026, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -313,5 +313,21 @@ public class SM3HMacTest {
 
         Assertions.assertArrayEquals(MAC, mac);
         Assertions.assertArrayEquals(mac, macClone);
+    }
+
+    // Each clone allocates its own (native) context. The cloned context must
+    // be tracked for cleanup, otherwise it leaks. This exercises that path
+    // repeatedly to make sure cloning stays correct and stable.
+    @Test
+    public void testRepeatedClone() throws Exception {
+        Mac hmacSM3 = Mac.getInstance("HmacSM3", PROVIDER);
+        SecretKeySpec keySpec = new SecretKeySpec(KEY, "HmacSM3");
+        hmacSM3.init(keySpec);
+
+        for (int i = 0; i < 10000; i++) {
+            Mac clone = (Mac) hmacSM3.clone();
+            byte[] macClone = clone.doFinal(MESSAGE);
+            Assertions.assertArrayEquals(MAC, macClone);
+        }
     }
 }

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2023, Tencent. All rights reserved.
+ * Copyright (C) 2022, 2026, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -312,5 +312,19 @@ public class SM3Test {
         byte[] digest = clone.digest();
 
         Assertions.assertArrayEquals(DIGEST_LONG, digest);
+    }
+
+    // Each clone allocates its own (native) context. The cloned context must
+    // be tracked for cleanup, otherwise it leaks. This exercises that path
+    // repeatedly to make sure cloning stays correct and stable.
+    @Test
+    public void testRepeatedClone() throws Exception {
+        MessageDigest md = MessageDigest.getInstance("SM3", PROVIDER);
+
+        for (int i = 0; i < 10000; i++) {
+            MessageDigest clone = (MessageDigest) md.clone();
+            byte[] digest = clone.digest(MESSAGE_SHORT);
+            Assertions.assertArrayEquals(DIGEST_SHORT, digest);
+        }
     }
 }

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4Test.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/SM4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, 2025, Tencent. All rights reserved.
+ * Copyright (C) 2022, 2026, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1069,5 +1069,34 @@ public class SM4Test {
                 SM4_GCM_TAG_LEN * 8, GCM_IV));
         Assertions.assertEquals(31, cipherGCMNoPadding.getOutputSize(15));
         Assertions.assertEquals(32, cipherGCMNoPadding.getOutputSize(16));
+    }
+
+    // Re-initializing a Cipher (optionally feeding data) without ever calling
+    // doFinal must release the context created by the previous init. A missing
+    // explicit close on re-init would leak a native context until the cipher
+    // object itself is GC'd. This drives many re-inits and verifies the cipher
+    // still produces correct output.
+    @Test
+    public void testRepeatedReinitWithoutDoFinal() throws Exception {
+        SecretKey key = new SecretKeySpec(KEY, "SM4");
+        IvParameterSpec ivParamSpec = new IvParameterSpec(IV);
+
+        Cipher cipher = Cipher.getInstance("SM4/CBC/PKCS7Padding", PROVIDER);
+        for (int i = 0; i < 10000; i++) {
+            cipher.init(Cipher.ENCRYPT_MODE, key, ivParamSpec);
+            // Feed data but deliberately skip doFinal, then re-init.
+            cipher.update(MESSAGE);
+        }
+
+        // After all the abandoned re-inits, a full encrypt/decrypt round-trip
+        // must still work.
+        cipher.init(Cipher.ENCRYPT_MODE, key, ivParamSpec);
+        byte[] ciphertext = cipher.doFinal(MESSAGE);
+
+        Cipher decrypter = Cipher.getInstance("SM4/CBC/PKCS7Padding", PROVIDER);
+        decrypter.init(Cipher.DECRYPT_MODE, key, ivParamSpec);
+        byte[] plaintext = decrypter.doFinal(ciphertext);
+
+        Assertions.assertArrayEquals(MESSAGE, plaintext);
     }
 }

--- a/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/SM4OneShotCryptCleanupTest.java
+++ b/kona-crypto/src/test/java/com/tencent/kona/crypto/provider/nativeImpl/SM4OneShotCryptCleanupTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2026, Tencent. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.tencent.kona.crypto.provider.nativeImpl;
+
+import com.tencent.kona.crypto.util.Sweeper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+
+import static com.tencent.kona.crypto.CryptoUtils.toBytes;
+
+/**
+ * Verifies that {@link SM4OneShotCrypt} actually releases its native context
+ * when the cipher object is abandoned without ever calling {@code doFinal}.
+ * <p>
+ * Unlike the functional SM4 tests, this test observes the cleanup path itself:
+ * the OneShot implementation has no automatic release on {@code doFinal} when
+ * that call never happens, so without a Sweeper registration the native
+ * context would leak. The test holds onto the inner {@link NativeSM4} (so it
+ * survives GC), drops the owning {@link SM4OneShotCrypt}, and asserts that the
+ * Sweeper eventually closes the native context (pointer reset to 0). Against an
+ * implementation that does not register a Sweeper, the pointer would never be
+ * reset and this test would time out / fail.
+ */
+@EnabledOnOs(OS.LINUX)
+public class SM4OneShotCryptCleanupTest {
+
+    private static final byte[] KEY = toBytes("0123456789abcdef0123456789abcdef");
+    private static final byte[] IV = toBytes("00000000000000000000000000000001");
+    private static final byte[] MESSAGE = toBytes(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+
+    @Test
+    public void testNativeContextReleasedWhenAbandonedWithoutDoFinal()
+            throws Exception {
+        NativeSM4 nativeSM4 = createAndAbandon();
+        Assertions.assertNotNull(nativeSM4);
+
+        // The native context must be live right after init()/update().
+        Assertions.assertNotEquals(0L, pointerOf(nativeSM4),
+                "native context should be allocated after init/update");
+
+        // The owning SM4OneShotCrypt is now unreachable, but nativeSM4 is still
+        // strongly held here. Once the Sweeper observes the owner becoming
+        // phantom-reachable it runs SweepNativeRef, which closes nativeSM4 and
+        // resets its pointer to 0.
+        boolean released = waitUntil(
+                () -> pointerOf(nativeSM4) == 0L,
+                Duration.ofSeconds(30));
+
+        Assertions.assertTrue(released,
+                "native context was not released by the Sweeper; "
+                        + "SM4OneShotCrypt likely lacks a Sweeper registration");
+    }
+
+    // Creates an SM4OneShotCrypt, initializes and feeds it data but never calls
+    // doFinal, then returns only its inner NativeSM4 so the owning cipher
+    // becomes eligible for GC once this method returns.
+    private static NativeSM4 createAndAbandon() throws Exception {
+        SM4OneShotCrypt crypt = new SM4OneShotCrypt();
+        crypt.init(false, "SM4", KEY,
+                new SM4Params(Mode.CBC, Padding.PKCS7Padding, IV));
+        crypt.encryptBlock(MESSAGE, 0, MESSAGE.length);
+
+        return extractNativeSM4(crypt);
+    }
+
+    private static NativeSM4 extractNativeSM4(SM4OneShotCrypt crypt)
+            throws Exception {
+        Field field = SM4OneShotCrypt.class.getDeclaredField("sm4");
+        field.setAccessible(true);
+        return (NativeSM4) field.get(crypt);
+    }
+
+    private static long pointerOf(NativeSM4 nativeSM4) {
+        return nativeSM4.pointer;
+    }
+
+    private static boolean waitUntil(BooleanSupplierEx condition, Duration timeout)
+            throws Exception {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            System.gc();
+            System.runFinalization();
+            if (condition.getAsBoolean()) {
+                return true;
+            }
+            Thread.sleep(50);
+        }
+        return condition.getAsBoolean();
+    }
+
+    @FunctionalInterface
+    private interface BooleanSupplierEx {
+        boolean getAsBoolean();
+    }
+}


### PR DESCRIPTION
SM3MessageDigest/SM3HMac clone and SM4OneShotCrypt leaked native contexts due to missing Sweeper registrations. Fix adds per-clone Sweeper, explicit close-on-reinit, and Sweeper fallback for all SM4 modes.

This PR will resolve #1267